### PR TITLE
fix(ci): use merge-commit + fallback token in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,5 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Adds the PR to GitHub's merge queue (merge commit) once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
@@ -31,10 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+      - name: Enable auto-merge (merge commit)
+        run: gh pr merge "$PR_NUMBER" --auto --merge
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
   update-behind-prs:
@@ -62,7 +62,7 @@ jobs:
               --method PUT -f expected_head_sha="$SHA" || true
           done
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.PAT || github.token }}
 
   close-linked-issues:
     name: Close linked issues


### PR DESCRIPTION
## Summary
- Switch \`gh pr merge --auto --squash\` → \`--merge\` to match the project's merge-commit-only convention
- Fall back to \`github.token\` when \`secrets.PAT\` is unset so the workflow doesn't silently exit 4 on unauthenticated \`gh\` calls

## Context
Observed on PR #7: \`Enable auto-merge\` job ran with empty \`GH_TOKEN\` (no \`PAT\` secret configured) and produced \`gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable\` → \`Process completed with exit code 4\`. Had to use \`gh pr merge --admin\` as a workaround.

## Note
Repo-level setting \`Allow auto-merge\` must also be enabled for \`gh pr merge --auto\` to succeed (GraphQL returned \`Auto merge is not allowed for this repository\` on PR #7). That's a repo Setting toggle, not a workflow change.

## Test Plan
- [ ] Next PR with \`reviewed\` label triggers Auto Merge workflow → job succeeds (or fails with a clearer error than empty token)
- [ ] PR gets queued for merge-commit (not squash) once all checks pass

---
Generated with [Claude Code](https://claude.com/claude-code)