### PR TITLE
ci(publish): add GHCR image publish workflow on staging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: publish
+on:
+  push:
+    branches: [staging]
+    tags: ['llmcli/v*']
+permissions:
+  contents: read
+  packages: write
+jobs:
+  publish:
+    uses: Roxabi/.github/.github/workflows/publish-container.yml@v1
+    with:
+      image_name: ghcr.io/roxabi/llmcli
+      release_please_component: llmcli
+      dockerfile_path: ./Dockerfile.llm


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` mirroring `Roxabi/lyra` — calls the shared reusable workflow `Roxabi/.github/.github/workflows/publish-container.yml@v1` to build and push the container image on every push to `staging` (and on `llmcli/v*` tags).

This unblocks the M₁ deploy of `deploy/quadlet/llmcli-nats-worker.container` (introduced in #12 / PR #18). That Quadlet pulls `ghcr.io/roxabi/llmcli:staging`, but until now nothing built or pushed it.

| Trigger | Pushes |
|---|---|
| `push: staging` | `ghcr.io/roxabi/llmcli:staging` |
| `tag llmcli/vX.Y.Z` | `ghcr.io/roxabi/llmcli:X.Y.Z` (+ `:X`) |

Uses `dockerfile_path: ./Dockerfile.llm` since llmCLI's image lives there (not at the default `./Dockerfile`).

## Test plan
- [ ] CI green on this PR (no behavior change to existing CI/tests)
- [ ] After merge to staging, the `publish` workflow runs and pushes `ghcr.io/roxabi/llmcli:staging`
- [ ] `curl -sI https://ghcr.io/v2/roxabi/llmcli/manifests/staging` returns 200/401 (not 404)
- [ ] M₁ podman can `pull ghcr.io/roxabi/llmcli:staging`

Closes #22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)