### PR TITLE
fix(nats): set _loaded_model in daemon-optional skip path

### DIFF
--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -104,6 +104,7 @@ class LlmNatsAdapter(NatsAdapterBase):
                 "skipping SWAP/STATUS (remote-worker mode, model assumed loaded externally)",
                 self._socket_path,
             )
+            self._loaded_model = self._model_name
             return
         try:
             reply = daemon_request(f"SWAP {self._model_name}", socket_path=self._socket_path)
@@ -120,6 +121,7 @@ class LlmNatsAdapter(NatsAdapterBase):
                 "skipping SWAP/STATUS, assuming model already loaded",
                 exc,
             )
+            self._loaded_model = self._model_name
 
     # ------------------------------------------------------------------
     # NatsAdapterBase overrides

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from llmcli.nats.llm_adapter import LlmNatsAdapter
+
 
 def _decode_publish(call) -> dict:
     """Extract JSON body from a nc.publish(subject, data) call."""
@@ -187,6 +189,40 @@ async def test_error_generic_emits_worker_internal(
     body = _decode_publish(adapter._nc.publish.await_args_list[-1])
     assert body["worker_error"]["code"] == "worker.internal"
     assert body["worker_error"]["retryable"] is False
+
+
+# ---------- Slice 2 — _ensure_model daemon-optional skip paths (#28) ----------
+
+
+def test_ensure_model_socket_missing_sets_loaded_model(tmp_path):
+    """Socket absent → _loaded_model populated from _model_name (not None)."""
+    a = LlmNatsAdapter(
+        model_name="qwen3-8b",
+        litellm_url="http://litellm.test/v1",
+        litellm_key="test-key",
+        socket_path=tmp_path / "nonexistent.sock",
+    )
+    a._ensure_model()
+    assert a._loaded_model == "qwen3-8b"
+
+
+def test_ensure_model_oserror_sets_loaded_model(tmp_path, monkeypatch):
+    """OSError mid-connect → _loaded_model populated from _model_name (not None)."""
+    import llmcli.daemon as daemon_mod
+
+    sock = tmp_path / "fake.sock"
+    sock.touch()  # exists() returns True → enters try block
+
+    monkeypatch.setattr(daemon_mod, "daemon_request", MagicMock(side_effect=OSError("refused")))
+
+    a = LlmNatsAdapter(
+        model_name="qwen3-8b",
+        litellm_url="http://litellm.test/v1",
+        litellm_key="test-key",
+        socket_path=sock,
+    )
+    a._ensure_model()
+    assert a._loaded_model == "qwen3-8b"
 
 
 # ---------- Slice 2 — heartbeat enrichment ----------


### PR DESCRIPTION
## Regression

PR #25 added a daemon-optional mode to `_ensure_model`: when the socket is absent (or an `OSError` fires mid-connect), the SWAP/STATUS path is skipped so a remote-worker container can start without a host daemon.

However, both skip branches returned without assigning `self._loaded_model`. The attribute stayed `None`, so line 242:

```python
body: dict = {"model": self._loaded_model or "default", "messages": messages}
```

silently fell back to the literal string `"default"`, which LiteLLM rejects with a 400 on every request from a remote worker.

## Fix

In both auto-skip branches of `_ensure_model`, set `self._loaded_model = self._model_name` before returning. The operator-supplied `--model` CLI arg is the authoritative contract for what is loaded externally in remote-worker mode.

## Tests

Two new unit tests added to `tests/nats/test_adapter.py` (lines 192–228):
- `test_ensure_model_socket_missing_sets_loaded_model` — socket absent path
- `test_ensure_model_oserror_sets_loaded_model` — OSError mid-connect path

Both assert `_loaded_model == _model_name` after `_ensure_model()`.

Closes #28