### PR TITLE
chore(quality): add quality_gates to stack.yml + re-stamp guard scripts

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -48,3 +48,25 @@ standards:
 lsp:
   enabled: true
   server: pyright
+
+# Quality gates — Python code-hygiene contracts (opt-in).
+# When section is absent: all gates OFF (backwards-compatible).
+# When section is present but a sub-block is absent: that gate OFF.
+# Gates are installed/synced by /release-setup --force via the quality-gates cookbook
+# (plugins/dev-core/skills/release-setup/cookbooks/quality-gates.md).
+# Python-only — stack-setup skips this section when runtime != python.
+quality_gates:
+  file_length:
+    enabled: true
+    max_lines: 300                             # default 300
+    globs: ["src/**/*.py"]
+    exemptions_file: tools/file_exemptions.txt # format: <path> <issue-url> (space-separated)
+  folder_size:
+    enabled: true
+    max_files: 12                              # default 12
+    globs: ["src/**"]
+    exemptions_file: tools/folder_exemptions.txt
+  import_layers:
+    enabled: true
+    stage: pre-push                            # pre-commit | pre-push (default pre-push; lint-imports is slow)
+    config: .importlinter

--- a/tools/check_file_length.sh
+++ b/tools/check_file_length.sh
@@ -1,17 +1,34 @@
 #!/usr/bin/env bash
-# Check that no Python source file exceeds 300 lines (tests excluded).
-# Known exceptions are listed in tools/file_exemptions.txt — each must have a tracking issue.
+# Canonical source: plugins/dev-core/tools/ — do not edit project-side copies directly
+# Check that no Python source file exceeds the configured line cap (tests excluded).
+# Known exceptions are listed in the exemptions file — each must have a tracking issue.
+# Configuration is read from tools/qg.conf if present (seeded from stack.yml by
+# /release-setup); defaults below apply when the file is absent.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-MAX=300
+# Source generated config (safe: file is owned by /release-setup, not user-editable).
+# shellcheck disable=SC1091
+[ -f tools/qg.conf ] && . tools/qg.conf
+
+MAX="${QG_FILE_MAX:-300}"
+FIND_ROOT="${QG_FILE_ROOT:-src/}"
+EXEMPT_FILE="${QG_FILE_EXEMPTIONS:-tools/file_exemptions.txt}"
 FAIL=0
-EXEMPT_FILE="tools/file_exemptions.txt"
+
+# src/ absent is not a hard error — skip with warning rather than false-green exit 0.
+if [ ! -d "$FIND_ROOT" ]; then
+    echo "WARN: $FIND_ROOT not found, skipping check_file_length" >&2
+    exit 0
+fi
 
 is_exempt() {
     [ ! -f "$EXEMPT_FILE" ] && return 1
-    grep -q "^$1[[:space:]]" "$EXEMPT_FILE"
+    # Exact match on the first whitespace-delimited field — no regex, no escaping,
+    # left-anchored (awk field split) so a path substring elsewhere on the line
+    # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' f; do
@@ -21,6 +38,6 @@ while IFS= read -r -d '' f; do
         echo "$f - $LINES lines (max $MAX)"
         FAIL=1
     fi
-done < <(find src/ -name "*.py" -print0)
+done < <(find "$FIND_ROOT" -name "*.py" -print0)
 
 exit $FAIL

--- a/tools/check_folder_size.sh
+++ b/tools/check_folder_size.sh
@@ -1,26 +1,46 @@
 #!/usr/bin/env bash
-# Check that no folder contains more than 12 Python source files.
+# Canonical source: plugins/dev-core/tools/ — do not edit project-side copies directly
+# Check that no folder contains more than the configured cap of Python source files.
 # Forces early splits and keeps folder lists graspable.
+# Configuration is read from tools/qg.conf if present (seeded from stack.yml by
+# /release-setup); defaults below apply when the file is absent.
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-MAX=12
+# Source generated config (safe: file is owned by /release-setup, not user-editable).
+# shellcheck disable=SC1091
+[ -f tools/qg.conf ] && . tools/qg.conf
+
+MAX="${QG_FOLDER_MAX:-12}"
+FIND_ROOT="${QG_FOLDER_ROOT:-src/}"
+EXEMPT_FILE="${QG_FOLDER_EXEMPTIONS:-tools/folder_exemptions.txt}"
 FAIL=0
-EXEMPT_FILE="tools/folder_exemptions.txt"
+
+if [ ! -d "$FIND_ROOT" ]; then
+    echo "WARN: $FIND_ROOT not found, skipping check_folder_size" >&2
+    exit 0
+fi
 
 is_exempt() {
     [ ! -f "$EXEMPT_FILE" ] && return 1
-    grep -q "^$1[[:space:]]" "$EXEMPT_FILE"
+    # Exact match on the first whitespace-delimited field — no regex, no escaping,
+    # left-anchored (awk field split) so a path substring elsewhere on the line
+    # cannot cause a false positive. Exemption format: '<path> <issue-url>'.
+    awk -v p="$1" '$1 == p { found = 1 } END { exit !found }' "$EXEMPT_FILE"
 }
 
 while IFS= read -r -d '' d; do
     is_exempt "$d" && continue
-    COUNT=$(find "$d" -maxdepth 1 -name "*.py" -type f | wc -l)
+    # Portable NUL-delimited count — works on macOS bash 3.2 (no mapfile/readarray).
+    COUNT=0
+    while IFS= read -r -d '' _; do
+        COUNT=$((COUNT + 1))
+    done < <(find "$d" -maxdepth 1 -name "*.py" -type f -print0)
     if [ "$COUNT" -gt "$MAX" ]; then
         echo "$d - $COUNT files (max $MAX)"
         FAIL=1
     fi
-done < <(find src/ -type d -print0)
+done < <(find "$FIND_ROOT" -type d -print0)
 
 exit $FAIL


### PR DESCRIPTION
## Summary
- Add `quality_gates:` section to `.claude/stack.yml` (file_length, folder_size, import_layers — all 3 sub-blocks enabled)
- Re-stamp `tools/check_file_length.sh` + `tools/check_folder_size.sh` from canonical dev-core: adds `qg.conf` sourcing, configurable `QG_*` env vars, `awk` exact-field exemption matching, portable NUL-delimited folder walk

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #2: chore(quality): merge guard branch + re-stamp from canonical dev-core | Open |
| Implementation | 1 commit on \`feat/2-quality-gates\` | Complete |
| Verification | Lint ✅ Typecheck ✅ import-layers ✅ pre-commit ✅ | Passed |

## Test Plan
- [ ] \`uv run lint-imports\` exits 0 (3 contracts kept, 0 broken)
- [ ] \`pre-commit run --all-files\` green (lint, typecheck, check-file-length, check-folder-size, import-layers)
- [ ] Scripts diff-clean against canonical \`plugins/dev-core/tools/\` modulo project-name header

Closes #2

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`