### PR TITLE
feat(nats): rectify NATS adapter — LiteLLM downstream + canonical contract

### DIFF
--- a/Dockerfile.llm
+++ b/Dockerfile.llm
@@ -41,12 +41,12 @@ RUN UV_SKIP="--no-install-package torch \
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-install-project \
         $(cat /uv-skip-flags) \
-        --group nats
+        --extra nats
 
 COPY src/ ./src/
 RUN uv sync --frozen --no-dev \
         $(cat /uv-skip-flags) \
-        --group nats
+        --extra nats
 
 COPY deploy/entrypoint-nats.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/deploy/entrypoint-nats.sh
+++ b/deploy/entrypoint-nats.sh
@@ -5,7 +5,7 @@ MODE="${1:-llm}"
 
 case "$MODE" in
     llm)
-        exec llmcli nats-serve llm
+        exec llmcli nats-serve llm "$@"
         ;;
     *)
         echo "Unknown mode: $MODE" >&2

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -1,0 +1,33 @@
+[Unit]
+Description=llmCLI NATS worker (canonical lyra.llm.generate.request)
+Wants=lyra-nats.service
+After=lyra-nats.service
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
+ContainerName=llmcli-nats-worker
+Network=roxabi.network
+Volume=llmcli-models:/home/llmcli/.cache/huggingface
+Secret=llmcli-nats-nkey,type=mount,target=/home/llmcli/.config/llmcli/nkeys/seed.seed,mode=0400,uid=1502,gid=1502
+Secret=llmcli-litellm-key,type=env,name=LLMCLI_LITELLM_API_KEY
+AddDevice=nvidia.com/gpu=all
+UserNS=keep-id:uid=1502,gid=1502
+Environment=LLMCLI_NATS_URL=nats://lyra-nats:4222
+Environment=LLMCLI_NATS_NKEY_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
+Environment=LLMCLI_LITELLM_URL=http://litellm:4000/v1
+Exec=llmcli nats-serve llm --model qwen3-8b
+HealthCmd=pgrep -f "llmcli nats-serve"
+HealthInterval=30s
+NoNewPrivileges=true
+DropCapability=all
+
+[Service]
+Restart=on-failure
+RestartSec=10
+RestartForceExitStatus=3 78
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -17,7 +17,8 @@ AddDevice=nvidia.com/gpu=all
 UserNS=keep-id:uid=1502,gid=1502
 Environment=LLMCLI_NATS_URL=nats://lyra-nats:4222
 Environment=LLMCLI_NATS_NKEY_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
-Environment=LLMCLI_LITELLM_URL=http://litellm:4000/v1
+Environment=NATS_NKEY_SEED_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
+Environment=LLMCLI_LITELLM_URL=http://host.containers.internal:4000/v1
 Exec=llmcli nats-serve llm --model qwen3-8b
 HealthCmd=pgrep -f "llmcli nats-serve"
 HealthInterval=30s
@@ -27,7 +28,6 @@ DropCapability=all
 [Service]
 Restart=on-failure
 RestartSec=10
-RestartForceExitStatus=3 78
 
 [Install]
 WantedBy=default.target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,9 @@ nats = [
     "nats-py>=2.6,<3",
     "nkeys>=0.1",
     "roxabi-nats",
+    "roxabi-contracts",
 ]
 
 [tool.uv.sources]
-roxabi-nats = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats", tag = "roxabi-nats/v0.2.1" }
+roxabi-nats      = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats",      branch = "staging" }
+roxabi-contracts = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }

--- a/src/llmcli/cli_nats.py
+++ b/src/llmcli/cli_nats.py
@@ -56,6 +56,7 @@ def nats_serve_llm(
         log.error("LLMCLI_NATS_URL (or legacy NATS_URL) env var is required")
         raise typer.Exit(2)
 
+    litellm_key = litellm_key.strip()
     if not litellm_key:
         log.error("LLMCLI_LITELLM_API_KEY env var (or --litellm-key) is required")
         raise typer.Exit(2)

--- a/src/llmcli/cli_nats.py
+++ b/src/llmcli/cli_nats.py
@@ -28,6 +28,13 @@ def nats_serve_llm(
         Optional[str],
         typer.Option("--socket-path", envvar="LLMCLI_SOCKET", help="Override daemon socket path."),
     ] = None,
+    litellm_url: Annotated[
+        str, typer.Option("--litellm-url", envvar="LLMCLI_LITELLM_URL", help="LiteLLM proxy base URL.")
+    ] = "http://localhost:4000/v1",
+    litellm_key: Annotated[
+        str,
+        typer.Option("--litellm-key", envvar="LLMCLI_LITELLM_API_KEY", help="LiteLLM API key (master or virtual)."),
+    ] = "",
 ) -> None:
     """Subscribe to lyra.llm.generate.request and serve LLM completions.
 
@@ -44,17 +51,28 @@ def nats_serve_llm(
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("llmcli.nats-serve")
 
-    nats_url = os.environ.get("NATS_URL")
+    nats_url = os.environ.get("LLMCLI_NATS_URL") or os.environ.get("NATS_URL")
     if not nats_url:
-        log.error("NATS_URL env var is required")
+        log.error("LLMCLI_NATS_URL (or legacy NATS_URL) env var is required")
+        raise typer.Exit(2)
+
+    if not litellm_key:
+        log.error("LLMCLI_LITELLM_API_KEY env var (or --litellm-key) is required")
         raise typer.Exit(2)
 
     sock = Path(socket_path) if socket_path else None
 
-    log.info("Starting LLM NATS adapter: model=%s max_concurrent=%d", model, max_concurrent)
+    log.info(
+        "Starting LLM NATS adapter: model=%s max_concurrent=%d litellm_url=%s",
+        model,
+        max_concurrent,
+        litellm_url,
+    )
 
     adapter = LlmNatsAdapter(
         model_name=model,
+        litellm_url=litellm_url,
+        litellm_key=litellm_key,
         socket_path=sock,
         max_concurrent=max_concurrent,
         reject_when_full=reject_when_full,

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -16,14 +16,18 @@ import logging
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
 from roxabi_nats.adapter_base import NatsAdapterBase
 
 from llmcli.daemon import SOCKET_PATH, daemon_request
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.errors import WorkerError
 from roxabi_contracts.llm import SUBJECTS
 from roxabi_contracts.llm.builders import build_llm_chunk, build_llm_response
+from roxabi_contracts.llm.models import LlmChunkEvent, LlmResponse
 
 log = logging.getLogger(__name__)
 
@@ -124,22 +128,44 @@ class LlmNatsAdapter(NatsAdapterBase):
     async def handle(self, msg, payload: dict) -> None:
         request_id = str(payload.get("request_id", ""))
         if not _REQUEST_ID_RE.match(request_id):
-            await self._err(msg, payload, "malformed_request: invalid request_id")
+            await self._err(
+                msg,
+                payload,
+                self._make_worker_error("transport.parse", "invalid request_id", retryable=False),
+            )
             return
 
         if self._reject_when_full and self._sem.locked():
-            await self._err(msg, payload, "capacity_exceeded")
+            await self._err(
+                msg,
+                payload,
+                self._make_worker_error("worker.busy", "capacity_exceeded", retryable=True),
+            )
             return
 
         async with self._sem:
             await self._run_generation(msg, payload, request_id)
 
-    async def _err(self, msg, payload: dict, error: str) -> None:
+    @staticmethod
+    def _make_worker_error(code: str, msg: str, retryable: bool) -> WorkerError:
+        return WorkerError(code=code, message=msg, retryable=retryable)
+
+    async def _err(self, msg, payload: dict, worker_error: WorkerError) -> None:
         safe_payload = {
             "request_id": str(payload.get("request_id", "unknown"))[:128],
             "trace_id": payload.get("trace_id"),
         }
-        await self.reply(msg, build_llm_response(safe_payload, ok=False, error=error).encode())
+        # builders.py does not accept worker_error= — build envelope manually.
+        data = LlmResponse(
+            contract_version=CONTRACT_VERSION,
+            trace_id=safe_payload.get("trace_id") or safe_payload["request_id"],
+            issued_at=datetime.now(timezone.utc),
+            request_id=safe_payload["request_id"],
+            ok=False,
+            error=worker_error.message,
+            worker_error=worker_error,
+        ).model_dump_json(exclude_none=True).encode()
+        await self.reply(msg, data)
 
     async def _run_generation(self, msg, payload: dict, request_id: str) -> None:
         messages: list[dict] = payload.get("messages") or []
@@ -164,21 +190,56 @@ class LlmNatsAdapter(NatsAdapterBase):
                 await self._stream_response(msg, payload, body, t0)
             else:
                 await self._blocking_response(msg, payload, body, t0)
+            return
+        except httpx.TimeoutException as exc:
+            we = self._make_worker_error(
+                "worker.timeout", str(exc) or "upstream timeout", retryable=True
+            )
+        except httpx.HTTPStatusError as exc:
+            code = "upstream.5xx" if exc.response.status_code >= 500 else "upstream.unavailable"
+            we = self._make_worker_error(
+                code, f"upstream {exc.response.status_code}", retryable=True
+            )
+        except httpx.ConnectError as exc:
+            we = self._make_worker_error(
+                "upstream.unavailable", str(exc) or "upstream unavailable", retryable=True
+            )
+        except json.JSONDecodeError as exc:
+            we = self._make_worker_error(
+                "transport.parse", str(exc) or "invalid SSE chunk", retryable=False
+            )
         except Exception as exc:  # noqa: BLE001
-            log.error("llm_adapter: generation error request_id=%s: %s", request_id, exc)
-            if stream and msg.reply:
-                try:
-                    await self._nc.publish(
-                        msg.reply,
-                        build_llm_chunk(payload, done=True, is_error=True, error="generation_failed").encode(),
-                    )
-                except Exception:  # noqa: BLE001
-                    pass
-            else:
-                try:
-                    await self._err(msg, payload, "generation_failed")
-                except Exception:  # noqa: BLE001
-                    pass
+            we = self._make_worker_error(
+                "worker.internal", str(exc) or "internal error", retryable=False
+            )
+
+        log.error(
+            "llm_adapter: generation error request_id=%s code=%s: %s",
+            request_id,
+            we.code,
+            we.message,
+        )
+        if stream and msg.reply and self._nc:
+            try:
+                # builders.py does not accept worker_error= — build envelope manually.
+                data = LlmChunkEvent(
+                    contract_version=CONTRACT_VERSION,
+                    trace_id=payload.get("trace_id") or request_id,
+                    issued_at=datetime.now(timezone.utc),
+                    request_id=request_id,
+                    done=True,
+                    is_error=True,
+                    error=we.message,
+                    worker_error=we,
+                ).model_dump_json(exclude_none=True).encode()
+                await self._nc.publish(msg.reply, data)
+            except Exception:  # noqa: BLE001
+                pass
+        else:
+            try:
+                await self._err(msg, payload, we)
+            except Exception:  # noqa: BLE001
+                pass
 
     async def _stream_response(
         self, msg, payload: dict, body: dict, t0: float

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -110,6 +110,21 @@ class LlmNatsAdapter(NatsAdapterBase):
         payload = super().heartbeat_payload()
         payload["model_loaded"] = self._loaded_model
         payload["active_requests"] = self._active_requests()
+
+        from llmcli.gpu import probe_free_vram_gib
+
+        free_gib = probe_free_vram_gib()
+        payload["vram_free_mb"] = int(free_gib * 1024)
+        try:
+            import pynvml  # type: ignore[import-untyped]
+
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            total_mb = pynvml.nvmlDeviceGetMemoryInfo(handle).total // (1024 * 1024)
+            pynvml.nvmlShutdown()
+            payload["vram_used_mb"] = max(0, int(total_mb) - payload["vram_free_mb"])
+        except Exception:  # noqa: BLE001
+            payload["vram_used_mb"] = 0
         return payload
 
     def _active_requests(self) -> int:
@@ -139,7 +154,7 @@ class LlmNatsAdapter(NatsAdapterBase):
             await self._err(
                 msg,
                 payload,
-                self._make_worker_error("worker.busy", "capacity_exceeded", retryable=True),
+                self._make_worker_error("worker.internal", "capacity_exceeded", retryable=True),
             )
             return
 

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -43,6 +43,8 @@ class LlmNatsAdapter(NatsAdapterBase):
         self,
         *,
         model_name: str,
+        litellm_url: str,
+        litellm_key: str,
         socket_path: Path | None = None,
         max_concurrent: int = 4,
         reject_when_full: bool = False,
@@ -67,6 +69,11 @@ class LlmNatsAdapter(NatsAdapterBase):
         self._executor = ThreadPoolExecutor(max_workers=1)
         self._port: int | None = None
         self._loaded_model: str | None = None
+        self._client = httpx.AsyncClient(
+            base_url=litellm_url,
+            headers={"Authorization": f"Bearer {litellm_key}"},
+            timeout=httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0),
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle — SWAP before subscribing
@@ -103,6 +110,12 @@ class LlmNatsAdapter(NatsAdapterBase):
 
     def _active_requests(self) -> int:
         return self._max_concurrent - self._sem._value  # type: ignore[attr-defined]
+
+    async def _shutdown(self) -> None:
+        try:
+            await self._client.aclose()
+        finally:
+            await super()._shutdown()
 
     # ------------------------------------------------------------------
     # Request handling

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -142,10 +142,6 @@ class LlmNatsAdapter(NatsAdapterBase):
         await self.reply(msg, build_llm_response(safe_payload, ok=False, error=error).encode())
 
     async def _run_generation(self, msg, payload: dict, request_id: str) -> None:
-        if self._port is None:
-            await self._err(msg, payload, "model_unavailable")
-            return
-
         messages: list[dict] = payload.get("messages") or []
         system_prompt: str | None = payload.get("system_prompt")
         stream: bool = bool(payload.get("stream", True))
@@ -162,13 +158,12 @@ class LlmNatsAdapter(NatsAdapterBase):
             body["temperature"] = temperature
 
         t0 = time.monotonic()
-        base_url = f"http://localhost:{self._port}/v1"
 
         try:
             if stream:
-                await self._stream_response(msg, payload, body, base_url, t0)
+                await self._stream_response(msg, payload, body, t0)
             else:
-                await self._blocking_response(msg, payload, body, base_url, t0)
+                await self._blocking_response(msg, payload, body, t0)
         except Exception as exc:  # noqa: BLE001
             log.error("llm_adapter: generation error request_id=%s: %s", request_id, exc)
             if stream and msg.reply:
@@ -186,36 +181,33 @@ class LlmNatsAdapter(NatsAdapterBase):
                     pass
 
     async def _stream_response(
-        self, msg, payload: dict, body: dict, base_url: str, t0: float
+        self, msg, payload: dict, body: dict, t0: float
     ) -> None:
         body = {**body, "stream": True}
         nc = self._nc
 
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
-        ) as client:
-            async with client.stream("POST", f"{base_url}/chat/completions", json=body) as resp:
-                resp.raise_for_status()
-                async for line in resp.aiter_lines():
-                    if not line.startswith("data: "):
-                        continue
-                    data = line[6:]
-                    if data == "[DONE]":
-                        break
-                    try:
-                        chunk_data = json.loads(data)
-                    except json.JSONDecodeError:
-                        continue
-                    delta = (
-                        chunk_data.get("choices", [{}])[0]
-                        .get("delta", {})
-                        .get("content")
+        async with self._client.stream("POST", "/chat/completions", json=body) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk_data = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                delta = (
+                    chunk_data.get("choices", [{}])[0]
+                    .get("delta", {})
+                    .get("content")
+                )
+                if delta and msg.reply:
+                    await nc.publish(
+                        msg.reply,
+                        build_llm_chunk(payload, delta=delta).encode(),
                     )
-                    if delta and msg.reply:
-                        await nc.publish(
-                            msg.reply,
-                            build_llm_chunk(payload, delta=delta).encode(),
-                        )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         if msg.reply:
@@ -225,14 +217,13 @@ class LlmNatsAdapter(NatsAdapterBase):
             )
 
     async def _blocking_response(
-        self, msg, payload: dict, body: dict, base_url: str, t0: float
+        self, msg, payload: dict, body: dict, t0: float
     ) -> None:
         body = {**body, "stream": False}
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            resp = await client.post(f"{base_url}/chat/completions", json=body)
-            resp.raise_for_status()
-            data = resp.json()
-            text: str = data["choices"][0]["message"]["content"]
+        resp = await self._client.post("/chat/completions", json=body)
+        resp.raise_for_status()
+        data = resp.json()
+        text: str = data["choices"][0]["message"]["content"]
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         await self.reply(

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -2,7 +2,8 @@
 
 Subscribes to the NATS queue group ``llm-workers``, receives LlmRequest
 messages, routes them through the local llmCLI daemon (SWAP + STATUS),
-then forwards to the running engine's OpenAI-compatible HTTP API.
+then forwards to the LiteLLM proxy (``LLMCLI_LITELLM_URL``) with Bearer
+auth, which owns catalog/aliasing/fallback.
 
 Streaming requests publish LlmChunkEvent messages to the reply inbox.
 Non-streaming requests publish a single LlmResponse.
@@ -32,7 +33,6 @@ from roxabi_contracts.llm.models import LlmChunkEvent, LlmResponse
 log = logging.getLogger(__name__)
 
 _REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
-_STATUS_PORT_RE = re.compile(r"port=(\d+)")
 _STATUS_MODEL_RE = re.compile(r"model=(\S+)")
 
 
@@ -71,8 +71,9 @@ class LlmNatsAdapter(NatsAdapterBase):
         self._sem = asyncio.Semaphore(max_concurrent)
         self._reject_when_full = reject_when_full
         self._executor = ThreadPoolExecutor(max_workers=1)
-        self._port: int | None = None
         self._loaded_model: str | None = None
+        self._nvml_handle: object | None = None
+        self._nvml_init_failed = False
         self._client = httpx.AsyncClient(
             base_url=litellm_url,
             headers={"Authorization": f"Bearer {litellm_key}"},
@@ -84,7 +85,7 @@ class LlmNatsAdapter(NatsAdapterBase):
     # ------------------------------------------------------------------
 
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             self._executor, self._ensure_model
         )
         await super().run(nats_url, stop)
@@ -95,16 +96,31 @@ class LlmNatsAdapter(NatsAdapterBase):
         if not reply.startswith("OK"):
             raise RuntimeError(f"llmCLI daemon SWAP failed: {reply}")
         status = daemon_request("STATUS", socket_path=self._socket_path)
-        self._port = self._parse_port(status)
         self._loaded_model = self._parse_model(status)
-        log.info("llm_adapter: model=%s port=%d ready", self._loaded_model, self._port)
+        log.info("llm_adapter: model=%s ready", self._loaded_model)
 
     # ------------------------------------------------------------------
     # NatsAdapterBase overrides
     # ------------------------------------------------------------------
 
     def _extra_subjects(self) -> list[str]:
-        return [f"{self.subject}.{self._worker_id}"]
+        return []
+
+    def _get_nvml_handle(self) -> object | None:
+        """Lazy-init nvml device handle; cached for heartbeat reuse."""
+        if self._nvml_init_failed:
+            return None
+        if self._nvml_handle is not None:
+            return self._nvml_handle
+        try:
+            import pynvml  # type: ignore[import-untyped]
+
+            pynvml.nvmlInit()
+            self._nvml_handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            return self._nvml_handle
+        except Exception:  # noqa: BLE001
+            self._nvml_init_failed = True
+            return None
 
     def heartbeat_payload(self) -> dict:
         payload = super().heartbeat_payload()
@@ -115,15 +131,16 @@ class LlmNatsAdapter(NatsAdapterBase):
 
         free_gib = probe_free_vram_gib()
         payload["vram_free_mb"] = int(free_gib * 1024)
-        try:
-            import pynvml  # type: ignore[import-untyped]
+        handle = self._get_nvml_handle()
+        if handle is not None:
+            try:
+                import pynvml  # type: ignore[import-untyped]
 
-            pynvml.nvmlInit()
-            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
-            total_mb = pynvml.nvmlDeviceGetMemoryInfo(handle).total // (1024 * 1024)
-            pynvml.nvmlShutdown()
-            payload["vram_used_mb"] = max(0, int(total_mb) - payload["vram_free_mb"])
-        except Exception:  # noqa: BLE001
+                total_mb = pynvml.nvmlDeviceGetMemoryInfo(handle).total // (1024 * 1024)
+                payload["vram_used_mb"] = max(0, int(total_mb) - payload["vram_free_mb"])
+            except Exception:  # noqa: BLE001
+                payload["vram_used_mb"] = 0
+        else:
             payload["vram_used_mb"] = 0
         return payload
 
@@ -132,6 +149,14 @@ class LlmNatsAdapter(NatsAdapterBase):
 
     async def _shutdown(self) -> None:
         try:
+            if self._nvml_handle is not None:
+                try:
+                    import pynvml  # type: ignore[import-untyped]
+
+                    pynvml.nvmlShutdown()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._nvml_handle = None
             await self._client.aclose()
         finally:
             await super()._shutdown()
@@ -211,10 +236,14 @@ class LlmNatsAdapter(NatsAdapterBase):
                 "worker.timeout", str(exc) or "upstream timeout", retryable=True
             )
         except httpx.HTTPStatusError as exc:
-            code = "upstream.5xx" if exc.response.status_code >= 500 else "upstream.unavailable"
-            we = self._make_worker_error(
-                code, f"upstream {exc.response.status_code}", retryable=True
-            )
+            status = exc.response.status_code
+            if status >= 500:
+                code, retry = "upstream.5xx", True
+            elif status == 429:
+                code, retry = "upstream.unavailable", True  # rate limited — retryable
+            else:
+                code, retry = "upstream.unavailable", False  # 4xx client error — non-retryable
+            we = self._make_worker_error(code, f"upstream {status}", retryable=retry)
         except httpx.ConnectError as exc:
             we = self._make_worker_error(
                 "upstream.unavailable", str(exc) or "upstream unavailable", retryable=True
@@ -262,6 +291,8 @@ class LlmNatsAdapter(NatsAdapterBase):
         body = {**body, "stream": True}
         nc = self._nc
 
+        chunk_count = 0
+        saw_done = False
         async with self._client.stream("POST", "/chat/completions", json=body) as resp:
             resp.raise_for_status()
             async for line in resp.aiter_lines():
@@ -269,6 +300,7 @@ class LlmNatsAdapter(NatsAdapterBase):
                     continue
                 data = line[6:]
                 if data == "[DONE]":
+                    saw_done = True
                     break
                 try:
                     chunk_data = json.loads(data)
@@ -284,6 +316,10 @@ class LlmNatsAdapter(NatsAdapterBase):
                         msg.reply,
                         build_llm_chunk(payload, delta=delta).encode(),
                     )
+                    chunk_count += 1
+
+        if chunk_count == 0 and not saw_done:
+            raise json.JSONDecodeError("no parseable SSE chunks", "", 0)
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         if msg.reply:
@@ -312,13 +348,9 @@ class LlmNatsAdapter(NatsAdapterBase):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_port(status: str) -> int:
-        m = _STATUS_PORT_RE.search(status)
-        if not m or m.group(1) == "none":
-            raise RuntimeError(f"llmCLI STATUS did not return a port: {status!r}")
-        return int(m.group(1))
-
-    @staticmethod
-    def _parse_model(status: str) -> str:
+    def _parse_model(status: str) -> str | None:
         m = _STATUS_MODEL_RE.search(status)
-        return m.group(1) if m else "unknown"
+        if not m:
+            return None
+        val = m.group(1)
+        return None if val == "none" else val

--- a/tests/nats/SMOKE.md
+++ b/tests/nats/SMOKE.md
@@ -38,7 +38,7 @@ journalctl -u llmcli-nats-worker -n 50 --no-pager
 
 Look for log lines:
 - `Starting LLM NATS adapter: model=qwen3-8b max_concurrent=… litellm_url=http://litellm:4000/v1`
-- `llm_adapter: model=qwen3-8b port=8091 ready` (from `_ensure_model`)
+- `llm_adapter: model=qwen3-8b ready` (from `_ensure_model`)
 
 ## Smoke 1 — non-streaming
 

--- a/tests/nats/SMOKE.md
+++ b/tests/nats/SMOKE.md
@@ -1,0 +1,126 @@
+# M₁ Smoke — llmCLI NATS adapter (#12) × lyra#1104
+
+End-to-end verification on `roxabituwer` (M₁) gating the coordinated merge.
+Pass criteria gate the merge window; failure aborts the bundle.
+
+## Prerequisites
+
+- [ ] lyra#1104 deployed: `deploy/nats/auth.conf` regenerated with canonical
+      ACL (`lyra.llm.generate.request` for hub publish + worker subscribe;
+      `lyra.llm.heartbeat` for hub subscribe + worker publish). Confirm
+      neither `lyra.llm.request` (legacy) nor `lyra.llm.health.*` (legacy)
+      remain in the file.
+- [ ] `lyra-nats.service` running on M₁ (`systemctl status lyra-nats`).
+- [ ] LiteLLM proxy running on M₁ port `:4000` with `qwen3-8b` mapped to the
+      local llama-server route. Verify:
+      ```bash
+      curl -sS -H "Authorization: Bearer $LLMCLI_LITELLM_API_KEY" \
+        http://localhost:4000/v1/models | jq '.data[].id' | grep qwen3-8b
+      ```
+- [ ] llmCLI worker container ready: `podman secret ls` shows
+      `llmcli-nats-nkey` and `llmcli-litellm-key`.
+- [ ] llama-server on `:8091` already serving `qwen3-8b` (`llmcli serve qwen3-8b`).
+
+## Bring up the worker
+
+```bash
+# Install the Quadlet unit (one-time per host).
+sudo cp deploy/quadlet/llmcli-nats-worker.container /etc/containers/systemd/
+sudo systemctl daemon-reload
+
+# Start.
+sudo systemctl start llmcli-nats-worker
+
+# Verify it stayed up.
+sudo systemctl status llmcli-nats-worker
+journalctl -u llmcli-nats-worker -n 50 --no-pager
+```
+
+Look for log lines:
+- `Starting LLM NATS adapter: model=qwen3-8b max_concurrent=… litellm_url=http://litellm:4000/v1`
+- `llm_adapter: model=qwen3-8b port=8091 ready` (from `_ensure_model`)
+
+## Smoke 1 — non-streaming
+
+From any host with `nats-cli` and the hub nkey:
+
+```bash
+nats --creds=/path/to/hub.creds request lyra.llm.generate.request \
+  --timeout 10s '{
+    "contract_version": "1",
+    "schema_version": 1,
+    "trace_id": "smoke-ns-1",
+    "issued_at": "2026-05-07T12:00:00Z",
+    "request_id": "smoke-ns-1",
+    "messages": [{"role": "user", "content": "Say hello in 5 words."}],
+    "model": "qwen3-8b",
+    "stream": false,
+    "max_tokens": 64,
+    "temperature": 0.7
+  }'
+```
+
+**Assert (pass criteria):**
+- [ ] Reply received within **5 s**.
+- [ ] Reply JSON has `ok: true`, `text` non-empty, `duration_ms` set,
+      `worker_error` is null.
+- [ ] `journalctl -u llmcli-nats-worker -n 20` shows no error lines.
+
+## Smoke 2 — streaming
+
+```bash
+nats --creds=/path/to/hub.creds request lyra.llm.generate.request \
+  --timeout 10s --raw '{
+    "contract_version": "1",
+    "schema_version": 1,
+    "trace_id": "smoke-s-1",
+    "issued_at": "2026-05-07T12:00:00Z",
+    "request_id": "smoke-s-1",
+    "messages": [{"role": "user", "content": "Count from 1 to 5."}],
+    "model": "qwen3-8b",
+    "stream": true,
+    "max_tokens": 64,
+    "temperature": 0.0
+  }'
+```
+
+(Streaming requires a small consumer that subscribes to a private inbox and
+prints each chunk; if `nats request --raw` doesn't fit, use the
+`scripts/smoke_llm.py` harness in lyra or call from within the hub.)
+
+**Assert:**
+- [ ] At least **1** `LlmChunkEvent` with `delta` populated, then
+      a terminator with `done: true` and `duration_ms` set.
+- [ ] First chunk arrives within **2 s**, last terminator within **5 s**.
+
+## Smoke 3 — heartbeat
+
+In a separate shell:
+
+```bash
+nats --creds=/path/to/hub.creds sub lyra.llm.heartbeat
+```
+
+**Assert (within ~10 s):**
+- [ ] At least one heartbeat received.
+- [ ] Payload contains: `worker_id`, `model_loaded == "qwen3-8b"`,
+      `vram_used_mb` > 0, `vram_free_mb` >= 0, `active_requests`
+      (likely 0 if no in-flight req at that moment).
+
+## Failure / Rollback
+
+Any of the asserts above failing aborts the bundled merge:
+
+```bash
+sudo systemctl stop llmcli-nats-worker
+sudo rm /etc/containers/systemd/llmcli-nats-worker.container
+sudo systemctl daemon-reload
+```
+
+Then either revert lyra#1104 (worker speaks canonical, hub legacy → red)
+or land both PRs together in a follow-up after the failure is fixed.
+
+## Tracking
+
+Record results inline in the bundled-merge PR comment thread on llmCLI #12.
+Pass — both PRs go ready and merge in the same window.

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -77,7 +77,6 @@ def adapter(monkeypatch) -> Iterator[LlmNatsAdapter]:
     )
     # State that _ensure_model would have set:
     a._loaded_model = "qwen3-8b"
-    a._port = 8091
 
     # Replace the real httpx client with an AsyncMock — tests configure responses.
     a._client = MagicMock()

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -1,0 +1,115 @@
+"""Fixtures for NATS adapter unit tests."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from llmcli.nats.llm_adapter import LlmNatsAdapter
+
+
+@pytest.fixture
+def fake_msg_factory():
+    """Build a NATS-message-shaped object with .data (bytes) and .reply (str).
+
+    Tests pass a payload dict; we encode it to JSON bytes mirroring
+    NatsAdapterBase._dispatch's input. .reply is a fixed inbox so callers
+    can assert publishes.
+    """
+
+    def _build(payload: dict, reply: str = "_inbox.test.1") -> SimpleNamespace:
+        return SimpleNamespace(data=json.dumps(payload).encode(), reply=reply)
+
+    return _build
+
+
+@pytest.fixture
+def make_request_payload():
+    """Factory for valid LlmRequest-shaped payload dicts.
+
+    Defaults satisfy NatsAdapterBase envelope checks (contract_version +
+    schema_version) and request_id pattern (^[A-Za-z0-9_-]{1,128}$).
+    Tests override per-case.
+    """
+    from roxabi_contracts.envelope import CONTRACT_VERSION
+
+    def _build(*, stream: bool = True, **overrides: Any) -> dict:
+        base = {
+            "contract_version": CONTRACT_VERSION,
+            "schema_version": 1,
+            "trace_id": "trace-xyz",
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "request_id": "req-001",
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "qwen3-8b",
+            "system_prompt": None,
+            "stream": stream,
+            "max_tokens": 16,
+            "temperature": 0.7,
+        }
+        base.update(overrides)
+        return base
+
+    return _build
+
+
+@pytest.fixture
+def adapter(monkeypatch) -> Iterator[LlmNatsAdapter]:
+    """LlmNatsAdapter instance with daemon SWAP/STATUS bypassed and shared
+    httpx client replaced by AsyncMock so individual tests can program responses.
+
+    Tests interact with `adapter._client.post` and `adapter._client.stream`
+    via AsyncMock.return_value to drive _blocking_response / _stream_response.
+    """
+
+    # Bypass _ensure_model so tests don't need a live daemon socket.
+    monkeypatch.setattr(LlmNatsAdapter, "_ensure_model", lambda self: None)
+
+    a = LlmNatsAdapter(
+        model_name="qwen3-8b",
+        litellm_url="http://litellm.test/v1",
+        litellm_key="test-key",
+        max_concurrent=2,
+    )
+    # State that _ensure_model would have set:
+    a._loaded_model = "qwen3-8b"
+    a._port = 8091
+
+    # Replace the real httpx client with an AsyncMock — tests configure responses.
+    a._client = MagicMock()
+    a._client.post = AsyncMock()
+    a._client.stream = MagicMock()  # context manager returned by stream() is configured per-test
+    a._client.aclose = AsyncMock()
+
+    # Provide a stand-in NATS connection so reply()/publish() calls don't blow up.
+    fake_nc = MagicMock()
+    fake_nc.publish = AsyncMock()
+    fake_nc.is_connected = True
+    a._nc = fake_nc
+
+    yield a
+
+
+@pytest.fixture
+def stream_lines():
+    """Helper to build SSE line iterators for adapter._client.stream mocking.
+
+    Returns a function: stream_lines(chunks: list[str]) -> async iterator emitting
+    `data: {...}` lines per chunk plus `data: [DONE]`. Each chunk is wrapped in the
+    OpenAI delta shape so the existing adapter parser extracts it.
+    """
+
+    def _build(chunks: list[str]):
+        async def _agen():
+            for c in chunks:
+                payload = {"choices": [{"delta": {"content": c}}]}
+                yield f"data: {json.dumps(payload)}"
+            yield "data: [DONE]"
+
+        return _agen()
+
+    return _build

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -1,0 +1,218 @@
+"""Unit tests for LlmNatsAdapter — issue #12."""
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+def _decode_publish(call) -> dict:
+    """Extract JSON body from a nc.publish(subject, data) call."""
+    return json.loads(call.args[1].decode())
+
+
+# ---------- Slice 2 — request parsing & happy paths ----------
+
+
+@pytest.mark.asyncio
+async def test_request_parse_invalid_request_id_emits_transport_parse(
+    adapter, fake_msg_factory, make_request_payload
+):
+    # Use a 129-char all-valid-char request_id: fails _REQUEST_ID_RE (max 128 chars)
+    # but _err slices it to [:128] before building LlmResponse, so serialization succeeds.
+    # Using "../../bad path"-style IDs would crash LlmResponse Pydantic validation.
+    payload = make_request_payload(stream=False, request_id="a" * 129)
+    msg = fake_msg_factory(payload)
+
+    await adapter.handle(msg, payload)
+
+    assert adapter._nc.publish.await_count == 1
+    body = _decode_publish(adapter._nc.publish.await_args_list[0])
+    assert body["ok"] is False
+    assert body["worker_error"]["code"] == "transport.parse"
+    assert body["worker_error"]["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_blocking_reply_shape(adapter, fake_msg_factory, make_request_payload):
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.json = MagicMock(return_value={
+        "choices": [{"message": {"content": "hello world"}}]
+    })
+    adapter._client.post.return_value = fake_resp
+
+    await adapter.handle(msg, payload)
+
+    # 1 publish: the LlmResponse via NatsAdapterBase.reply
+    assert adapter._nc.publish.await_count == 1
+    body = _decode_publish(adapter._nc.publish.await_args_list[0])
+    assert body["ok"] is True
+    assert body["text"] == "hello world"
+    assert "duration_ms" in body and body["duration_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_stream_chunks_and_terminator(
+    adapter, fake_msg_factory, make_request_payload, stream_lines
+):
+    payload = make_request_payload(stream=True)
+    msg = fake_msg_factory(payload)
+
+    # The async with self._client.stream(...) returns a response-like context
+    # whose .aiter_lines() yields our SSE lines and whose .raise_for_status() noops.
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.aiter_lines = lambda: stream_lines(["hello ", "world", "!"])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    adapter._client.stream.return_value = cm
+
+    await adapter.handle(msg, payload)
+
+    # 3 chunk publishes + 1 terminator publish = 4 total
+    assert adapter._nc.publish.await_count == 4
+    bodies = [_decode_publish(c) for c in adapter._nc.publish.await_args_list]
+    deltas = [b.get("delta") for b in bodies if not b.get("done")]
+    assert deltas == ["hello ", "world", "!"]
+    terminator = bodies[-1]
+    assert terminator["done"] is True
+    assert terminator.get("delta") in (None, "")
+    assert terminator.get("duration_ms", -1) >= 0
+
+
+# ---------- Slice 2 — error classifier (5 codes) ----------
+
+
+@pytest.mark.asyncio
+async def test_error_timeout_emits_worker_timeout(
+    adapter, fake_msg_factory, make_request_payload
+):
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+    adapter._client.post.side_effect = httpx.TimeoutException("upstream timeout")
+
+    await adapter.handle(msg, payload)
+
+    body = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert body["ok"] is False
+    assert body["worker_error"]["code"] == "worker.timeout"
+    assert body["worker_error"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_error_5xx_emits_upstream_5xx(
+    adapter, fake_msg_factory, make_request_payload
+):
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+
+    request = httpx.Request("POST", "http://litellm.test/v1/chat/completions")
+    response = httpx.Response(503, request=request)
+    adapter._client.post.side_effect = httpx.HTTPStatusError(
+        "5xx", request=request, response=response
+    )
+
+    await adapter.handle(msg, payload)
+
+    body = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert body["worker_error"]["code"] == "upstream.5xx"
+    assert body["worker_error"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_error_connect_emits_upstream_unavailable(
+    adapter, fake_msg_factory, make_request_payload
+):
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+    adapter._client.post.side_effect = httpx.ConnectError("refused")
+
+    await adapter.handle(msg, payload)
+
+    body = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert body["worker_error"]["code"] == "upstream.unavailable"
+    assert body["worker_error"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_error_parse_emits_transport_parse(
+    adapter, fake_msg_factory, make_request_payload
+):
+    payload = make_request_payload(stream=True)
+    msg = fake_msg_factory(payload)
+
+    # The per-line try/except in _stream_response swallows json.JSONDecodeError on
+    # individual lines. To reach the transport.parse branch in _run_generation's
+    # classifier, we raise JSONDecodeError directly from the async iterator's
+    # __anext__ — this escapes the per-line guard and propagates to _run_generation.
+    async def _raising_lines():
+        raise json.JSONDecodeError("bad", "{not valid", 0)
+        yield  # make it a generator
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.aiter_lines = lambda: _raising_lines()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    adapter._client.stream.return_value = cm
+
+    await adapter.handle(msg, payload)
+
+    # Streaming errors are published as LlmChunkEvent with is_error=True (not LlmResponse).
+    last = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert last.get("is_error") is True
+    assert last["worker_error"]["code"] == "transport.parse"
+    assert last["worker_error"]["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_error_generic_emits_worker_internal(
+    adapter, fake_msg_factory, make_request_payload
+):
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+    adapter._client.post.side_effect = RuntimeError("kaboom")
+
+    await adapter.handle(msg, payload)
+
+    body = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert body["worker_error"]["code"] == "worker.internal"
+    assert body["worker_error"]["retryable"] is False
+
+
+# ---------- Slice 2 — heartbeat enrichment ----------
+
+
+def test_heartbeat_payload_has_vram_keys(adapter, monkeypatch):
+    # Patch VRAM probe to a deterministic value (avoids real nvidia-smi / pynvml).
+    import llmcli.gpu as gpu_mod
+
+    monkeypatch.setattr(gpu_mod, "probe_free_vram_gib", lambda: 10.0)
+
+    # Patch pynvml in sys.modules so heartbeat_payload's `import pynvml` branch
+    # returns a known total VRAM of 16 GiB.
+    fake_pynvml = MagicMock()
+    fake_pynvml.nvmlInit.return_value = None
+    fake_pynvml.nvmlShutdown.return_value = None
+    fake_pynvml.nvmlDeviceGetHandleByIndex.return_value = "handle"
+    mem_info = MagicMock()
+    mem_info.total = 16 * 1024 * 1024 * 1024  # 16 GiB in bytes
+    fake_pynvml.nvmlDeviceGetMemoryInfo.return_value = mem_info
+    monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+
+    p = adapter.heartbeat_payload()
+
+    assert p["model_loaded"] == "qwen3-8b"
+    assert p["active_requests"] == 0
+    assert p["vram_free_mb"] == int(10.0 * 1024)  # 10240
+    assert p["vram_used_mb"] == 16 * 1024 - int(10.0 * 1024)  # 6144
+    assert "worker_id" in p

--- a/uv.lock
+++ b/uv.lock
@@ -993,6 +993,7 @@ dependencies = [
 nats = [
     { name = "nats-py" },
     { name = "nkeys" },
+    { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
 ]
 
@@ -1020,7 +1021,8 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.2.1" },
+    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
+    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.12" },
@@ -2325,16 +2327,16 @@ wheels = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.2.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&tag=roxabi-nats%2Fv0.2.1#86e00a1019c118c1578a98847615facb3b03853e" }
+version = "0.4.0"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#99f9bb25e45c3d26445f3a8bd0de097e6e5ed330" }
 dependencies = [
     { name = "pydantic" },
 ]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.2.1"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.2.1#86e00a1019c118c1578a98847615facb3b03853e" }
+version = "0.3.0"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#99f9bb25e45c3d26445f3a8bd0de097e6e5ed330" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary
- Rectify `src/llmcli/nats/llm_adapter.py` to call **LiteLLM proxy** (`LLMCLI_LITELLM_URL`, Bearer auth) instead of `localhost:{daemon_port}` directly — LiteLLM keeps catalog/aliasing/fallback ownership.
- Adopt canonical `WorkerError(code, message, retryable)` envelopes (ADR-066) on every error path with codes `worker.internal | worker.timeout | transport.parse | upstream.unavailable | upstream.5xx`.
- Enrich heartbeat with `vram_used_mb` + `vram_free_mb` (via `gpu.probe_free_vram_gib` + nvml total).
- Add Podman Quadlet, unit tests (9 cases, all green), and an M₁ smoke procedure that gates the bundled merge.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #12: feat(nats): add NATS worker — lyra.llm.request subscriber | OPEN |
| Frame | [12-nats-worker-frame.mdx](artifacts/frames/12-nats-worker-frame.mdx) | Approved |
| Spec | [12-nats-worker-spec.mdx](artifacts/specs/12-nats-worker-spec.mdx) | Approved (revised post code-audit) |
| Plan | [12-nats-worker-plan.mdx](artifacts/plans/12-nats-worker-plan.mdx) | 10/10 tasks complete |
| Implementation | 10 commits on `feat/12-nats-worker` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (9 new, 281 total) | Passed |

## Files changed

| Op | Path |
|---|---|
| M | `src/llmcli/nats/llm_adapter.py` (+192/-65) |
| M | `src/llmcli/cli_nats.py` (+24/-…) |
| M | `pyproject.toml` + `uv.lock` |
| N | `tests/nats/{__init__.py, conftest.py, test_adapter.py, SMOKE.md}` |
| N | `deploy/quadlet/llmcli-nats-worker.container` |

## Coordinated merge

⚠️ **Bundled with [Roxabi/lyra#1104](https://github.com/Roxabi/lyra/issues/1104)** — full canonical ACL migration:
- request: `lyra.llm.request` → `lyra.llm.generate.request`
- heartbeat: `lyra.llm.health.*` → `lyra.llm.heartbeat`
- hub bootstrap: `NatsLlmDriver` → `NatsLlmClient`

Either PR alone leaves the wire end-to-end red. Both must land in the same merge window. Smoke test on M₁ (procedure in `tests/nats/SMOKE.md`) gates the merge.

## Test Plan
- [ ] `uv sync --extra nats && uv run pytest tests/nats -v` → 9/9 green
- [ ] `uv run llmcli nats-serve llm --help` shows `--litellm-url`, `--litellm-key`, `LLMCLI_LITELLM_URL`, `LLMCLI_LITELLM_API_KEY`
- [ ] `grep -c "localhost:" src/llmcli/nats/llm_adapter.py` → 0 (no direct llama-server bypass)
- [ ] M₁ smoke per `tests/nats/SMOKE.md` — non-stream <5s, stream <5s, heartbeat with vram>0 (gates the bundle)

Closes #12

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`
