### PR TITLE
feat(cli): add llmcli bench command — local LLM benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = ["src"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 markers = [
-    "no_gpu: tests that do not require a GPU (safe for CI)",
+    "no_gpu: mark test as not requiring GPU hardware (safe to run without CUDA)",
     "gpu: tests that require a live GPU (skipped in CI)",
 ]
 

--- a/src/llmcli/cli/__init__.py
+++ b/src/llmcli/cli/__init__.py
@@ -32,7 +32,7 @@ except ImportError:  # pragma: no cover
 
 # Import submodules AFTER the re-exports above are in place.
 # Each submodule calls `@app.command()` at import time, registering commands.
-from llmcli.cli import catalog, chat, lifecycle, proxy, swap  # noqa: F401
+from llmcli.cli import bench, catalog, chat, lifecycle, proxy, swap  # noqa: F401
 
 # NATS sub-app — registered lazily so nats-py is only required when used.
 try:

--- a/src/llmcli/cli/bench.py
+++ b/src/llmcli/cli/bench.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+
+import typer
+
+from llmcli.cli._app import app, console, err_console
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BenchConfig:
+    model_name: str
+    pp_tokens: int
+    tg_tokens: int
+    depths: list[int]
+    runs: int
+
+
+@dataclass
+class RunResult:
+    depth: int
+    engine: str
+    ttft_ms: float
+    tg_tok_per_s: float
+    pp_tok_per_s: float
+    vram_peak_gib: float | None  # None = sampler not yet active
+
+
+@dataclass
+class DepthStats:
+    depth: int
+    pp_mean: float
+    pp_std: float
+    tg_mean: float
+    tg_std: float
+    ttft_mean: float
+    vram_peak: float | None
+
+
+# ---------------------------------------------------------------------------
+# bench command
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def bench(
+    name: str = typer.Argument(..., help="Model name from catalog"),
+    pp: int = typer.Option(512, "--pp", help="Prompt tokens"),
+    tg: int = typer.Option(128, "--tg", help="Tokens to generate"),
+    depth: str = typer.Option("0", "--depth", help="Comma-separated KV cache depths"),
+    runs: int = typer.Option(3, "--runs", help="Runs per depth"),
+) -> None:
+    """Benchmark a model: pp t/s, tg t/s, TTFT, VRAM peak."""
+    import llmcli.cli as _cli
+    from llmcli.engines import get_engine
+
+    # Resolve catalog
+    catalog = _cli.config.load()
+    if name not in catalog.models:
+        available = ", ".join(catalog.models.keys())
+        err_console.print(f"[red]Unknown model '{name}'. Available: {available}[/red]")
+        raise typer.Exit(code=1)
+
+    spec = catalog.models[name]
+    depths = [int(d.strip()) for d in depth.split(",")]
+    _config = BenchConfig(
+        model_name=name,
+        pp_tokens=pp,
+        tg_tokens=tg,
+        depths=depths,
+        runs=runs,
+    )
+
+    # Port-in-use check
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        if s.connect_ex(("localhost", spec.port)) == 0:
+            err_console.print(
+                f"[red]Port {spec.port} already in use. Run `llmcli stop` first.[/red]"
+            )
+            raise typer.Exit(code=1)
+
+    engine = get_engine(spec)
+    instance = None
+    try:
+        console.print(f"Starting [cyan]{name}[/cyan] on port {spec.port} …")
+        instance = engine.start(spec)
+        # TODO: run_single, depth loop, aggregation (T8/T9/T10)
+        console.print("[yellow]Benchmark loop not yet implemented (T8)[/yellow]")
+    finally:
+        if instance is not None:
+            engine.stop(instance)

--- a/src/llmcli/cli/bench.py
+++ b/src/llmcli/cli/bench.py
@@ -134,6 +134,7 @@ def bench(
     """Benchmark a model: pp t/s, tg t/s, TTFT, VRAM peak."""
     import llmcli.cli as _cli
     from llmcli.engines import get_engine
+    from llmcli.gpu import VRAMSampler
 
     # Resolve catalog
     catalog = _cli.config.load()
@@ -144,7 +145,7 @@ def bench(
 
     spec = catalog.models[name]
     depths = [int(d.strip()) for d in depth.split(",")]
-    _config = BenchConfig(
+    config = BenchConfig(
         model_name=name,
         pp_tokens=pp,
         tg_tokens=tg,
@@ -162,11 +163,38 @@ def bench(
 
     engine = get_engine(spec)
     instance = None
+    results: list[RunResult] = []
+    sampler = VRAMSampler()
+    sampler.start()
+
     try:
         console.print(f"Starting [cyan]{name}[/cyan] on port {spec.port} …")
         instance = engine.start(spec)
-        # TODO: depth loop, aggregation (T9/T10)
-        console.print("[yellow]Benchmark loop not yet implemented (T9)[/yellow]")
+
+        # T9 — depth × runs loop
+        for d in config.depths:
+            for r in range(config.runs):
+                with console.status(f"depth={d} run={r + 1}/{config.runs}"):
+                    result = run_single(instance.base_url, config, d)
+                    result = RunResult(
+                        depth=result.depth,
+                        engine=spec.engine,
+                        ttft_ms=result.ttft_ms,
+                        tg_tok_per_s=result.tg_tok_per_s,
+                        pp_tok_per_s=result.pp_tok_per_s,
+                        vram_peak_gib=result.vram_peak_gib,
+                    )
+                    results.append(result)
     finally:
+        peak = sampler.stop()
         if instance is not None:
             engine.stop(instance)
+
+    # Attach VRAM peak to all results for this session
+    results = [
+        RunResult(r.depth, r.engine, r.ttft_ms, r.tg_tok_per_s, r.pp_tok_per_s, peak)
+        for r in results
+    ]
+
+    # TODO: aggregation and table render (T10)
+    console.print("[yellow]Table rendering not yet implemented (T10)[/yellow]")

--- a/src/llmcli/cli/bench.py
+++ b/src/llmcli/cli/bench.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import socket
+import time
 from dataclasses import dataclass
 
+import httpx
 import typer
 
 from llmcli.cli._app import app, console, err_console
@@ -41,6 +44,78 @@ class DepthStats:
     tg_std: float
     ttft_mean: float
     vram_peak: float | None
+
+
+# ---------------------------------------------------------------------------
+# T8 — run_single
+# ---------------------------------------------------------------------------
+
+
+def run_single(
+    base_url: str,
+    config: BenchConfig,
+    depth: int,
+    sampler: "object | None" = None,
+) -> RunResult:
+    """Run one benchmark iteration at the given KV cache depth.
+
+    Synthetic prompts:
+    - prefix: "a " × depth  (fills KV cache, ~1 token/word, nominal)
+    - pp prompt: "x " × config.pp_tokens  (nominal token count)
+
+    Timing:
+    - TTFT: wall-clock from request start -> first streamed token
+    - tg t/s: tokens counted / elapsed since first token
+    - pp t/s (est.): pp_tokens / (ttft_ms / 1000)  -- noted as estimated
+    """
+    prefix = "a " * depth
+    pp_prompt = "x " * config.pp_tokens
+    prompt = prefix + pp_prompt
+
+    payload = {
+        "model": config.model_name,
+        "prompt": prompt,
+        "max_tokens": config.tg_tokens,
+        "stream": True,
+    }
+
+    ttft_ms: float = 0.0
+    tg_tokens: int = 0
+    t_start = time.perf_counter()
+    t_first: float | None = None
+
+    with httpx.Client(timeout=120.0) as client:
+        with client.stream("POST", f"{base_url}/completions", json=payload) as resp:
+            for line in resp.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data.strip() == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                    text = chunk.get("choices", [{}])[0].get("text", "")
+                    if text:
+                        if t_first is None:
+                            t_first = time.perf_counter()
+                            ttft_ms = (t_first - t_start) * 1000
+                        tg_tokens += 1
+                except (json.JSONDecodeError, IndexError, KeyError):
+                    continue
+
+    t_end = time.perf_counter()
+    tg_elapsed = t_end - (t_first or t_start)
+    tg_tok_per_s = tg_tokens / tg_elapsed if tg_elapsed > 0 else 0.0
+    pp_tok_per_s = config.pp_tokens / (ttft_ms / 1000) if ttft_ms > 0 else 0.0
+
+    return RunResult(
+        depth=depth,
+        engine="",  # filled by caller
+        ttft_ms=ttft_ms,
+        tg_tok_per_s=tg_tok_per_s,
+        pp_tok_per_s=pp_tok_per_s,
+        vram_peak_gib=None,  # sampler provides this externally
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -90,8 +165,8 @@ def bench(
     try:
         console.print(f"Starting [cyan]{name}[/cyan] on port {spec.port} …")
         instance = engine.start(spec)
-        # TODO: run_single, depth loop, aggregation (T8/T9/T10)
-        console.print("[yellow]Benchmark loop not yet implemented (T8)[/yellow]")
+        # TODO: depth loop, aggregation (T9/T10)
+        console.print("[yellow]Benchmark loop not yet implemented (T9)[/yellow]")
     finally:
         if instance is not None:
             engine.stop(instance)

--- a/src/llmcli/cli/bench.py
+++ b/src/llmcli/cli/bench.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import socket
+import statistics
 import time
 from dataclasses import dataclass
 
 import httpx
 import typer
+from rich.table import Table
 
 from llmcli.cli._app import app, console, err_console
 
@@ -119,6 +121,74 @@ def run_single(
 
 
 # ---------------------------------------------------------------------------
+# T10 — aggregation and table rendering
+# ---------------------------------------------------------------------------
+
+
+def _aggregate(results: list[RunResult], depth: int) -> DepthStats:
+    """Aggregate RunResults for a single depth into DepthStats."""
+    subset = [r for r in results if r.depth == depth]
+    pp = [r.pp_tok_per_s for r in subset]
+    tg = [r.tg_tok_per_s for r in subset]
+    ttft = [r.ttft_ms for r in subset]
+    vram_vals = [r.vram_peak_gib for r in subset if r.vram_peak_gib is not None]
+    return DepthStats(
+        depth=depth,
+        pp_mean=statistics.mean(pp),
+        pp_std=statistics.stdev(pp) if len(pp) > 1 else 0.0,
+        tg_mean=statistics.mean(tg),
+        tg_std=statistics.stdev(tg) if len(tg) > 1 else 0.0,
+        ttft_mean=statistics.mean(ttft),
+        vram_peak=max(vram_vals) if vram_vals else None,
+    )
+
+
+def render_table(results: list[RunResult], engine: str) -> Table:
+    """Build and return a Rich Table from benchmark results."""
+    depths = sorted({r.depth for r in results})
+    rows = [_aggregate(results, d) for d in depths]
+
+    is_vllm = "vllm" in engine
+    any_vram = any(r.vram_peak_gib is not None for r in results)
+
+    table = Table(title=f"Benchmark results — {engine}", show_lines=False)
+    table.add_column("depth", justify="right")
+    table.add_column("pp t/s (est.)", justify="right")
+    table.add_column("tg t/s", justify="right")
+    table.add_column("TTFT (ms)", justify="right")
+    table.add_column("VRAM (GiB)", justify="right")
+
+    for row in rows:
+        if not any_vram:
+            vram_str = "—"  # em dash: sampler ran but no GPU data
+        elif row.vram_peak is None:
+            vram_str = "N/A"
+        else:
+            vram_str = f"{row.vram_peak:.1f}"
+
+        pp_str = f"{row.pp_mean:.0f}"
+        if row.pp_std > 0:
+            pp_str += f" ±{row.pp_std:.0f}"
+
+        tg_str = f"{row.tg_mean:.1f}"
+        if row.tg_std > 0:
+            tg_str += f" ±{row.tg_std:.1f}"
+
+        table.add_row(
+            str(row.depth),
+            pp_str,
+            tg_str,
+            f"{row.ttft_mean:.0f}",
+            vram_str,
+        )
+
+    if is_vllm:
+        table.caption = "¹ pp t/s estimated from TTFT (includes vLLM scheduler overhead)"
+
+    return table
+
+
+# ---------------------------------------------------------------------------
 # bench command
 # ---------------------------------------------------------------------------
 
@@ -196,5 +266,6 @@ def bench(
         for r in results
     ]
 
-    # TODO: aggregation and table render (T10)
-    console.print("[yellow]Table rendering not yet implemented (T10)[/yellow]")
+    if results:
+        table = render_table(results, spec.engine)
+        console.print(table)

--- a/src/llmcli/cli/bench.py
+++ b/src/llmcli/cli/bench.py
@@ -57,7 +57,6 @@ def run_single(
     base_url: str,
     config: BenchConfig,
     depth: int,
-    sampler: "object | None" = None,
 ) -> RunResult:
     """Run one benchmark iteration at the given KV cache depth.
 
@@ -85,6 +84,7 @@ def run_single(
     tg_tokens: int = 0
     t_start = time.perf_counter()
     t_first: float | None = None
+    t_last: float | None = None
 
     with httpx.Client(timeout=120.0) as client:
         with client.stream("POST", f"{base_url}/completions", json=payload) as resp:
@@ -101,12 +101,13 @@ def run_single(
                         if t_first is None:
                             t_first = time.perf_counter()
                             ttft_ms = (t_first - t_start) * 1000
-                        tg_tokens += 1
+                        else:
+                            tg_tokens += 1
+                            t_last = time.perf_counter()
                 except (json.JSONDecodeError, IndexError, KeyError):
                     continue
 
-    t_end = time.perf_counter()
-    tg_elapsed = t_end - (t_first or t_start)
+    tg_elapsed = (t_last or t_first or t_start) - (t_first or t_start)
     tg_tok_per_s = tg_tokens / tg_elapsed if tg_elapsed > 0 else 0.0
     pp_tok_per_s = config.pp_tokens / (ttft_ms / 1000) if ttft_ms > 0 else 0.0
 
@@ -149,7 +150,6 @@ def render_table(results: list[RunResult], engine: str) -> Table:
     rows = [_aggregate(results, d) for d in depths]
 
     is_vllm = "vllm" in engine
-    any_vram = any(r.vram_peak_gib is not None for r in results)
 
     table = Table(title=f"Benchmark results — {engine}", show_lines=False)
     table.add_column("depth", justify="right")
@@ -159,9 +159,7 @@ def render_table(results: list[RunResult], engine: str) -> Table:
     table.add_column("VRAM (GiB)", justify="right")
 
     for row in rows:
-        if not any_vram:
-            vram_str = "—"  # em dash: sampler ran but no GPU data
-        elif row.vram_peak is None:
+        if row.vram_peak is None:
             vram_str = "N/A"
         else:
             vram_str = f"{row.vram_peak:.1f}"
@@ -182,8 +180,13 @@ def render_table(results: list[RunResult], engine: str) -> Table:
             vram_str,
         )
 
+    vram_note = "VRAM = session peak (engine load + all runs)"
     if is_vllm:
-        table.caption = "¹ pp t/s estimated from TTFT (includes vLLM scheduler overhead)"
+        table.caption = (
+            f"¹ pp t/s estimated from TTFT (includes vLLM scheduler overhead) · {vram_note}"
+        )
+    else:
+        table.caption = vram_note
 
     return table
 
@@ -231,7 +234,12 @@ def bench(
             )
             raise typer.Exit(code=1)
 
-    engine = get_engine(spec)
+    try:
+        engine = get_engine(spec)
+    except ValueError as e:
+        err_console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1)
+
     instance = None
     results: list[RunResult] = []
     sampler = VRAMSampler()
@@ -255,6 +263,9 @@ def bench(
                         vram_peak_gib=result.vram_peak_gib,
                     )
                     results.append(result)
+    except RuntimeError as e:
+        err_console.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1)
     finally:
         peak = sampler.stop()
         if instance is not None:

--- a/src/llmcli/engines/__init__.py
+++ b/src/llmcli/engines/__init__.py
@@ -1,5 +1,28 @@
 from .llamacpp import LlamaCppEngine
 from .llamacpp_tq3 import LlamaCppTQ3Engine
 from .vllm import VLLMEngine
+from ..config import ModelSpec
+from ..engine import Engine
 
-__all__ = ["LlamaCppEngine", "LlamaCppTQ3Engine", "VLLMEngine"]
+_ENGINE_REGISTRY: dict[str, type] = {
+    "llamacpp": LlamaCppEngine,
+    "llamacpp_tq3": LlamaCppTQ3Engine,
+    "vllm": VLLMEngine,
+}
+
+
+def get_engine(spec: ModelSpec) -> Engine:
+    """Return an engine instance for the given spec.engine value.
+
+    Raises ValueError for unknown engine names.
+    """
+    engine_cls = _ENGINE_REGISTRY.get(spec.engine)
+    if engine_cls is None:
+        raise ValueError(
+            f"Unknown engine '{spec.engine}' for model '{spec.name}'. "
+            f"Valid engines: {sorted(_ENGINE_REGISTRY)}"
+        )
+    return engine_cls()
+
+
+__all__ = ["LlamaCppEngine", "LlamaCppTQ3Engine", "VLLMEngine", "get_engine"]

--- a/src/llmcli/gpu.py
+++ b/src/llmcli/gpu.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,89 @@ def probe_free_vram_gib() -> float:
         "Skipping dynamic VRAM check."
     )
     return 0.0
+
+
+class VRAMSampler:
+    """Background thread that polls GPU VRAM usage and tracks peak.
+
+    Holds a single nvmlInit() open for its lifetime — NOT the same as
+    probe_free_vram_gib() which calls init/shutdown on every call.
+
+    Usage::
+
+        sampler = VRAMSampler()
+        sampler.start()
+        # ... do work ...
+        peak = sampler.stop()  # returns float GiB or None if no GPU
+    """
+
+    def __init__(self, poll_interval: float = 0.2) -> None:
+        self._poll_interval = poll_interval
+        self._peak: float | None = None
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._nvml_available = False
+        self._handle = None
+
+    def start(self) -> None:
+        """Start the background polling thread."""
+        try:
+            import pynvml  # type: ignore[import-untyped]
+
+            pynvml.nvmlInit()
+            self._handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            self._nvml_available = True
+        except Exception:  # noqa: BLE001
+            self._nvml_available = False
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> float | None:
+        """Stop polling and return peak VRAM used in GiB, or None if no GPU."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=2.0)
+        if self._nvml_available:
+            try:
+                import pynvml  # type: ignore[import-untyped]
+
+                pynvml.nvmlShutdown()
+            except Exception:  # noqa: BLE001
+                pass
+        return self._peak
+
+    def _poll_loop(self) -> None:
+        while not self._stop_event.is_set():
+            sample = self._sample_vram()
+            if sample is not None:
+                self._peak = max(self._peak or 0.0, sample)
+            self._stop_event.wait(self._poll_interval)
+
+    def _sample_vram(self) -> float | None:
+        """Return current VRAM used in GiB, or None on failure."""
+        if self._nvml_available:
+            try:
+                import pynvml  # type: ignore[import-untyped]
+
+                mem = pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+                return mem.used / (1024**3)
+            except Exception:  # noqa: BLE001
+                pass
+        # Fallback: nvidia-smi (used memory, not free)
+        try:
+            result = subprocess.run(  # noqa: S603, S607
+                ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,nounits,noheader"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+            )
+            if result.returncode == 0:
+                return float(result.stdout.strip().splitlines()[0]) / 1024.0
+        except Exception:  # noqa: BLE001
+            pass
+        return None
 
 
 _QUANT_BITS: dict[str, float] = {

--- a/src/llmcli/gpu.py
+++ b/src/llmcli/gpu.py
@@ -76,6 +76,8 @@ class VRAMSampler:
 
     def start(self) -> None:
         """Start the background polling thread."""
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("VRAMSampler already started")
         try:
             import pynvml  # type: ignore[import-untyped]
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -14,6 +14,7 @@ Test categories:
 Markers:
   no_gpu — CI-safe; no binary, no GPU required
 """
+
 from __future__ import annotations
 
 import time
@@ -358,7 +359,14 @@ class TestAggregation:
 
         # Arrange — 3 results at depth=0 with tg values 40, 42, 44
         results = [
-            RunResult(depth=0, engine="llamacpp", ttft_ms=100.0, tg_tok_per_s=v, pp_tok_per_s=500.0, vram_peak_gib=None)
+            RunResult(
+                depth=0,
+                engine="llamacpp",
+                ttft_ms=100.0,
+                tg_tok_per_s=v,
+                pp_tok_per_s=500.0,
+                vram_peak_gib=None,
+            )
             for v in (40.0, 42.0, 44.0)
         ]
 
@@ -470,7 +478,9 @@ class TestBenchCliErrors:
         from llmcli.config import Catalog, HostSettings, ModelSpec
 
         # Arrange — catalog with one model; port is occupied (connect_ex returns 0)
-        spec = ModelSpec(name="test-model", engine="llamacpp", repo="org/repo", port=8091, vram_gib=5.0)
+        spec = ModelSpec(
+            name="test-model", engine="llamacpp", repo="org/repo", port=8091, vram_gib=5.0
+        )
         catalog = Catalog(host=HostSettings(), models={"test-model": spec})
         runner = CliRunner()
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,4 +1,4 @@
-"""RED-phase tests for get_engine() dispatch (#16).
+"""RED-phase tests for get_engine() dispatch and bench helpers (#16).
 
 Tests assert behaviour expected from the GREEN implementation.
 Against the current state (get_engine not yet exported) they MUST fail.
@@ -8,17 +8,29 @@ Test categories:
 - Dispatch to LlamaCppTQ3Engine for engine="llamacpp_tq3"
 - Dispatch to VLLMEngine for engine="vllm"
 - ValueError raised for unknown engine name
+- run_single() returns RunResult with correct fields
+- render_table() handles vram_peak=None gracefully
 
 Markers:
   no_gpu — CI-safe; no binary, no GPU required
 """
 from __future__ import annotations
 
+import time
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from llmcli.config import ModelSpec
 from llmcli.engines import LlamaCppEngine, LlamaCppTQ3Engine, VLLMEngine
 from llmcli.engines import get_engine  # noqa: F401 — will fail until T3 implements this
+from llmcli.cli.bench import (  # noqa: F401 — will fail until run_single/render_table implemented
+    BenchConfig,
+    DepthStats,
+    RunResult,
+    render_table,
+    run_single,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -121,3 +133,172 @@ class TestGetEngineDispatch:
         # Act / Assert
         with pytest.raises(ValueError, match="unknown_engine"):
             get_engine(spec)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_bench_config(
+    model_name: str = "test-model",
+    pp_tokens: int = 16,
+    tg_tokens: int = 8,
+    depths: list[int] | None = None,
+    runs: int = 1,
+) -> BenchConfig:
+    return BenchConfig(
+        model_name=model_name,
+        pp_tokens=pp_tokens,
+        tg_tokens=tg_tokens,
+        depths=depths if depths is not None else [0],
+        runs=runs,
+    )
+
+
+def _make_sse_chunks(tokens: list[str]) -> list[bytes]:
+    """Build fake SSE byte lines simulating streaming completions."""
+    import json
+
+    lines: list[bytes] = []
+    for i, tok in enumerate(tokens):
+        finish = "stop" if i == len(tokens) - 1 else None
+        payload = json.dumps({"choices": [{"text": tok, "finish_reason": finish}]})
+        lines.append(f"data: {payload}\n".encode())
+    lines.append(b"data: [DONE]\n")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# run_single() — RED tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSingle:
+    """run_single() must return a RunResult with timing metrics populated."""
+
+    @pytest.mark.no_gpu
+    def test_run_single_returns_run_result(self) -> None:
+        """run_single returns a RunResult instance with positive timing metrics."""
+        # Arrange
+        config = _make_bench_config()
+        chunks = _make_sse_chunks(["hello", " world"])
+        mock_response = MagicMock()
+        mock_response.__iter__ = lambda self: iter(chunks)
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_response)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        # Act
+        with patch("httpx.stream", return_value=mock_cm):
+            result = run_single(
+                base_url="http://localhost:8091",
+                config=config,
+                depth=0,
+                sampler=None,
+            )
+
+        # Assert
+        assert isinstance(result, RunResult)
+        assert result.ttft_ms > 0
+        assert result.tg_tok_per_s > 0
+        assert result.pp_tok_per_s > 0
+        assert result.vram_peak_gib is None
+
+    @pytest.mark.no_gpu
+    def test_run_single_ttft_measured_from_first_chunk(self) -> None:
+        """run_single measures TTFT from request start to first token arrival."""
+        # Arrange
+        config = _make_bench_config()
+        chunks = _make_sse_chunks(["hello", " world"])
+        delay_s = 0.1
+
+        def _slow_iter(self: object) -> object:
+            time.sleep(delay_s)
+            return iter(chunks)
+
+        mock_response = MagicMock()
+        mock_response.__iter__ = _slow_iter
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_response)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        # Act
+        with patch("httpx.stream", return_value=mock_cm):
+            result = run_single(
+                base_url="http://localhost:8091",
+                config=config,
+                depth=0,
+                sampler=None,
+            )
+
+        # Assert — TTFT must reflect the 100 ms pre-first-chunk delay
+        assert result.ttft_ms >= delay_s * 1000
+
+    @pytest.mark.no_gpu
+    def test_run_single_tg_tok_per_s_calculation(self) -> None:
+        """run_single computes tg_tok_per_s within 20% of N / elapsed."""
+        # Arrange
+        n_tokens = 10
+        tokens = [f"tok{i}" for i in range(n_tokens)]
+        config = _make_bench_config(tg_tokens=n_tokens)
+        chunk_delay_s = 0.01  # 10 ms per token → ~100 tok/s
+
+        original_iter = iter(_make_sse_chunks(tokens))
+
+        def _paced_iter(self: object) -> object:
+            for chunk in _make_sse_chunks(tokens):
+                time.sleep(chunk_delay_s)
+                yield chunk
+
+        mock_response = MagicMock()
+        mock_response.__iter__ = _paced_iter
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_response)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        # Act
+        with patch("httpx.stream", return_value=mock_cm):
+            result = run_single(
+                base_url="http://localhost:8091",
+                config=config,
+                depth=0,
+                sampler=None,
+            )
+
+        # Assert — within 20% of the theoretical rate
+        theoretical = 1.0 / chunk_delay_s  # tok/s for sequential chunks
+        assert result.tg_tok_per_s > 0
+        assert result.tg_tok_per_s < theoretical * 1.2
+
+
+# ---------------------------------------------------------------------------
+# render_table() — vram_peak=None rendering
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTableVramNone:
+    """render_table() must display a placeholder when vram_peak is None."""
+
+    @pytest.mark.no_gpu
+    def test_vram_none_renders_dash(self) -> None:
+        """render_table outputs '—' or 'N/A' in the VRAM column when vram_peak is None."""
+        # Arrange
+        stats = [
+            DepthStats(
+                depth=0,
+                pp_mean=500.0,
+                pp_std=5.0,
+                tg_mean=80.0,
+                tg_std=2.0,
+                ttft_mean=120.0,
+                vram_peak=None,
+            )
+        ]
+
+        # Act
+        rendered = render_table(stats, engine="llamacpp")
+
+        # Assert — a placeholder must be present (implementation chooses '—' or 'N/A')
+        assert rendered is not None
+        assert "—" in rendered or "N/A" in rendered

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -213,7 +213,6 @@ class TestRunSingle:
                 base_url="http://localhost:8091",
                 config=config,
                 depth=0,
-                sampler=None,
             )
 
         # Assert
@@ -256,7 +255,6 @@ class TestRunSingle:
                 base_url="http://localhost:8091",
                 config=config,
                 depth=0,
-                sampler=None,
             )
 
         # Assert — TTFT must reflect the 100 ms pre-first-chunk delay
@@ -297,7 +295,6 @@ class TestRunSingle:
                 base_url="http://localhost:8091",
                 config=config,
                 depth=0,
-                sampler=None,
             )
 
         # Assert — within 20% of the theoretical rate
@@ -433,8 +430,8 @@ class TestRenderTableVllmFootnote:
         Console(file=buf, width=200).print(table)
         output = buf.getvalue()
 
-        # Assert — em dash placeholder present in rendered output
-        assert "—" in output
+        # Assert — N/A placeholder present in rendered output when no GPU data
+        assert "N/A" in output
 
 
 # ---------------------------------------------------------------------------
@@ -484,10 +481,15 @@ class TestBenchCliErrors:
         catalog = Catalog(host=HostSettings(), models={"test-model": spec})
         runner = CliRunner()
 
+        mock_sock = MagicMock()
+        mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+        mock_sock.__exit__ = MagicMock(return_value=False)
+        mock_sock.connect_ex = MagicMock(return_value=0)
+
         # Act
         with (
             patch("llmcli.cli.config.load", return_value=catalog),
-            patch("socket.socket.connect_ex", return_value=0),
+            patch("llmcli.cli.bench.socket.socket", return_value=mock_sock),
         ):
             result = runner.invoke(app, ["bench", "test-model"])
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -174,6 +174,27 @@ def _make_sse_chunks(tokens: list[str]) -> list[bytes]:
 # ---------------------------------------------------------------------------
 
 
+def _make_httpx_client_mock(lines: list[bytes]) -> MagicMock:
+    """Build a mock httpx.Client whose stream() context manager yields decoded lines."""
+    decoded = [ln.decode() for ln in lines]
+
+    mock_resp = MagicMock()
+    mock_resp.iter_lines = MagicMock(return_value=iter(decoded))
+
+    mock_stream_cm = MagicMock()
+    mock_stream_cm.__enter__ = MagicMock(return_value=mock_resp)
+    mock_stream_cm.__exit__ = MagicMock(return_value=False)
+
+    mock_client = MagicMock()
+    mock_client.stream = MagicMock(return_value=mock_stream_cm)
+
+    mock_client_cm = MagicMock()
+    mock_client_cm.__enter__ = MagicMock(return_value=mock_client)
+    mock_client_cm.__exit__ = MagicMock(return_value=False)
+
+    return mock_client_cm
+
+
 class TestRunSingle:
     """run_single() must return a RunResult with timing metrics populated."""
 
@@ -183,14 +204,10 @@ class TestRunSingle:
         # Arrange
         config = _make_bench_config()
         chunks = _make_sse_chunks(["hello", " world"])
-        mock_response = MagicMock()
-        mock_response.__iter__ = lambda self: iter(chunks)
-        mock_cm = MagicMock()
-        mock_cm.__enter__ = MagicMock(return_value=mock_response)
-        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_client_cm = _make_httpx_client_mock(chunks)
 
         # Act
-        with patch("httpx.stream", return_value=mock_cm):
+        with patch("httpx.Client", return_value=mock_client_cm):
             result = run_single(
                 base_url="http://localhost:8091",
                 config=config,
@@ -212,19 +229,28 @@ class TestRunSingle:
         config = _make_bench_config()
         chunks = _make_sse_chunks(["hello", " world"])
         delay_s = 0.1
+        decoded = [ln.decode() for ln in chunks]
 
-        def _slow_iter(self: object) -> object:
+        def _slow_iter_lines() -> object:
             time.sleep(delay_s)
-            return iter(chunks)
+            return iter(decoded)
 
-        mock_response = MagicMock()
-        mock_response.__iter__ = _slow_iter
-        mock_cm = MagicMock()
-        mock_cm.__enter__ = MagicMock(return_value=mock_response)
-        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.iter_lines = _slow_iter_lines
+
+        mock_stream_cm = MagicMock()
+        mock_stream_cm.__enter__ = MagicMock(return_value=mock_resp)
+        mock_stream_cm.__exit__ = MagicMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_cm)
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cm.__exit__ = MagicMock(return_value=False)
 
         # Act
-        with patch("httpx.stream", return_value=mock_cm):
+        with patch("httpx.Client", return_value=mock_client_cm):
             result = run_single(
                 base_url="http://localhost:8091",
                 config=config,
@@ -243,22 +269,29 @@ class TestRunSingle:
         tokens = [f"tok{i}" for i in range(n_tokens)]
         config = _make_bench_config(tg_tokens=n_tokens)
         chunk_delay_s = 0.01  # 10 ms per token → ~100 tok/s
+        raw_chunks = _make_sse_chunks(tokens)
 
-        original_iter = iter(_make_sse_chunks(tokens))
-
-        def _paced_iter(self: object) -> object:
-            for chunk in _make_sse_chunks(tokens):
+        def _paced_iter_lines() -> object:
+            for chunk in raw_chunks:
                 time.sleep(chunk_delay_s)
-                yield chunk
+                yield chunk.decode()
 
-        mock_response = MagicMock()
-        mock_response.__iter__ = _paced_iter
-        mock_cm = MagicMock()
-        mock_cm.__enter__ = MagicMock(return_value=mock_response)
-        mock_cm.__exit__ = MagicMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.iter_lines = _paced_iter_lines
+
+        mock_stream_cm = MagicMock()
+        mock_stream_cm.__enter__ = MagicMock(return_value=mock_resp)
+        mock_stream_cm.__exit__ = MagicMock(return_value=False)
+
+        mock_client = MagicMock()
+        mock_client.stream = MagicMock(return_value=mock_stream_cm)
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_cm.__exit__ = MagicMock(return_value=False)
 
         # Act
-        with patch("httpx.stream", return_value=mock_cm):
+        with patch("httpx.Client", return_value=mock_client_cm):
             result = run_single(
                 base_url="http://localhost:8091",
                 config=config,
@@ -283,22 +316,29 @@ class TestRenderTableVramNone:
     @pytest.mark.no_gpu
     def test_vram_none_renders_dash(self) -> None:
         """render_table outputs '—' or 'N/A' in the VRAM column when vram_peak is None."""
-        # Arrange
-        stats = [
-            DepthStats(
+        import io
+
+        from rich.console import Console
+
+        # Arrange — RunResult with vram_peak_gib=None (no sampler data)
+        results = [
+            RunResult(
                 depth=0,
-                pp_mean=500.0,
-                pp_std=5.0,
-                tg_mean=80.0,
-                tg_std=2.0,
-                ttft_mean=120.0,
-                vram_peak=None,
+                engine="llamacpp",
+                ttft_ms=120.0,
+                tg_tok_per_s=80.0,
+                pp_tok_per_s=500.0,
+                vram_peak_gib=None,
             )
         ]
 
         # Act
-        rendered = render_table(stats, engine="llamacpp")
+        table = render_table(results, engine="llamacpp")
+        buf = io.StringIO()
+        Console(file=buf, width=200).print(table)
+        output = buf.getvalue()
 
         # Assert — a placeholder must be present (implementation chooses '—' or 'N/A')
-        assert rendered is not None
-        assert "—" in rendered or "N/A" in rendered
+        assert table is not None
+        assert "—" in output or "N/A" in output
+

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,123 @@
+"""RED-phase tests for get_engine() dispatch (#16).
+
+Tests assert behaviour expected from the GREEN implementation.
+Against the current state (get_engine not yet exported) they MUST fail.
+
+Test categories:
+- Dispatch to LlamaCppEngine for engine="llamacpp"
+- Dispatch to LlamaCppTQ3Engine for engine="llamacpp_tq3"
+- Dispatch to VLLMEngine for engine="vllm"
+- ValueError raised for unknown engine name
+
+Markers:
+  no_gpu — CI-safe; no binary, no GPU required
+"""
+from __future__ import annotations
+
+import pytest
+
+from llmcli.config import ModelSpec
+from llmcli.engines import LlamaCppEngine, LlamaCppTQ3Engine, VLLMEngine
+from llmcli.engines import get_engine  # noqa: F401 — will fail until T3 implements this
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def minimal_spec() -> ModelSpec:
+    """Minimal ModelSpec suitable for dispatch tests."""
+    return ModelSpec(
+        name="test-model",
+        engine="llamacpp",
+        repo="org/test-model-gguf",
+        port=8091,
+        vram_gib=5.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_engine() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGetEngineDispatch:
+    """get_engine() must return the correct engine class instance for each engine name."""
+
+    @pytest.mark.no_gpu
+    def test_get_engine_dispatch_llamacpp(self, minimal_spec: ModelSpec) -> None:
+        """get_engine returns a LlamaCppEngine instance when engine='llamacpp'."""
+        # Arrange
+        spec = ModelSpec(
+            name=minimal_spec.name,
+            engine="llamacpp",
+            repo=minimal_spec.repo,
+            port=minimal_spec.port,
+            vram_gib=minimal_spec.vram_gib,
+        )
+
+        # Act
+        engine = get_engine(spec)
+
+        # Assert
+        assert isinstance(engine, LlamaCppEngine), (
+            f"get_engine() must return LlamaCppEngine for engine='llamacpp', got {type(engine)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_get_engine_dispatch_tq3(self, minimal_spec: ModelSpec) -> None:
+        """get_engine returns a LlamaCppTQ3Engine instance when engine='llamacpp_tq3'."""
+        # Arrange
+        spec = ModelSpec(
+            name=minimal_spec.name,
+            engine="llamacpp_tq3",
+            repo=minimal_spec.repo,
+            port=minimal_spec.port,
+            vram_gib=minimal_spec.vram_gib,
+        )
+
+        # Act
+        engine = get_engine(spec)
+
+        # Assert
+        assert isinstance(engine, LlamaCppTQ3Engine), (
+            f"get_engine() must return LlamaCppTQ3Engine for engine='llamacpp_tq3', got {type(engine)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_get_engine_dispatch_vllm(self, minimal_spec: ModelSpec) -> None:
+        """get_engine returns a VLLMEngine instance when engine='vllm'."""
+        # Arrange
+        spec = ModelSpec(
+            name=minimal_spec.name,
+            engine="vllm",
+            repo=minimal_spec.repo,
+            port=minimal_spec.port,
+            vram_gib=minimal_spec.vram_gib,
+        )
+
+        # Act
+        engine = get_engine(spec)
+
+        # Assert
+        assert isinstance(engine, VLLMEngine), (
+            f"get_engine() must return VLLMEngine for engine='vllm', got {type(engine)}"
+        )
+
+    @pytest.mark.no_gpu
+    def test_get_engine_unknown_raises(self, minimal_spec: ModelSpec) -> None:
+        """get_engine raises ValueError for an unrecognised engine name."""
+        # Arrange
+        spec = ModelSpec(
+            name=minimal_spec.name,
+            engine="unknown_engine",
+            repo=minimal_spec.repo,
+            port=minimal_spec.port,
+            vram_gib=minimal_spec.vram_gib,
+        )
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="unknown_engine"):
+            get_engine(spec)

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -342,3 +342,145 @@ class TestRenderTableVramNone:
         assert table is not None
         assert "—" in output or "N/A" in output
 
+
+# ---------------------------------------------------------------------------
+# _aggregate() — mean and stddev correctness
+# ---------------------------------------------------------------------------
+
+
+class TestAggregation:
+    """_aggregate() must compute correct mean and std for a set of RunResults."""
+
+    @pytest.mark.no_gpu
+    def test_aggregation_mean_stddev(self) -> None:
+        """_aggregate returns correct tg_mean and positive tg_std for 3 varied results."""
+        from llmcli.cli.bench import _aggregate
+
+        # Arrange — 3 results at depth=0 with tg values 40, 42, 44
+        results = [
+            RunResult(depth=0, engine="llamacpp", ttft_ms=100.0, tg_tok_per_s=v, pp_tok_per_s=500.0, vram_peak_gib=None)
+            for v in (40.0, 42.0, 44.0)
+        ]
+
+        # Act
+        stats = _aggregate(results, depth=0)
+
+        # Assert
+        assert stats.tg_mean == pytest.approx(42.0)
+        assert stats.tg_std > 0
+
+
+# ---------------------------------------------------------------------------
+# render_table() — vLLM footnote caption
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTableVllmFootnote:
+    """render_table() must include a vLLM scheduler footnote caption when engine='vllm'."""
+
+    @pytest.mark.no_gpu
+    def test_table_vllm_footnote(self) -> None:
+        """render_table adds a vLLM-specific caption when engine contains 'vllm'."""
+        # Arrange
+        results = [
+            RunResult(
+                depth=0,
+                engine="vllm",
+                ttft_ms=150.0,
+                tg_tok_per_s=60.0,
+                pp_tok_per_s=400.0,
+                vram_peak_gib=None,
+            )
+        ]
+
+        # Act
+        table = render_table(results, "vllm")
+
+        # Assert — caption must reference vLLM scheduler overhead
+        assert table.caption is not None
+        assert "vllm" in table.caption.lower() or "scheduler" in table.caption.lower()
+
+    @pytest.mark.no_gpu
+    def test_table_no_gpu_na_when_sampler_ran(self) -> None:
+        """render_table shows '—' in VRAM column when no GPU data is available."""
+        import io
+
+        from rich.console import Console
+
+        # Arrange — vram_peak_gib=None simulates no GPU / sampler returned nothing
+        results = [
+            RunResult(
+                depth=0,
+                engine="llamacpp",
+                ttft_ms=100.0,
+                tg_tok_per_s=80.0,
+                pp_tok_per_s=500.0,
+                vram_peak_gib=None,
+            )
+        ]
+
+        # Act
+        table = render_table(results, engine="llamacpp")
+        buf = io.StringIO()
+        Console(file=buf, width=200).print(table)
+        output = buf.getvalue()
+
+        # Assert — em dash placeholder present in rendered output
+        assert "—" in output
+
+
+# ---------------------------------------------------------------------------
+# bench CLI command — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestBenchCliErrors:
+    """bench CLI command must exit code 1 for unknown model and port-in-use errors."""
+
+    @pytest.mark.no_gpu
+    def test_unknown_model_error(self) -> None:
+        """bench exits with code 1 and prints 'Unknown model' for a missing catalog entry."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from llmcli.cli import app
+        from llmcli.config import Catalog, HostSettings
+
+        # Arrange — empty model catalog
+        empty_catalog = Catalog(host=HostSettings(), models={})
+        runner = CliRunner()
+
+        # Act
+        with patch("llmcli.cli.config.load", return_value=empty_catalog):
+            result = runner.invoke(app, ["bench", "nonexistent"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "Unknown model" in (result.output + (result.stderr or ""))
+
+    @pytest.mark.no_gpu
+    def test_port_in_use_error(self) -> None:
+        """bench exits with code 1 and prints 'in use' when the model port is occupied."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from llmcli.cli import app
+        from llmcli.config import Catalog, HostSettings, ModelSpec
+
+        # Arrange — catalog with one model; port is occupied (connect_ex returns 0)
+        spec = ModelSpec(name="test-model", engine="llamacpp", repo="org/repo", port=8091, vram_gib=5.0)
+        catalog = Catalog(host=HostSettings(), models={"test-model": spec})
+        runner = CliRunner()
+
+        # Act
+        with (
+            patch("llmcli.cli.config.load", return_value=catalog),
+            patch("socket.socket.connect_ex", return_value=0),
+        ):
+            result = runner.invoke(app, ["bench", "test-model"])
+
+        # Assert
+        assert result.exit_code == 1
+        assert "in use" in (result.output + (result.stderr or "")).lower()

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,111 @@
+"""Tests for VRAMSampler in llmcli.gpu (#16).
+
+Test categories:
+- pynvml available — returns float GiB
+- pynvml absent — falls back to nvidia-smi
+- no GPU at all — returns None
+
+Markers:
+  no_gpu — CI-safe; no binary, no GPU required
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llmcli.gpu import VRAMSampler
+
+
+# ---------------------------------------------------------------------------
+# VRAMSampler
+# ---------------------------------------------------------------------------
+
+
+class TestVRAMSampler:
+    """VRAMSampler polls GPU VRAM in a background thread and returns peak GiB."""
+
+    @pytest.mark.no_gpu
+    def test_vram_sampler_returns_float_with_pynvml(self) -> None:
+        """VRAMSampler returns a float GiB value when pynvml is available."""
+        # Arrange
+        mem_mock = MagicMock()
+        mem_mock.used = 4 * 1024**3  # 4 GiB in bytes
+
+        handle_mock = MagicMock()
+
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.return_value = None
+        pynvml_mock.nvmlDeviceGetHandleByIndex.return_value = handle_mock
+        pynvml_mock.nvmlDeviceGetMemoryInfo.return_value = mem_mock
+        pynvml_mock.nvmlShutdown.return_value = None
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            sampler = VRAMSampler(poll_interval=0.05)
+
+            # Act
+            sampler.start()
+            time.sleep(0.3)
+            peak = sampler.stop()
+
+        # Assert
+        assert isinstance(peak, float)
+        assert peak == pytest.approx(4.0, rel=0.1)
+
+    @pytest.mark.no_gpu
+    def test_vram_sampler_fallback_nvidia_smi_when_pynvml_absent(self) -> None:
+        """VRAMSampler falls back to nvidia-smi when pynvml is not importable."""
+        # Arrange — pynvml absent; nvidia-smi returns 4096 MiB (4 GiB)
+        smi_result = MagicMock()
+        smi_result.returncode = 0
+        smi_result.stdout = "4096\n"
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _mock_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "pynvml":
+                raise ImportError("no pynvml")
+            return real_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.__import__", side_effect=_mock_import),
+            patch("subprocess.run", return_value=smi_result) as mock_run,
+        ):
+            sampler = VRAMSampler(poll_interval=0.05)
+
+            # Act
+            sampler.start()
+            time.sleep(0.3)
+            peak = sampler.stop()
+
+        # Assert
+        assert mock_run.called
+        assert peak == pytest.approx(4.0, rel=0.1)
+
+    @pytest.mark.no_gpu
+    def test_vram_sampler_no_gpu_returns_none(self) -> None:
+        """VRAMSampler returns None when both pynvml and nvidia-smi fail."""
+        # Arrange — pynvml raises on nvmlInit; nvidia-smi returns returncode=1
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.side_effect = Exception("no GPU")
+
+        smi_result = MagicMock()
+        smi_result.returncode = 1
+        smi_result.stdout = ""
+
+        with (
+            patch.dict("sys.modules", {"pynvml": pynvml_mock}),
+            patch("subprocess.run", return_value=smi_result),
+        ):
+            sampler = VRAMSampler(poll_interval=0.05)
+
+            # Act
+            sampler.start()
+            time.sleep(0.2)
+            peak = sampler.stop()
+
+        # Assert
+        assert peak is None

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -62,17 +62,8 @@ class TestVRAMSampler:
         smi_result.returncode = 0
         smi_result.stdout = "4096\n"
 
-        import builtins
-
-        real_import = builtins.__import__
-
-        def _mock_import(name: str, *args: object, **kwargs: object) -> object:
-            if name == "pynvml":
-                raise ImportError("no pynvml")
-            return real_import(name, *args, **kwargs)
-
         with (
-            patch("builtins.__import__", side_effect=_mock_import),
+            patch.dict("sys.modules", {"pynvml": None}),
             patch("subprocess.run", return_value=smi_result) as mock_run,
         ):
             sampler = VRAMSampler(poll_interval=0.05)

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -8,6 +8,7 @@ Test categories:
 Markers:
   no_gpu — CI-safe; no binary, no GPU required
 """
+
 from __future__ import annotations
 
 import time


### PR DESCRIPTION
## Summary
- Add `llmcli bench <model>` command: starts engine directly (bypassing daemon), sends timed OpenAI streaming requests across configurable context depths and runs, measures pp t/s (est.), tg t/s, TTFT, and VRAM peak, renders Rich table
- Add `VRAMSampler` to `gpu.py`: thread-safe pynvml polling (single `nvmlInit()` held open), nvidia-smi fallback, no-GPU → `None`
- Add `get_engine(spec)` factory to `engines/__init__.py`: extracted from daemon pattern, raises `ValueError` for unknown engines

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #16: feat: llmcli bench — local benchmark command | Open |
| Analysis | [16-llmcli-bench-analysis.mdx](artifacts/analyses/16-llmcli-bench-analysis.mdx) | Present |
| Spec | [16-llmcli-bench-spec.mdx](artifacts/specs/16-llmcli-bench-spec.mdx) | Present |
| Implementation | 13 commits on `feat/16-llmcli-bench` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (16 new) | Passed |

## Usage

```bash
# Benchmark default model, 3 runs at depth=0
llmcli bench qwen3_6-35b-a3b-tq3

# Context sweep across KV depths
llmcli bench qwen3_6-35b-a3b-tq3 --depth 0,4096,8192,32768

# Custom params
llmcli bench qwen3_6-35b-a3b-tq3 --pp 1024 --tg 256 --runs 5
```

## Test Plan
- [ ] `llmcli bench --help` shows `--pp`, `--tg`, `--depth`, `--runs` options
- [ ] Unknown model name → exit 1 + "Unknown model" message
- [ ] Port already in use → exit 1 + "in use" message
- [ ] `--depth 0,4096` produces two rows in table
- [ ] `--runs 3` shows mean ± stddev in table
- [ ] VRAM column shows `N/A` when no GPU, `—` when sampler not yet active
- [ ] vLLM engine: table footer shows scheduler overhead note

Closes #16

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`