### PR TITLE
feat(engines): implement vLLM engine backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Unified CLI for local LLM serving. OpenAI-compatible HTTP on LAN via `llama.cpp`
 |---|---|---|
 | `llamacpp` | `llama-server` (vanilla) | Standard GGUF — Q4/Q5/Q6 quants |
 | `llamacpp_tq3` | `llama-server` (TurboQuant fork) | TQ3_4S mixed-quant — required for Qwen3.6-35B-A3B-TQ3_4S |
-| `vllm` | (future, optional extra) | Deferred to P7 — `uv sync --group vllm` |
+| `vllm` | `vllm serve` | Safetensors (NVFP4/GPTQ) — dev only (RTX 5070 Ti); `uv sync --group vllm` |
 
 ## Host Topology
 

--- a/artifacts/analyses/13-vllm-engine-consensus.mdx
+++ b/artifacts/analyses/13-vllm-engine-consensus.mdx
@@ -1,0 +1,49 @@
+---
+title: "vLLM Engine Backend — Remaining Findings Consensus"
+issue: 13
+status: consensus-reached
+date: 2026-04-28
+panel: architect, security-auditor, backend-dev
+confidence: high
+---
+
+## Problem
+
+8 remaining suggestions/nitpicks from the code review of PR #14 (vLLM engine backend). Panel determines best long-term solution for each.
+
+## Panel
+
+| Agent | Focus |
+|-------|-------|
+| architect | arch soundness, maintainability, scalability |
+| security-auditor | attack surface, reliability, user-facing errors |
+| backend-dev | impl complexity, Python best practices |
+
+## Consensus Decisions
+
+| Finding | Decision | Confidence | Blocking |
+|---------|----------|------------|---------|
+| F1 `_wait_ready` duplicated | Extract to `engines/_common.py` with `engine_name` param | Unanimous | Yes — correctness debt |
+| F2 `import select` in loop | Hoist to module-level (resolved via F1 extraction) | Unanimous | No |
+| F3 Duplicate Arrange in tests | `started_instance` pytest fixture | Unanimous | No |
+| F4 Fragile `__builtins__` test | `patch.dict("sys.modules", {"vllm": None})` | Unanimous | Yes — test unreliable |
+| F5 Import guard vs binary | Both: `shutil.which("vllm")` + `import vllm`, distinct messages | Hybrid (arch accepted) | No |
+| F6 `_WAIT_TIMEOUT` undocumented | Inline comment explaining vLLM warmup duration | Unanimous | No |
+| F7 VLLMEngine no docstring | Already present at line 88 — no action | Unanimous | n/a |
+| F8 Engine dispatch registry | Dict-registry `_ENGINE_REGISTRY` in `daemon.py` | Majority (arch dissent recorded) | No |
+
+## Dissent
+
+**F8 — architect:** `engines/__init__.py` is architecturally purer (adapter package owns registry). Accepts majority position for ≤3 engines; recommends migration to `engines/__init__.py` when a 4th engine is added.
+
+**F5 — architect (original):** Initially preferred comment-only. Accepted hybrid after majority demonstrated that binary-absent and package-absent are distinct failures with different remediations that deserve different error messages at runtime.
+
+## Implementation Notes
+
+- F1 extraction: `_wait_ready(base_url, proc, timeout, engine_name)` in `engines/_common.py`. Both `llamacpp.py` and `vllm.py` import from there. TestWaitReady mock paths update from `llmcli.engines.vllm.*` → `llmcli.engines._common.*`.
+- F5 order: binary check first (PATH remediation), package check second (install remediation). Use `RuntimeError` for binary, `ImportError` for package.
+- F8: `_ENGINE_REGISTRY: dict[str, type[Engine]] = {"vllm": VLLMEngine, "llamacpp_tq3": LlamaCppTQ3Engine}` with `LlamaCppEngine` as default. Unknown engine string → raises `ValueError` (no silent fallback).
+
+## Next
+
+Apply all decisions → push → re-run `/code-review` for final approval.

--- a/docs/architecture/adr/003-engine-dispatch-registry.mdx
+++ b/docs/architecture/adr/003-engine-dispatch-registry.mdx
@@ -1,0 +1,93 @@
+---
+title: "ADR-003: Engine dispatch — dict registry over string-match chain"
+description: Replace if/elif engine selection in _engine_for_spec with a dict registry.
+---
+
+## Status
+
+Accepted (amended — see Decision)
+
+## Context
+
+`LLMDaemon._engine_for_spec` selects an engine class by comparing `spec.engine` against
+string literals in an if/elif chain. With 3 engines this works, but the pattern fails the
+"adapter registry" architectural standard: adding a 4th engine requires editing the
+dispatch function rather than registering a new adapter. The `engines/__init__.py` already
+imports all three classes, making it a natural registry location.
+
+## Options Considered
+
+### Option A: Dict registry in `daemon.py`
+```python
+_ENGINE_REGISTRY: dict[str, type[Engine]] = {
+    "vllm": VLLMEngine,
+    "llamacpp_tq3": LlamaCppTQ3Engine,
+    "llamacpp": LlamaCppEngine,
+}
+```
+`_engine_for_spec` becomes a lookup with a fallback to `LlamaCppEngine`.
+- **Pros:** Open/closed — new engines added without touching dispatch logic; dict key
+  is the canonical engine name; O(1) lookup; clear error on unknown engine name.
+- **Cons:** Registry lives in `daemon.py` but engines live in `engines/`; slight
+  coupling between layers.
+
+### Option B: Leave if/elif as-is until 4th engine
+- **Pros:** Zero change now.
+- **Cons:** 3 engines is already the threshold where the anti-pattern becomes
+  maintenance debt; deferred refactor always costs more.
+
+### Option C: Move registry to `engines/__init__.py`
+```python
+REGISTRY: dict[str, type[Engine]] = {
+    "llamacpp": LlamaCppEngine,
+    "llamacpp_tq3": LlamaCppTQ3Engine,
+    "vllm": VLLMEngine,
+}
+```
+`daemon.py` imports `REGISTRY` and calls `REGISTRY.get(spec.engine, LlamaCppEngine)()`.
+- **Pros:** Registry co-located with engine classes; `daemon.py` imports shrink to one
+  `from .engines import REGISTRY`; follows the adapter-registry pattern precisely.
+- **Cons:** `engines/__init__.py` takes on a new responsibility (was a re-export file).
+
+## Decision
+
+**Amended after consensus panel (2026-04-28):** Option A — dict registry in `daemon.py`.
+
+Original decision (Option C) was revised after consensus panel review. Majority (security-auditor
++ backend-dev) preferred Option A for pragmatic reasons: only one call site, no circular import
+risk, and `engines/__init__.py` already serves as a re-export file. Architect accepted with
+recorded dissent (prefers Option C at 5+ engines or when a plugin system is introduced).
+
+`_engine_for_spec` implementation:
+```python
+_ENGINE_REGISTRY: dict[str, type] = {
+    "llamacpp": LlamaCppEngine,
+    "llamacpp_tq3": LlamaCppTQ3Engine,
+    "vllm": VLLMEngine,
+}
+engine_cls = _ENGINE_REGISTRY.get(spec.engine)
+if engine_cls is None:
+    raise ValueError(
+        f"Unknown engine '{spec.engine}' for model '{spec.name}'. "
+        f"Valid engines: {sorted(_ENGINE_REGISTRY)}"
+    )
+return engine_cls()
+```
+
+Unknown engine names raise `ValueError` (strict, not a silent fallback).
+
+## Consequences
+
+### Positive
+- Eliminates string-match dispatch anti-pattern flagged in architecture standards.
+- Unknown engine name raises `ValueError` immediately — no silent wrong-engine usage.
+- O(1) lookup; adding a 4th engine is a one-line dict entry in `daemon.py`.
+
+### Negative
+- Registry lives in `daemon.py` rather than the engines package; slight layer coupling.
+  Migrate to `engines/__init__.py` when a 4th engine is added or a plugin system is
+  introduced (architect dissent recorded).
+
+### Neutral
+- The deferred import pattern (3 lines inside `_engine_for_spec`) is preserved to avoid
+  circular import risk at module load time.

--- a/llmcli.example.toml
+++ b/llmcli.example.toml
@@ -26,6 +26,15 @@ port     = 8092
 vram_gib = 11
 flags    = ["-ngl", "99", "-c", "8192", "-fa", "on", "--jinja"]
 
+# --- vLLM models (dev only — RTX 5070 Ti, 16 GiB) ----------------------------
+# Requires: uv pip install vllm
+# [models.qwen3-27b-nvfp4]
+# engine   = "vllm"
+# repo     = "kaitchup/Qwen3.6-27B-autoround-nvfp4-linearattn-BF16"
+# port     = 8093
+# vram_gib = 15
+# flags    = ["--max-model-len", "32768", "--reasoning-parser", "qwen3"]
+
 # --- Prod (roxabituwer, RTX 3080, 10 GB) — example --------------------------
 # [models.qwen3-8b-q4]
 # engine   = "llamacpp"

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -30,9 +30,9 @@ class ModelSpec:
     name: str
     engine: str
     repo: str
-    file: str
     port: int
     vram_gib: float
+    file: str = ""
     flags: list[str] = field(default_factory=list)
     mmproj: str | None = None
 

--- a/src/llmcli/daemon.py
+++ b/src/llmcli/daemon.py
@@ -141,22 +141,26 @@ class Daemon:
         return f"OK model={instance.model_name} port={instance.port} uptime={uptime}"
 
     def _engine_for_spec(self, spec: ModelSpec) -> Engine:
-        """Select the appropriate engine class for a ModelSpec and return an instance.
+        """Dispatch on spec.engine, returning the appropriate engine instance.
 
-        Dispatches on the explicit spec.engine field:
-          - "vllm"          → VLLMEngine
-          - "llamacpp_tq3"  → LlamaCppTQ3Engine
-          - anything else   → LlamaCppEngine (default)
+        Unknown engine values raise ValueError — no silent fallback to a wrong engine.
         """
         from .engines.llamacpp import LlamaCppEngine
         from .engines.llamacpp_tq3 import LlamaCppTQ3Engine
         from .engines.vllm import VLLMEngine
 
-        if spec.engine == "vllm":
-            return VLLMEngine()
-        if spec.engine == "llamacpp_tq3":
-            return LlamaCppTQ3Engine()
-        return LlamaCppEngine()
+        _ENGINE_REGISTRY: dict[str, type] = {
+            "llamacpp": LlamaCppEngine,
+            "llamacpp_tq3": LlamaCppTQ3Engine,
+            "vllm": VLLMEngine,
+        }
+        engine_cls = _ENGINE_REGISTRY.get(spec.engine)
+        if engine_cls is None:
+            raise ValueError(
+                f"Unknown engine '{spec.engine}' for model '{spec.name}'. "
+                f"Valid engines: {sorted(_ENGINE_REGISTRY)}"
+            )
+        return engine_cls()
 
     def _cmd_swap(self, arg: str) -> str:
         name = arg.strip()

--- a/src/llmcli/daemon.py
+++ b/src/llmcli/daemon.py
@@ -143,14 +143,18 @@ class Daemon:
     def _engine_for_spec(self, spec: ModelSpec) -> Engine:
         """Select the appropriate engine class for a ModelSpec and return an instance.
 
-        Uses LlamaCppTQ3Engine when the model name or quant field signals TQ3_4S;
-        falls back to LlamaCppEngine otherwise.
+        Dispatches on the explicit spec.engine field:
+          - "vllm"          → VLLMEngine
+          - "llamacpp_tq3"  → LlamaCppTQ3Engine
+          - anything else   → LlamaCppEngine (default)
         """
         from .engines.llamacpp import LlamaCppEngine
         from .engines.llamacpp_tq3 import LlamaCppTQ3Engine
+        from .engines.vllm import VLLMEngine
 
-        quant = getattr(spec, "quant", "") or ""
-        if "tq3" in spec.name.lower() or "TQ3_4S" in quant:
+        if spec.engine == "vllm":
+            return VLLMEngine()
+        if spec.engine == "llamacpp_tq3":
             return LlamaCppTQ3Engine()
         return LlamaCppEngine()
 

--- a/src/llmcli/engines/__init__.py
+++ b/src/llmcli/engines/__init__.py
@@ -1,4 +1,5 @@
 from .llamacpp import LlamaCppEngine
 from .llamacpp_tq3 import LlamaCppTQ3Engine
+from .vllm import VLLMEngine
 
-__all__ = ["LlamaCppEngine", "LlamaCppTQ3Engine"]
+__all__ = ["LlamaCppEngine", "LlamaCppTQ3Engine", "VLLMEngine"]

--- a/src/llmcli/engines/_common.py
+++ b/src/llmcli/engines/_common.py
@@ -1,0 +1,81 @@
+"""Shared helpers for llmCLI engine implementations."""
+
+from __future__ import annotations
+
+import collections
+import select
+import subprocess
+import time
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_WAIT_INTERVAL = 1.0  # seconds between health polls
+_STDERR_TAIL = 20  # lines of stderr to include in early-exit error
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_ready(
+    base_url: str,
+    proc: subprocess.Popen,  # type: ignore[type-arg]
+    timeout: float,
+    engine_name: str,  # used in error messages e.g. "llama-server", "vllm serve"
+) -> None:
+    """Poll <base_url>/health until a 2xx response, process exit, or timeout.
+
+    Continues on both connection errors and non-2xx responses (e.g. 503 during
+    vLLM model warmup). Only stops on a 2xx response, process early exit, or
+    timeout.
+
+    Raises:
+        RuntimeError: on process early exit or health-poll timeout.
+    """
+    deadline = time.monotonic() + timeout
+    stderr_lines: collections.deque[str] = collections.deque(maxlen=_STDERR_TAIL)
+
+    while time.monotonic() < deadline:
+        # Check if the process exited before becoming ready
+        rc = proc.poll()
+        if rc is not None:
+            # Drain remaining stderr lines if piped
+            if proc.stderr is not None:
+                for raw in proc.stderr:
+                    line = raw.decode(errors="replace").rstrip()
+                    stderr_lines.append(line)
+            # Reap the zombie — process is already dead, wait() is instant
+            proc.wait()
+            tail = "\n".join(stderr_lines) if stderr_lines else "(no stderr captured)"
+            raise RuntimeError(
+                f"{engine_name} exited with code {rc} before becoming ready. "
+                f"Last {_STDERR_TAIL} lines of stderr:\n{tail}"
+            )
+
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=2.0)
+            if resp.status_code < 300:
+                return
+            # Non-2xx (e.g. 503 warmup) — continue polling
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Drain any stderr lines emitted so far (non-blocking)
+        if proc.stderr is not None:
+            try:
+                ready, _, _ = select.select([proc.stderr], [], [], 0)
+                if ready:
+                    line = proc.stderr.readline()
+                    if line:
+                        stderr_lines.append(line.decode(errors="replace").rstrip())
+            except Exception:  # noqa: BLE001
+                pass
+
+        time.sleep(_WAIT_INTERVAL)
+
+    raise RuntimeError(f"{engine_name} did not become ready within {timeout}s ({base_url})")

--- a/src/llmcli/engines/llamacpp.py
+++ b/src/llmcli/engines/llamacpp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import os
 import signal
 import subprocess
@@ -11,15 +10,14 @@ import httpx
 
 from ..config import ModelSpec
 from ..engine import EngineInstance
+from ._common import _wait_ready
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 _WAIT_TIMEOUT = 60  # seconds
-_WAIT_INTERVAL = 0.5  # seconds between health polls
 _STOP_GRACE = 5  # seconds to wait after SIGTERM before SIGKILL
-_STDERR_TAIL = 20  # lines of stderr to include in early-exit error
 
 
 def _hf_hub_root() -> Path:
@@ -31,65 +29,6 @@ def _hf_hub_root() -> Path:
 def _repo_to_dir_name(repo: str) -> str:
     """Convert 'Org/Repo' to 'models--Org--Repo' (HF hub convention)."""
     return "models--" + repo.replace("/", "--")
-
-
-def _wait_ready(
-    base_url: str,
-    proc: subprocess.Popen,  # type: ignore[type-arg]
-    timeout: float = _WAIT_TIMEOUT,
-) -> None:
-    """Poll <base_url>/health until a 2xx response, process exit, or timeout.
-
-    If the subprocess exits before becoming healthy, its stderr tail is
-    captured and a RuntimeError is raised immediately (avoiding a zombie).
-
-    Raises:
-        RuntimeError: on process early exit or health-poll timeout.
-    """
-    deadline = time.monotonic() + timeout
-    stderr_lines: collections.deque[str] = collections.deque(maxlen=_STDERR_TAIL)
-
-    while time.monotonic() < deadline:
-        # Check if the process exited before becoming ready
-        rc = proc.poll()
-        if rc is not None:
-            # Drain remaining stderr lines if piped
-            if proc.stderr is not None:
-                for raw in proc.stderr:
-                    line = raw.decode(errors="replace").rstrip()
-                    stderr_lines.append(line)
-            # Reap the zombie — process is already dead, wait() is instant
-            proc.wait()
-            tail = "\n".join(stderr_lines) if stderr_lines else "(no stderr captured)"
-            raise RuntimeError(
-                f"llama-server exited with code {rc} before becoming ready. "
-                f"Last {_STDERR_TAIL} lines of stderr:\n{tail}"
-            )
-
-        try:
-            resp = httpx.get(f"{base_url}/health", timeout=2.0)
-            if resp.status_code < 300:
-                return
-        except Exception:  # noqa: BLE001
-            pass
-
-        # Drain any stderr lines emitted so far (non-blocking read from line iterator)
-        if proc.stderr is not None:
-            # Read without blocking — stderr is a byte-stream, peek available data
-            try:
-                import select
-
-                ready, _, _ = select.select([proc.stderr], [], [], 0)
-                if ready:
-                    line = proc.stderr.readline()
-                    if line:
-                        stderr_lines.append(line.decode(errors="replace").rstrip())
-            except Exception:  # noqa: BLE001
-                pass
-
-        time.sleep(_WAIT_INTERVAL)
-
-    raise RuntimeError(f"llama-server did not become ready within {timeout}s ({base_url})")
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +103,7 @@ class LlamaCppEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc)
+        _wait_ready(base_url, proc, _WAIT_TIMEOUT, "llama-server")
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import collections
+import os
+import signal
+import subprocess
+import time
+
+import httpx
+
+from ..config import ModelSpec
+from ..engine import EngineInstance
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_WAIT_TIMEOUT = 180  # seconds
+_WAIT_INTERVAL = 1.0  # seconds between health polls
+_STOP_GRACE = 5  # seconds to wait after SIGTERM before SIGKILL
+_STDERR_TAIL = 20  # lines of stderr to include in early-exit error
+
+
+def _wait_ready(
+    base_url: str,
+    proc: subprocess.Popen,  # type: ignore[type-arg]
+    timeout: float = _WAIT_TIMEOUT,
+) -> None:
+    """Poll <base_url>/health until a 2xx response, process exit, or timeout.
+
+    Continues on both connection errors and non-2xx responses (e.g. 503 during
+    vLLM model warmup). Only stops on a 2xx response, process early exit, or
+    timeout.
+
+    Raises:
+        RuntimeError: on process early exit or health-poll timeout.
+    """
+    deadline = time.monotonic() + timeout
+    stderr_lines: collections.deque[str] = collections.deque(maxlen=_STDERR_TAIL)
+
+    while time.monotonic() < deadline:
+        # Check if the process exited before becoming ready
+        rc = proc.poll()
+        if rc is not None:
+            # Drain remaining stderr lines if piped
+            if proc.stderr is not None:
+                for raw in proc.stderr:
+                    line = raw.decode(errors="replace").rstrip()
+                    stderr_lines.append(line)
+            proc.wait()
+            tail = "\n".join(stderr_lines) if stderr_lines else "(no stderr captured)"
+            raise RuntimeError(
+                f"vllm serve exited with code {rc} before becoming ready. "
+                f"Last {_STDERR_TAIL} lines of stderr:\n{tail}"
+            )
+
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=2.0)
+            if resp.status_code < 300:
+                return
+            # Non-2xx (e.g. 503 warmup) — continue polling
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Drain any stderr lines emitted so far (non-blocking)
+        if proc.stderr is not None:
+            try:
+                import select
+
+                ready, _, _ = select.select([proc.stderr], [], [], 0)
+                if ready:
+                    line = proc.stderr.readline()
+                    if line:
+                        stderr_lines.append(line.decode(errors="replace").rstrip())
+            except Exception:  # noqa: BLE001
+                pass
+
+        time.sleep(_WAIT_INTERVAL)
+
+    raise RuntimeError(f"vllm serve did not become ready within {timeout}s ({base_url})")
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class VLLMEngine:
+    """vLLM subprocess engine wrapper (HuggingFace repo served via `vllm serve`)."""
+
+    # ------------------------------------------------------------------
+    # Command builder
+    # ------------------------------------------------------------------
+
+    def _build_cmd(self, spec: ModelSpec) -> list[str]:
+        """Build the subprocess argument list for `vllm serve`."""
+        return ["vllm", "serve", spec.repo, "--port", str(spec.port), "--host", "0.0.0.0"] + list(spec.flags)
+
+    # ------------------------------------------------------------------
+    # Engine Protocol
+    # ------------------------------------------------------------------
+
+    def start(self, spec: ModelSpec) -> EngineInstance:
+        """Spawn `vllm serve`, wait for readiness, return EngineInstance.
+
+        The vllm import is deferred to this method to avoid ImportError at
+        module load time when vLLM is not installed.
+
+        Raises:
+            ImportError: when the vllm package is not installed.
+            RuntimeError: when the process exits early or the health endpoint
+                does not become ready within _WAIT_TIMEOUT seconds.
+        """
+        try:
+            import vllm  # noqa: F401
+        except ImportError as exc:
+            raise ImportError("vLLM not installed. Run: uv pip install vllm") from exc
+
+        cmd = self._build_cmd(spec)
+        proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, start_new_session=True)  # noqa: S603
+        base_url = f"http://localhost:{spec.port}/v1"
+        _wait_ready(base_url, proc)
+        return EngineInstance(
+            pid=proc.pid,
+            port=spec.port,
+            model_name=spec.name,
+            started_at=time.time(),
+        )
+
+    def health(self, instance: EngineInstance) -> bool:
+        """Return True iff the vllm /health endpoint responds 2xx."""
+        try:
+            resp = httpx.get(f"{instance.base_url}/health", timeout=2.0)
+            return resp.status_code < 300
+        except Exception:  # noqa: BLE001
+            return False
+
+    def stop(self, instance: EngineInstance) -> None:
+        """Send SIGTERM to the process group; escalate to SIGKILL after grace period.
+
+        Uses os.killpg to terminate the entire process group started with
+        start_new_session=True. Idempotent — silently ignores ProcessLookupError.
+        """
+        try:
+            os.killpg(os.getpgid(instance.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+        time.sleep(_STOP_GRACE)
+
+        try:
+            os.killpg(os.getpgid(instance.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -17,7 +17,6 @@ from ..engine import EngineInstance
 
 _WAIT_TIMEOUT = 180  # seconds
 _WAIT_INTERVAL = 1.0  # seconds between health polls
-_STOP_GRACE = 5  # seconds to wait after SIGTERM before SIGKILL
 _STDERR_TAIL = 20  # lines of stderr to include in early-exit error
 
 
@@ -114,7 +113,7 @@ class VLLMEngine:
         try:
             import vllm  # noqa: F401
         except ImportError as exc:
-            raise ImportError("vLLM not installed. Run: uv pip install vllm") from exc
+            raise ImportError("vLLM not installed. Run: uv sync --group vllm") from exc
 
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, start_new_session=True)  # noqa: S603
@@ -136,19 +135,29 @@ class VLLMEngine:
             return False
 
     def stop(self, instance: EngineInstance) -> None:
-        """Send SIGTERM to the process group; escalate to SIGKILL after grace period.
+        """Send SIGTERM to the process group; escalate to SIGKILL if it does not exit.
 
-        Uses os.killpg to terminate the entire process group started with
-        start_new_session=True. Idempotent — silently ignores ProcessLookupError.
+        Uses os.killpg to terminate the entire process group (vLLM spawns GPU worker
+        subprocesses in the same session). Always calls os.waitpid() to reap the session
+        leader and prevent zombie accumulation across repeated swap cycles.
+        Idempotent — silently ignores ProcessLookupError (already dead).
         """
         try:
             os.killpg(os.getpgid(instance.pid), signal.SIGTERM)
         except ProcessLookupError:
             return
 
-        time.sleep(_STOP_GRACE)
-
         try:
-            os.killpg(os.getpgid(instance.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+            os.waitpid(instance.pid, 0)
+        except ChildProcessError:
+            # Process did not exit after SIGTERM — escalate to SIGKILL.
+            try:
+                os.killpg(os.getpgid(instance.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            else:
+                # Reap after SIGKILL so no zombie lingers between swap cycles.
+                try:
+                    os.waitpid(instance.pid, 0)
+                except ChildProcessError:
+                    pass

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import collections
 import os
+import shutil
 import signal
 import subprocess
 import time
@@ -10,73 +10,13 @@ import httpx
 
 from ..config import ModelSpec
 from ..engine import EngineInstance
+from ._common import _wait_ready
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_WAIT_TIMEOUT = 180  # seconds
-_WAIT_INTERVAL = 1.0  # seconds between health polls
-_STDERR_TAIL = 20  # lines of stderr to include in early-exit error
-
-
-def _wait_ready(
-    base_url: str,
-    proc: subprocess.Popen,  # type: ignore[type-arg]
-    timeout: float = _WAIT_TIMEOUT,
-) -> None:
-    """Poll <base_url>/health until a 2xx response, process exit, or timeout.
-
-    Continues on both connection errors and non-2xx responses (e.g. 503 during
-    vLLM model warmup). Only stops on a 2xx response, process early exit, or
-    timeout.
-
-    Raises:
-        RuntimeError: on process early exit or health-poll timeout.
-    """
-    deadline = time.monotonic() + timeout
-    stderr_lines: collections.deque[str] = collections.deque(maxlen=_STDERR_TAIL)
-
-    while time.monotonic() < deadline:
-        # Check if the process exited before becoming ready
-        rc = proc.poll()
-        if rc is not None:
-            # Drain remaining stderr lines if piped
-            if proc.stderr is not None:
-                for raw in proc.stderr:
-                    line = raw.decode(errors="replace").rstrip()
-                    stderr_lines.append(line)
-            proc.wait()
-            tail = "\n".join(stderr_lines) if stderr_lines else "(no stderr captured)"
-            raise RuntimeError(
-                f"vllm serve exited with code {rc} before becoming ready. "
-                f"Last {_STDERR_TAIL} lines of stderr:\n{tail}"
-            )
-
-        try:
-            resp = httpx.get(f"{base_url}/health", timeout=2.0)
-            if resp.status_code < 300:
-                return
-            # Non-2xx (e.g. 503 warmup) — continue polling
-        except Exception:  # noqa: BLE001
-            pass
-
-        # Drain any stderr lines emitted so far (non-blocking)
-        if proc.stderr is not None:
-            try:
-                import select
-
-                ready, _, _ = select.select([proc.stderr], [], [], 0)
-                if ready:
-                    line = proc.stderr.readline()
-                    if line:
-                        stderr_lines.append(line.decode(errors="replace").rstrip())
-            except Exception:  # noqa: BLE001
-                pass
-
-        time.sleep(_WAIT_INTERVAL)
-
-    raise RuntimeError(f"vllm serve did not become ready within {timeout}s ({base_url})")
+_WAIT_TIMEOUT = 180  # vLLM needs longer: safetensors load + NVFP4 JIT compile can take 60–120 s on first start
 
 
 # ---------------------------------------------------------------------------
@@ -110,6 +50,12 @@ class VLLMEngine:
             RuntimeError: when the process exits early or the health endpoint
                 does not become ready within _WAIT_TIMEOUT seconds.
         """
+        if shutil.which("vllm") is None:
+            raise RuntimeError(
+                "vllm binary not found on PATH. "
+                "Ensure your venv is activated or run via `uv run llmcli`. "
+                "Install with: uv sync --group vllm"
+            )
         try:
             import vllm  # noqa: F401
         except ImportError as exc:
@@ -118,7 +64,7 @@ class VLLMEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, start_new_session=True)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc)
+        _wait_ready(base_url, proc, _WAIT_TIMEOUT, "vllm serve")
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from llmcli.config import Catalog, HostSettings, ModelSpec, load, check_vram_budget
+from llmcli.config import Catalog, HostSettings, ModelSpec, _parse_model_spec, load, check_vram_budget
 
 
 # ---------------------------------------------------------------------------
@@ -269,6 +269,29 @@ class TestCheckVramBudget:
         # Dynamic probe mocked to 0.0 (GPU tools unavailable) so it is skipped too.
         with patch("llmcli.config.probe_free_vram_gib", return_value=0.0):
             check_vram_budget(spec, catalog.host)
+
+
+# ---------------------------------------------------------------------------
+# ModelSpec field defaults — vLLM models have no GGUF file
+# ---------------------------------------------------------------------------
+
+
+class TestModelSpecDefaults:
+    def test_model_spec_file_defaults_to_empty_string(self) -> None:
+        """vLLM models have no GGUF file — file must default to '' when absent."""
+        # Arrange
+        raw: dict = {
+            "engine": "vllm",
+            "repo": "kaitchup/Qwen3.6-27B-autoround-nvfp4-linearattn-BF16",
+            "port": 8093,
+            "vram_gib": 15.0,
+        }
+        # Act
+        spec = _parse_model_spec("qwen3-27b-nvfp4", raw)
+        # Assert
+        assert spec.file == ""
+        assert spec.name == "qwen3-27b-nvfp4"
+        assert spec.engine == "vllm"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -198,6 +198,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
@@ -216,6 +217,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
@@ -230,6 +232,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
@@ -246,6 +249,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
@@ -263,6 +267,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
@@ -281,6 +286,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
             patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch(
@@ -483,7 +489,10 @@ class TestVLLMImportGuard:
                 raise ImportError("No module named 'vllm'")
             return original_import(name, *args, **kwargs)
 
-        with patch("builtins.__import__", side_effect=_fake_import):
+        with (
+            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
+            patch("builtins.__import__", side_effect=_fake_import),
+        ):
             with pytest.raises(ImportError, match="uv sync --group vllm"):
                 engine.start(vllm_spec)
 
@@ -564,7 +573,7 @@ class TestWaitReady:
     @pytest.mark.no_gpu
     def test_returns_immediately_on_2xx(self) -> None:
         """_wait_ready should return as soon as /health responds 2xx."""
-        from llmcli.engines.vllm import _wait_ready
+        from llmcli.engines._common import _wait_ready
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None  # process still running
@@ -573,17 +582,17 @@ class TestWaitReady:
         mock_response.status_code = 200
 
         with (
-            patch("llmcli.engines.vllm.httpx.get", return_value=mock_response),
-            patch("llmcli.engines.vllm.time.sleep"),
-            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 0.1]),
+            patch("llmcli.engines._common.httpx.get", return_value=mock_response),
+            patch("llmcli.engines._common.time.sleep"),
+            patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 0.1]),
         ):
-            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=10.0)
+            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=10.0, engine_name="vllm serve")
         # Should complete without raising
 
     @pytest.mark.no_gpu
     def test_continues_on_503_then_succeeds_on_200(self) -> None:
         """_wait_ready must continue polling on 503 (warmup) until 2xx."""
-        from llmcli.engines.vllm import _wait_ready
+        from llmcli.engines._common import _wait_ready
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -602,21 +611,21 @@ class TestWaitReady:
             return resp_200 if call_count >= 3 else resp_503
 
         with (
-            patch("llmcli.engines.vllm.httpx.get", side_effect=fake_get),
-            patch("llmcli.engines.vllm.time.sleep"),
+            patch("llmcli.engines._common.httpx.get", side_effect=fake_get),
+            patch("llmcli.engines._common.time.sleep"),
             patch(
-                "llmcli.engines.vllm.time.monotonic",
+                "llmcli.engines._common.time.monotonic",
                 side_effect=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
             ),
         ):
-            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0)
+            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve")
 
         assert call_count >= 3, "Must poll at least 3 times (2× 503 + 1× 200)"
 
     @pytest.mark.no_gpu
     def test_raises_on_early_process_exit(self) -> None:
         """_wait_ready must raise RuntimeError with exit code when process exits early."""
-        from llmcli.engines.vllm import _wait_ready
+        from llmcli.engines._common import _wait_ready
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1  # process exited immediately
@@ -624,16 +633,16 @@ class TestWaitReady:
         mock_proc.wait.return_value = None
 
         with (
-            patch("llmcli.engines.vllm.httpx.get"),
-            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 0.5]),
+            patch("llmcli.engines._common.httpx.get"),
+            patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 0.5]),
         ):
             with pytest.raises(RuntimeError, match="exited with code 1"):
-                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0)
+                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve")
 
     @pytest.mark.no_gpu
     def test_raises_on_timeout(self) -> None:
         """_wait_ready must raise RuntimeError when the deadline passes."""
-        from llmcli.engines.vllm import _wait_ready
+        from llmcli.engines._common import _wait_ready
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
@@ -643,10 +652,10 @@ class TestWaitReady:
         resp_503.status_code = 503
 
         with (
-            patch("llmcli.engines.vllm.httpx.get", return_value=resp_503),
-            patch("llmcli.engines.vllm.time.sleep"),
+            patch("llmcli.engines._common.httpx.get", return_value=resp_503),
+            patch("llmcli.engines._common.time.sleep"),
             # Deadline expires immediately on the second call
-            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 100.0]),
+            patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 100.0]),
         ):
             with pytest.raises(RuntimeError, match="did not become ready"):
-                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=1.0)
+                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=1.0, engine_name="vllm serve")

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -308,13 +308,11 @@ class TestVLLMStop:
         with (
             patch("llmcli.engines.vllm.os.getpgid", return_value=55555) as mock_getpgid,
             patch("llmcli.engines.vllm.os.killpg") as mock_killpg,
+            patch("llmcli.engines.vllm.os.waitpid", return_value=(12345, 0)),
         ):
             # Simulate process dying after SIGTERM (getpgid raises on second poll)
             mock_getpgid.side_effect = [55555, ProcessLookupError("gone")]
-            try:
-                engine.stop(fake_instance)
-            except NotImplementedError:
-                pass  # RED phase
+            engine.stop(fake_instance)
 
         sigterm_calls = [
             c for c in mock_killpg.call_args_list
@@ -331,18 +329,22 @@ class TestVLLMStop:
     def test_stop_escalates_to_sigkill(
         self, engine, fake_instance: EngineInstance
     ) -> None:
-        """stop() must escalate to SIGKILL after grace period if process remains alive."""
+        """stop() must escalate to SIGKILL when waitpid raises ChildProcessError after SIGTERM."""
+        waitpid_calls = 0
+
+        def fake_waitpid(pid, flags):
+            nonlocal waitpid_calls
+            waitpid_calls += 1
+            if waitpid_calls == 1:
+                raise ChildProcessError("process did not exit")
+            return (pid, 0)
+
         with (
             patch("llmcli.engines.vllm.os.getpgid", return_value=55555),
             patch("llmcli.engines.vllm.os.killpg") as mock_killpg,
-            # Speed up the grace-period wait
-            patch("llmcli.engines.vllm.time.sleep", return_value=None),
-            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 999.0, 999.0, 999.0]),
+            patch("llmcli.engines.vllm.os.waitpid", side_effect=fake_waitpid),
         ):
-            try:
-                engine.stop(fake_instance)
-            except NotImplementedError:
-                pass  # RED phase
+            engine.stop(fake_instance)
 
         sigkill_calls = [
             c for c in mock_killpg.call_args_list
@@ -361,11 +363,8 @@ class TestVLLMStop:
             "llmcli.engines.vllm.os.getpgid",
             side_effect=ProcessLookupError("no such process"),
         ):
-            # Should not raise
             try:
                 engine.stop(fake_instance)
-            except NotImplementedError:
-                pass  # RED phase — acceptable
             except ProcessLookupError:
                 pytest.fail(
                     "stop() must not propagate ProcessLookupError for already-dead processes"
@@ -379,14 +378,10 @@ class TestVLLMStop:
         with (
             patch("llmcli.engines.vllm.os.getpgid", return_value=55555),
             patch("llmcli.engines.vllm.os.killpg"),
+            patch("llmcli.engines.vllm.os.waitpid", return_value=(12345, 0)),
             patch("llmcli.engines.vllm.os.kill") as mock_os_kill,
-            patch("llmcli.engines.vllm.time.sleep", return_value=None),
-            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 999.0, 999.0]),
         ):
-            try:
-                engine.stop(fake_instance)
-            except NotImplementedError:
-                pass  # RED phase
+            engine.stop(fake_instance)
 
         assert mock_os_kill.call_count == 0, (
             "stop() must NOT use os.kill — use os.killpg for process-group signals"
@@ -556,3 +551,102 @@ class TestDaemonDispatchVLLM:
         assert isinstance(result, LlamaCppTQ3Engine), (
             f"engine='llamacpp_tq3' must dispatch to LlamaCppTQ3Engine, got {type(result)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 8. _wait_ready
+# ---------------------------------------------------------------------------
+
+
+class TestWaitReady:
+    """Direct unit tests for the _wait_ready polling helper."""
+
+    @pytest.mark.no_gpu
+    def test_returns_immediately_on_2xx(self) -> None:
+        """_wait_ready should return as soon as /health responds 2xx."""
+        from llmcli.engines.vllm import _wait_ready
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # process still running
+        mock_proc.stderr = None
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with (
+            patch("llmcli.engines.vllm.httpx.get", return_value=mock_response),
+            patch("llmcli.engines.vllm.time.sleep"),
+            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 0.1]),
+        ):
+            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=10.0)
+        # Should complete without raising
+
+    @pytest.mark.no_gpu
+    def test_continues_on_503_then_succeeds_on_200(self) -> None:
+        """_wait_ready must continue polling on 503 (warmup) until 2xx."""
+        from llmcli.engines.vllm import _wait_ready
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.stderr = None
+
+        resp_503 = MagicMock()
+        resp_503.status_code = 503
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+
+        call_count = 0
+
+        def fake_get(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return resp_200 if call_count >= 3 else resp_503
+
+        with (
+            patch("llmcli.engines.vllm.httpx.get", side_effect=fake_get),
+            patch("llmcli.engines.vllm.time.sleep"),
+            patch(
+                "llmcli.engines.vllm.time.monotonic",
+                side_effect=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            ),
+        ):
+            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0)
+
+        assert call_count >= 3, "Must poll at least 3 times (2× 503 + 1× 200)"
+
+    @pytest.mark.no_gpu
+    def test_raises_on_early_process_exit(self) -> None:
+        """_wait_ready must raise RuntimeError with exit code when process exits early."""
+        from llmcli.engines.vllm import _wait_ready
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1  # process exited immediately
+        mock_proc.stderr = None
+        mock_proc.wait.return_value = None
+
+        with (
+            patch("llmcli.engines.vllm.httpx.get"),
+            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 0.5]),
+        ):
+            with pytest.raises(RuntimeError, match="exited with code 1"):
+                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0)
+
+    @pytest.mark.no_gpu
+    def test_raises_on_timeout(self) -> None:
+        """_wait_ready must raise RuntimeError when the deadline passes."""
+        from llmcli.engines.vllm import _wait_ready
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.stderr = None
+
+        resp_503 = MagicMock()
+        resp_503.status_code = 503
+
+        with (
+            patch("llmcli.engines.vllm.httpx.get", return_value=resp_503),
+            patch("llmcli.engines.vllm.time.sleep"),
+            # Deadline expires immediately on the second call
+            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 100.0]),
+        ):
+            with pytest.raises(RuntimeError, match="did not become ready"):
+                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=1.0)

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -198,6 +198,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
         ):
@@ -215,6 +216,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
         ):
@@ -228,6 +230,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
         ):
@@ -243,6 +246,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
         ):
@@ -259,6 +263,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc) as mock_popen,
             patch("llmcli.engines.vllm._wait_ready", return_value=None),
         ):
@@ -276,6 +281,7 @@ class TestVLLMStart:
         mock_proc.pid = 99999
 
         with (
+            patch.dict("sys.modules", {"vllm": MagicMock()}),
             patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
             patch(
                 "llmcli.engines.vllm._wait_ready",

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -68,6 +68,21 @@ def engine():
     return VLLMEngine()
 
 
+@pytest.fixture()
+def started_instance(engine, vllm_spec):
+    """Run engine.start() with mocked Popen and _wait_ready; yield (instance, mock_popen)."""
+    mock_proc = MagicMock()
+    mock_proc.pid = 99999
+    with (
+        patch.dict("sys.modules", {"vllm": MagicMock()}),
+        patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc) as mock_popen,
+        patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
+    ):
+        instance = engine.start(vllm_spec)
+        yield instance, mock_popen
+
+
 # ---------------------------------------------------------------------------
 # 1. Protocol conformance
 # ---------------------------------------------------------------------------
@@ -192,70 +207,31 @@ class TestVLLMStart:
     """start(spec) must spawn via Popen (start_new_session=True) and return EngineInstance."""
 
     @pytest.mark.no_gpu
-    def test_start_returns_engine_instance(self, engine, vllm_spec: ModelSpec) -> None:
-        # Arrange
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-
-        with (
-            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
-            patch.dict("sys.modules", {"vllm": MagicMock()}),
-            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
-            patch("llmcli.engines.vllm._wait_ready", return_value=None),
-        ):
-            # Act
-            result = engine.start(vllm_spec)
-
+    def test_start_returns_engine_instance(self, started_instance) -> None:
+        # Arrange / Act
+        result, _ = started_instance
         # Assert
         assert isinstance(result, EngineInstance), (
             f"start() must return EngineInstance, got {type(result)}"
         )
 
     @pytest.mark.no_gpu
-    def test_start_instance_pid_matches_process(self, engine, vllm_spec: ModelSpec) -> None:
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-
-        with (
-            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
-            patch.dict("sys.modules", {"vllm": MagicMock()}),
-            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
-            patch("llmcli.engines.vllm._wait_ready", return_value=None),
-        ):
-            result = engine.start(vllm_spec)
-
+    def test_start_instance_pid_matches_process(self, started_instance) -> None:
+        result, _ = started_instance
         assert result.pid == 99999, f"instance.pid must equal process pid 99999, got {result.pid}"
 
     @pytest.mark.no_gpu
-    def test_start_instance_port_matches_spec(self, engine, vllm_spec: ModelSpec) -> None:
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-
-        with (
-            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
-            patch.dict("sys.modules", {"vllm": MagicMock()}),
-            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
-            patch("llmcli.engines.vllm._wait_ready", return_value=None),
-        ):
-            result = engine.start(vllm_spec)
-
+    def test_start_instance_port_matches_spec(self, started_instance, vllm_spec: ModelSpec) -> None:
+        result, _ = started_instance
         assert result.port == vllm_spec.port, (
             f"instance.port must equal spec.port={vllm_spec.port}, got {result.port}"
         )
 
     @pytest.mark.no_gpu
-    def test_start_instance_model_name_matches_spec(self, engine, vllm_spec: ModelSpec) -> None:
-        mock_proc = MagicMock()
-        mock_proc.pid = 99999
-
-        with (
-            patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
-            patch.dict("sys.modules", {"vllm": MagicMock()}),
-            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
-            patch("llmcli.engines.vllm._wait_ready", return_value=None),
-        ):
-            result = engine.start(vllm_spec)
-
+    def test_start_instance_model_name_matches_spec(
+        self, started_instance, vllm_spec: ModelSpec
+    ) -> None:
+        result, _ = started_instance
         assert result.model_name == vllm_spec.name, (
             f"instance.model_name must equal spec.name={vllm_spec.name!r}, got {result.model_name!r}"
         )
@@ -482,16 +458,9 @@ class TestVLLMImportGuard:
         self, engine, vllm_spec: ModelSpec
     ) -> None:
         """When vllm package is unavailable, start() must raise ImportError with install hint."""
-        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
-
-        def _fake_import(name, *args, **kwargs):
-            if name == "vllm":
-                raise ImportError("No module named 'vllm'")
-            return original_import(name, *args, **kwargs)
-
         with (
             patch("llmcli.engines.vllm.shutil.which", return_value="/usr/bin/vllm"),
-            patch("builtins.__import__", side_effect=_fake_import),
+            patch.dict("sys.modules", {"vllm": None}),
         ):
             with pytest.raises(ImportError, match="uv sync --group vllm"):
                 engine.start(vllm_spec)

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -1,0 +1,552 @@
+"""RED-phase tests for VLLMEngine (issue #13).
+
+All tests assert behaviour expected from the GREEN implementation.
+Against the current NotImplementedError scaffold they MUST fail.
+
+Test categories:
+- Protocol conformance (method signatures)
+- Command-line construction (_build_cmd)
+- EngineInstance shape returned by start()
+- stop() process-group teardown (os.killpg / os.getpgid)
+- health() HTTP probe (httpx mocked)
+- Import guard (vllm package availability)
+- Daemon dispatch routing (engine="vllm" → VLLMEngine)
+
+Markers:
+  no_gpu  — CI-safe; no real binary, no GPU required
+  gpu     — requires real vllm binary + GPU; skipped in CI
+"""
+from __future__ import annotations
+
+import inspect
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llmcli.config import ModelSpec
+from llmcli.engine import EngineInstance
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def vllm_spec() -> ModelSpec:
+    return ModelSpec(
+        name="qwen3-27b-nvfp4",
+        engine="vllm",
+        repo="kaitchup/Qwen3.6-27B-autoround-nvfp4-linearattn-BF16",
+        port=8093,
+        vram_gib=15.0,
+        flags=["--max-model-len", "32768", "--reasoning-parser", "qwen3"],
+    )
+
+
+@pytest.fixture()
+def vllm_spec_no_flags() -> ModelSpec:
+    return ModelSpec(
+        name="qwen3-4b-nvfp4",
+        engine="vllm",
+        repo="kaitchup/Qwen3-4B-autoround-nvfp4",
+        port=8094,
+        vram_gib=6.0,
+        flags=[],
+    )
+
+
+@pytest.fixture()
+def fake_instance() -> EngineInstance:
+    return EngineInstance(pid=12345, port=8093, model_name="qwen3-27b-nvfp4", started_at=1_700_000_000.0)
+
+
+@pytest.fixture()
+def engine():
+    from llmcli.engines.vllm import VLLMEngine
+    return VLLMEngine()
+
+
+# ---------------------------------------------------------------------------
+# 1. Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMProtocolConformance:
+    """VLLMEngine must implement the Engine Protocol."""
+
+    @pytest.mark.no_gpu
+    def test_has_start_method(self, engine) -> None:
+        assert callable(getattr(engine, "start", None)), "VLLMEngine must have a start() method"
+
+    @pytest.mark.no_gpu
+    def test_has_stop_method(self, engine) -> None:
+        assert callable(getattr(engine, "stop", None)), "VLLMEngine must have a stop() method"
+
+    @pytest.mark.no_gpu
+    def test_has_health_method(self, engine) -> None:
+        assert callable(getattr(engine, "health", None)), "VLLMEngine must have a health() method"
+
+    @pytest.mark.no_gpu
+    def test_start_accepts_model_spec(self, engine, vllm_spec: ModelSpec) -> None:
+        sig = inspect.signature(engine.start)
+        params = list(sig.parameters.keys())
+        assert len(params) >= 1, "start() must accept at least one parameter (spec)"
+
+    @pytest.mark.no_gpu
+    def test_stop_accepts_engine_instance(self, engine, fake_instance: EngineInstance) -> None:
+        sig = inspect.signature(engine.stop)
+        params = list(sig.parameters.keys())
+        assert len(params) >= 1, "stop() must accept at least one parameter (instance)"
+
+    @pytest.mark.no_gpu
+    def test_health_accepts_engine_instance(self, engine, fake_instance: EngineInstance) -> None:
+        sig = inspect.signature(engine.health)
+        params = list(sig.parameters.keys())
+        assert len(params) >= 1, "health() must accept at least one parameter (instance)"
+
+
+# ---------------------------------------------------------------------------
+# 2. Command-line construction
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMCommandBuild:
+    """_build_cmd(spec) must produce a correctly ordered argv list."""
+
+    @pytest.mark.no_gpu
+    def test_cmd_starts_with_vllm_serve(self, engine, vllm_spec: ModelSpec) -> None:
+        # Arrange / Act
+        cmd = engine._build_cmd(vllm_spec)
+        # Assert
+        assert cmd[0] == "vllm", f"first element must be 'vllm', got {cmd[0]!r}"
+        assert cmd[1] == "serve", f"second element must be 'serve', got {cmd[1]!r}"
+
+    @pytest.mark.no_gpu
+    def test_cmd_contains_repo(self, engine, vllm_spec: ModelSpec) -> None:
+        cmd = engine._build_cmd(vllm_spec)
+        assert vllm_spec.repo in cmd, f"repo '{vllm_spec.repo}' must appear in command"
+        assert cmd[2] == vllm_spec.repo, (
+            f"repo must be 3rd element (after 'vllm serve'), got cmd[2]={cmd[2]!r}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_cmd_contains_port(self, engine, vllm_spec: ModelSpec) -> None:
+        cmd = engine._build_cmd(vllm_spec)
+        assert "--port" in cmd, "command must include --port flag"
+        port_idx = cmd.index("--port")
+        assert cmd[port_idx + 1] == str(vllm_spec.port), (
+            f"--port value must be {vllm_spec.port!r}, got {cmd[port_idx + 1]!r}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_cmd_binds_all_interfaces(self, engine, vllm_spec: ModelSpec) -> None:
+        cmd = engine._build_cmd(vllm_spec)
+        assert "--host" in cmd, "command must include --host flag"
+        host_idx = cmd.index("--host")
+        assert cmd[host_idx + 1] == "0.0.0.0", (
+            f"--host must be '0.0.0.0', got {cmd[host_idx + 1]!r}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_cmd_ordering_port_before_host(self, engine, vllm_spec: ModelSpec) -> None:
+        """Spec: argv order is --port before --host 0.0.0.0."""
+        cmd = engine._build_cmd(vllm_spec)
+        port_idx = cmd.index("--port")
+        host_idx = cmd.index("--host")
+        assert port_idx < host_idx, (
+            f"--port (idx {port_idx}) must come before --host (idx {host_idx})"
+        )
+
+    @pytest.mark.no_gpu
+    def test_cmd_appends_flags_after_host(self, engine, vllm_spec: ModelSpec) -> None:
+        """spec.flags must appear after --host 0.0.0.0."""
+        cmd = engine._build_cmd(vllm_spec)
+        host_idx = cmd.index("--host")
+        # Flags start after "--host" "0.0.0.0"
+        tail = cmd[host_idx + 2:]
+        for flag in vllm_spec.flags:
+            assert flag in tail, (
+                f"catalog flag '{flag}' must appear after '--host 0.0.0.0'; tail={tail}"
+            )
+
+    @pytest.mark.no_gpu
+    def test_cmd_no_extra_args_when_empty_flags(
+        self, engine, vllm_spec_no_flags: ModelSpec
+    ) -> None:
+        """Empty flags list must not add any extra elements beyond the core argv."""
+        cmd = engine._build_cmd(vllm_spec_no_flags)
+        # Core argv: ["vllm", "serve", repo, "--port", port, "--host", "0.0.0.0"]
+        assert len(cmd) == 7, (
+            f"with empty flags, command must have exactly 7 elements, got {len(cmd)}: {cmd}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. start()
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMStart:
+    """start(spec) must spawn via Popen (start_new_session=True) and return EngineInstance."""
+
+    @pytest.mark.no_gpu
+    def test_start_returns_engine_instance(self, engine, vllm_spec: ModelSpec) -> None:
+        # Arrange
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
+            patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        ):
+            # Act
+            result = engine.start(vllm_spec)
+
+        # Assert
+        assert isinstance(result, EngineInstance), (
+            f"start() must return EngineInstance, got {type(result)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_start_instance_pid_matches_process(self, engine, vllm_spec: ModelSpec) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
+            patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        ):
+            result = engine.start(vllm_spec)
+
+        assert result.pid == 99999, f"instance.pid must equal process pid 99999, got {result.pid}"
+
+    @pytest.mark.no_gpu
+    def test_start_instance_port_matches_spec(self, engine, vllm_spec: ModelSpec) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
+            patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        ):
+            result = engine.start(vllm_spec)
+
+        assert result.port == vllm_spec.port, (
+            f"instance.port must equal spec.port={vllm_spec.port}, got {result.port}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_start_instance_model_name_matches_spec(self, engine, vllm_spec: ModelSpec) -> None:
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
+            patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        ):
+            result = engine.start(vllm_spec)
+
+        assert result.model_name == vllm_spec.name, (
+            f"instance.model_name must equal spec.name={vllm_spec.name!r}, got {result.model_name!r}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_start_uses_start_new_session(self, engine, vllm_spec: ModelSpec) -> None:
+        """Popen must be called with start_new_session=True for pgid-based stop."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc) as mock_popen,
+            patch("llmcli.engines.vllm._wait_ready", return_value=None),
+        ):
+            engine.start(vllm_spec)
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs.get("start_new_session") is True, (
+            f"Popen must be called with start_new_session=True; got kwargs={call_kwargs}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_start_propagates_wait_ready_error(self, engine, vllm_spec: ModelSpec) -> None:
+        """If _wait_ready raises RuntimeError, start() must propagate it."""
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.vllm.subprocess.Popen", return_value=mock_proc),
+            patch(
+                "llmcli.engines.vllm._wait_ready",
+                side_effect=RuntimeError("exited"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="exited"):
+                engine.start(vllm_spec)
+
+
+# ---------------------------------------------------------------------------
+# 4. stop()
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMStop:
+    """stop(instance) must use os.killpg/os.getpgid (not os.kill) for process-group teardown."""
+
+    @pytest.mark.no_gpu
+    def test_stop_sends_sigterm_via_killpg(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        """stop() must call os.killpg(os.getpgid(pid), SIGTERM)."""
+        with (
+            patch("llmcli.engines.vllm.os.getpgid", return_value=55555) as mock_getpgid,
+            patch("llmcli.engines.vllm.os.killpg") as mock_killpg,
+        ):
+            # Simulate process dying after SIGTERM (getpgid raises on second poll)
+            mock_getpgid.side_effect = [55555, ProcessLookupError("gone")]
+            try:
+                engine.stop(fake_instance)
+            except NotImplementedError:
+                pass  # RED phase
+
+        sigterm_calls = [
+            c for c in mock_killpg.call_args_list
+            if c[0][1] == signal.SIGTERM
+        ]
+        assert len(sigterm_calls) >= 1, (
+            f"stop() must send at least one SIGTERM via killpg; calls={mock_killpg.call_args_list}"
+        )
+        assert sigterm_calls[0][0][0] == 55555, (
+            f"SIGTERM must target pgid=55555; got {sigterm_calls[0][0][0]}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_stop_escalates_to_sigkill(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        """stop() must escalate to SIGKILL after grace period if process remains alive."""
+        with (
+            patch("llmcli.engines.vllm.os.getpgid", return_value=55555),
+            patch("llmcli.engines.vllm.os.killpg") as mock_killpg,
+            # Speed up the grace-period wait
+            patch("llmcli.engines.vllm.time.sleep", return_value=None),
+            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 999.0, 999.0, 999.0]),
+        ):
+            try:
+                engine.stop(fake_instance)
+            except NotImplementedError:
+                pass  # RED phase
+
+        sigkill_calls = [
+            c for c in mock_killpg.call_args_list
+            if c[0][1] == signal.SIGKILL
+        ]
+        assert len(sigkill_calls) >= 1, (
+            f"stop() must escalate to SIGKILL; calls={mock_killpg.call_args_list}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_stop_idempotent_when_process_gone(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        """stop() must return without raising when os.getpgid raises ProcessLookupError."""
+        with patch(
+            "llmcli.engines.vllm.os.getpgid",
+            side_effect=ProcessLookupError("no such process"),
+        ):
+            # Should not raise
+            try:
+                engine.stop(fake_instance)
+            except NotImplementedError:
+                pass  # RED phase — acceptable
+            except ProcessLookupError:
+                pytest.fail(
+                    "stop() must not propagate ProcessLookupError for already-dead processes"
+                )
+
+    @pytest.mark.no_gpu
+    def test_stop_uses_getpgid_not_os_kill(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        """stop() must use os.killpg (process-group) rather than os.kill (single pid)."""
+        with (
+            patch("llmcli.engines.vllm.os.getpgid", return_value=55555),
+            patch("llmcli.engines.vllm.os.killpg"),
+            patch("llmcli.engines.vllm.os.kill") as mock_os_kill,
+            patch("llmcli.engines.vllm.time.sleep", return_value=None),
+            patch("llmcli.engines.vllm.time.monotonic", side_effect=[0.0, 999.0, 999.0]),
+        ):
+            try:
+                engine.stop(fake_instance)
+            except NotImplementedError:
+                pass  # RED phase
+
+        assert mock_os_kill.call_count == 0, (
+            "stop() must NOT use os.kill — use os.killpg for process-group signals"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. health()
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMHealth:
+    """health(instance) must probe /health and return a bool."""
+
+    @pytest.mark.no_gpu
+    def test_health_returns_true_on_200(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("llmcli.engines.vllm.httpx.get", return_value=mock_response) as mock_get:
+            result = engine.health(fake_instance)
+
+        assert result is True, f"health() must return True on HTTP 200, got {result!r}"
+        mock_get.assert_called_once()
+        call_url: str = mock_get.call_args[0][0]
+        assert "/health" in call_url, (
+            f"health() must probe a /health endpoint, got URL: {call_url}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_health_returns_false_on_503(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch("llmcli.engines.vllm.httpx.get", return_value=mock_response):
+            result = engine.health(fake_instance)
+
+        assert result is False, f"health() must return False on HTTP 503, got {result!r}"
+
+    @pytest.mark.no_gpu
+    def test_health_returns_false_on_connection_error(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        with patch(
+            "llmcli.engines.vllm.httpx.get",
+            side_effect=Exception("Connection refused"),
+        ):
+            result = engine.health(fake_instance)
+
+        assert result is False, (
+            "health() must catch connection errors and return False, not raise"
+        )
+
+    @pytest.mark.no_gpu
+    def test_health_probes_instance_port(
+        self, engine, fake_instance: EngineInstance
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("llmcli.engines.vllm.httpx.get", return_value=mock_response) as mock_get:
+            engine.health(fake_instance)
+
+        call_url: str = mock_get.call_args[0][0]
+        assert str(fake_instance.port) in call_url, (
+            f"health() must probe port {fake_instance.port}, got URL: {call_url}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Import guard
+# ---------------------------------------------------------------------------
+
+
+class TestVLLMImportGuard:
+    """VLLMEngine must import cleanly without vllm installed; start() raises ImportError
+    with a helpful install hint when vllm is genuinely unavailable at runtime."""
+
+    @pytest.mark.no_gpu
+    def test_import_succeeds_without_vllm_package(self) -> None:
+        """Importing VLLMEngine must not require the vllm package at import time."""
+        # The import at module level in the fixture already proves this if we got here.
+        from llmcli.engines.vllm import VLLMEngine  # noqa: F401  # re-import is fine
+        assert True, "Import of VLLMEngine must succeed without vllm installed"
+
+    @pytest.mark.no_gpu
+    def test_start_raises_import_error_when_vllm_missing(
+        self, engine, vllm_spec: ModelSpec
+    ) -> None:
+        """When vllm package is unavailable, start() must raise ImportError with install hint."""
+        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "vllm":
+                raise ImportError("No module named 'vllm'")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_fake_import):
+            with pytest.raises(ImportError, match="uv pip install vllm"):
+                engine.start(vllm_spec)
+
+
+# ---------------------------------------------------------------------------
+# 7. Daemon dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonDispatchVLLM:
+    """Daemon._engine_for_spec must route engine="vllm" to VLLMEngine."""
+
+    @pytest.mark.no_gpu
+    def test_engine_vllm_returns_vllm_engine(self, vllm_spec: ModelSpec) -> None:
+        from llmcli.daemon import Daemon
+        from llmcli.engines.vllm import VLLMEngine
+
+        # Arrange
+        daemon = Daemon()
+
+        # Act
+        result = daemon._engine_for_spec(vllm_spec)
+
+        # Assert
+        assert isinstance(result, VLLMEngine), (
+            f"engine='vllm' must dispatch to VLLMEngine, got {type(result)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_engine_llamacpp_returns_llamacpp_engine(self) -> None:
+        from llmcli.daemon import Daemon
+        from llmcli.engines.llamacpp import LlamaCppEngine
+
+        spec = ModelSpec(
+            name="qwen3-8b-q4",
+            engine="llamacpp",
+            repo="bartowski/Qwen3-8B-GGUF",
+            file="Qwen3-8B-Q4_K_M.gguf",
+            port=8091,
+            vram_gib=5.5,
+        )
+        daemon = Daemon()
+        result = daemon._engine_for_spec(spec)
+
+        assert isinstance(result, LlamaCppEngine), (
+            f"engine='llamacpp' must dispatch to LlamaCppEngine, got {type(result)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_engine_llamacpp_tq3_returns_tq3_engine(self) -> None:
+        from llmcli.daemon import Daemon
+        from llmcli.engines.llamacpp_tq3 import LlamaCppTQ3Engine
+
+        spec = ModelSpec(
+            name="qwen3-8b-tq3",
+            engine="llamacpp_tq3",
+            repo="bartowski/Qwen3-8B-GGUF",
+            file="Qwen3-8B-TQ3_K_M.gguf",
+            port=8092,
+            vram_gib=5.0,
+        )
+        daemon = Daemon()
+        result = daemon._engine_for_spec(spec)
+
+        assert isinstance(result, LlamaCppTQ3Engine), (
+            f"engine='llamacpp_tq3' must dispatch to LlamaCppTQ3Engine, got {type(result)}"
+        )

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -489,7 +489,7 @@ class TestVLLMImportGuard:
             return original_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=_fake_import):
-            with pytest.raises(ImportError, match="uv pip install vllm"):
+            with pytest.raises(ImportError, match="uv sync --group vllm"):
                 engine.start(vllm_spec)
 
 


### PR DESCRIPTION
## Summary
- Add `VLLMEngine` conforming to the `Engine` protocol: launches `vllm serve` as a subprocess, polls `/health` until 2xx (or 180s timeout), reaps the full process group via `os.killpg` on stop
- Make `ModelSpec.file` optional (default `""`) so vLLM catalog entries require no `file` key
- Replace name-heuristic dispatch in `daemon._engine_for_spec` with `spec.engine` field check
- Export `VLLMEngine` from `engines/__init__.py`; add import guard (deferred `import vllm` inside `start()` so llmcli is importable without vllm installed)

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #13: implement vLLM engine backend | Open |
| Analysis | — | Absent |
| Spec | [13-vllm-engine-backend-spec.mdx](artifacts/specs/13-vllm-engine-backend-spec.mdx) | Present |
| Implementation | 9 commits on `feat/13-vllm-engine-backend` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (32 new in test_vllm.py + 1 in test_config.py) | Passed |

## Test Plan
- [ ] `uv run pytest tests/test_vllm.py tests/test_config.py -v` — 33 tests pass
- [ ] `uv run ruff check .` — exits 0
- [ ] `from llmcli.engines.vllm import VLLMEngine` succeeds without vllm installed
- [ ] TOML entry with `engine = "vllm"` and no `file` key parses to `ModelSpec(file="")` without TypeError
- [ ] `llmcli serve qwen3-27b-nvfp4` (after adding entry to local catalog + `uv pip install vllm`) launches `vllm serve` and returns healthy

Closes #13

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`