### PR TITLE
ci(publish): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [staging]
     tags: ['llmcli/v*']
+  workflow_dispatch:
 permissions:
   contents: read
   packages: write


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` trigger to `publish.yml`
- Unblocks manual image rebuilds when GITHUB_TOKEN-driven auto-merges fail to propagate downstream workflows

## Problem

PR #25 merged to staging via `auto-merge.yml`, which uses `${{ secrets.PAT || github.token }}`. Since `PAT` is not configured, the merge ran as GITHUB_TOKEN. GitHub intentionally suppresses downstream workflow triggers for GITHUB_TOKEN actions to prevent recursion. Result: `publish.yml` did NOT fire on the PR #25 merge → `ghcr.io/roxabi/llmcli:staging` image was never rebuilt.

## Fix

One-line addition:

\`\`\`yaml
on:
  push:
    branches: [staging]
    tags: ['llmcli/v*']
  workflow_dispatch:
\`\`\`

After merge, ops can run:
\`\`\`bash
gh workflow run publish.yml -R Roxabi/llmCLI --ref staging
\`\`\`

## Test plan

- [ ] PR merges cleanly (triggers push to staging → publish should fire)
- [ ] `gh workflow run publish.yml -R Roxabi/llmCLI --ref staging` dispatches successfully post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)