### PR TITLE
feat(catalog): support cloud-passthrough engines + per-machine filter

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -32,11 +32,12 @@ forbidden_modules =
     llmcli.cli
 
 [importlinter:contract:base-isolation]
-name = base layer (config, engine) does not import higher layers
+name = base layer (config, engine, providers) does not import higher layers
 type = forbidden
 source_modules =
     llmcli.config
     llmcli.engine
+    llmcli.providers
 forbidden_modules =
     llmcli.cli
     llmcli.daemon

--- a/llmcli.example.toml
+++ b/llmcli.example.toml
@@ -1,6 +1,13 @@
 # llmCLI host config — copy to ~/.config/llmcli/llmcli.toml and edit.
 # Model definitions live in ~/.config/llmcli/models/<name>.toml (one file per model).
 # See models/ in this repo for examples to copy and adapt.
+#
+# Cloud passthrough examples (engine="remote", no GPU required):
+#   models/kimi-k2.6.toml         — Kimi K2.6 via Fireworks AI (OpenAI protocol)
+#   models/claude-sonnet-4-6.toml — Claude Sonnet 4.6 via Anthropic API
+#
+# Per-machine filter: set machines=["hostname"] on any spec to restrict it to
+# specific hosts. Empty list (machines=[]) means all hosts — the default.
 
 [host]
 bind              = "0.0.0.0"

--- a/models/claude-sonnet-4-6.toml
+++ b/models/claude-sonnet-4-6.toml
@@ -1,0 +1,7 @@
+# Claude Sonnet 4.6 via Anthropic API — cloud passthrough, Anthropic-native protocol.
+# Requires ANTHROPIC_API_KEY env var on the host.
+engine   = "remote"
+provider = "anthropic"
+model_id = "claude-sonnet-4-6"
+protocol = "anthropic"
+machines = []

--- a/models/kimi-k2.6.toml
+++ b/models/kimi-k2.6.toml
@@ -1,0 +1,7 @@
+# Kimi K2.6 via Fireworks AI — cloud passthrough, no local GPU needed.
+# Available on all hosts (M1 cloud-only + M2 local+cloud).
+engine   = "remote"
+provider = "fireworks"
+model_id = "accounts/fireworks/routers/kimi-k2p6-turbo"
+protocol = "openai"
+machines = []  # empty = all hosts

--- a/models/qwen3-14b-q5.toml
+++ b/models/qwen3-14b-q5.toml
@@ -5,3 +5,4 @@ file     = "qwen3-14b-q5_k_m.gguf"
 port     = 8092
 vram_gib = 11
 flags    = ["-ngl", "99", "-c", "8192", "-fa", "on", "--jinja"]
+machines = ["roxabitower"]

--- a/models/qwen3_6-35b-a3b-tq3.toml
+++ b/models/qwen3_6-35b-a3b-tq3.toml
@@ -7,3 +7,4 @@ mmproj   = "mmproj-BF16.gguf"
 port     = 8091
 vram_gib = 13
 flags    = ["-ngl", "99", "-c", "8192", "-ctk", "q4_0", "-ctv", "tq3_0", "-fa", "on", "--jinja"]
+machines = ["roxabitower"]

--- a/src/llmcli/cli/lifecycle.py
+++ b/src/llmcli/cli/lifecycle.py
@@ -31,9 +31,7 @@ def serve(
 
     if model_name not in catalog.models:
         available = ", ".join(catalog.models.keys())
-        err_console.print(
-            f"[red]Unknown model '{model_name}'. Available: {available}[/red]"
-        )
+        err_console.print(f"[red]Unknown model '{model_name}'. Available: {available}[/red]")
         raise typer.Exit(code=1)
 
     spec = catalog.models[model_name]

--- a/src/llmcli/cli/lifecycle.py
+++ b/src/llmcli/cli/lifecycle.py
@@ -36,9 +36,10 @@ def serve(
 
     spec = catalog.models[model_name]
 
-    # VRAM guard (C2 / SC-13)
+    # VRAM guard (C2 / SC-13) — Remote specs need no local GPU; skip VRAM check.
     try:
-        _cli.config.check_vram_budget(spec, catalog.host)
+        if spec.engine != "remote":
+            _cli.config.check_vram_budget(spec, catalog.host)
     except ValueError as exc:
         err_console.print(
             Panel(

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -34,9 +34,7 @@ def register_proxy(
     hostname = socket.gethostname()
 
     # 3. Resolve config path: --config flag > env var > default
-    resolved_path = (
-        Path(config_path) if config_path else Path.home() / ".litellm" / "config.yaml"
-    )
+    resolved_path = Path(config_path) if config_path else Path.home() / ".litellm" / "config.yaml"
 
     # 4. Friendly error when parent directory doesn't exist or is not writable
     if not resolved_path.parent.exists():

--- a/src/llmcli/cli_nats.py
+++ b/src/llmcli/cli_nats.py
@@ -10,7 +10,10 @@ nats_app = typer.Typer(help="NATS subscriber satellite for hub-driven LLM genera
 @nats_app.command("llm")
 def nats_serve_llm(
     model: Annotated[
-        str, typer.Option("--model", "-m", envvar="LLMCLI_MODEL", help="Catalog model name to load on startup.")
+        str,
+        typer.Option(
+            "--model", "-m", envvar="LLMCLI_MODEL", help="Catalog model name to load on startup."
+        ),
     ],
     max_concurrent: Annotated[
         int, typer.Option("--max-concurrent", envvar="LLMCLI_MAX_CONCURRENT")
@@ -29,11 +32,16 @@ def nats_serve_llm(
         typer.Option("--socket-path", envvar="LLMCLI_SOCKET", help="Override daemon socket path."),
     ] = None,
     litellm_url: Annotated[
-        str, typer.Option("--litellm-url", envvar="LLMCLI_LITELLM_URL", help="LiteLLM proxy base URL.")
+        str,
+        typer.Option("--litellm-url", envvar="LLMCLI_LITELLM_URL", help="LiteLLM proxy base URL."),
     ] = "http://localhost:4000/v1",
     litellm_key: Annotated[
         str,
-        typer.Option("--litellm-key", envvar="LLMCLI_LITELLM_API_KEY", help="LiteLLM API key (master or virtual)."),
+        typer.Option(
+            "--litellm-key",
+            envvar="LLMCLI_LITELLM_API_KEY",
+            help="LiteLLM API key (master or virtual).",
+        ),
     ] = "",
 ) -> None:
     """Subscribe to lyra.llm.generate.request and serve LLM completions.

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -59,6 +59,12 @@ def _parse_model_spec(name: str, spec: dict) -> ModelSpec:
     engine = spec.get("engine", "")
     valid_engines = _LOCAL_ENGINES | {"remote"}
 
+    if "engine" not in spec:
+        raise ValueError(
+            f"Model '{name}' is missing required field 'engine'. "
+            f"Valid engines: {sorted(valid_engines)}."
+        )
+
     if engine not in valid_engines:
         raise ValueError(
             f"Model '{name}' has unknown engine '{engine}'. Valid engines: {sorted(valid_engines)}."
@@ -88,6 +94,17 @@ def _parse_model_spec(name: str, spec: dict) -> ModelSpec:
                 f"Model '{name}' has invalid protocol '{protocol}'. "
                 f"Valid protocols: {sorted(_VALID_PROTOCOLS)}."
             )
+        # Cross-validate provider × protocol
+        if provider == "anthropic" and protocol != "anthropic":
+            raise ValueError(
+                f"Model '{name}' uses provider='anthropic' which requires protocol='anthropic', "
+                f"got protocol='{protocol}'."
+            )
+        if provider != "anthropic" and protocol == "anthropic":
+            raise ValueError(
+                f"Model '{name}' uses protocol='anthropic' which is only supported by "
+                f"provider='anthropic', got provider='{provider}'."
+            )
         # Reject mixing remote with local-only fields
         mixed = _REMOTE_LOCAL_FIELDS & spec.keys()
         if mixed:
@@ -102,7 +119,7 @@ def _parse_model_spec(name: str, spec: dict) -> ModelSpec:
                 f"Model '{name}' is missing required field 'repo'. "
                 "Add a 'repo' key pointing to the HuggingFace repository (e.g. 'Org/Model-GGUF')."
             )
-        remote_fields = {"provider", "model_id"} & spec.keys()
+        remote_fields = {"provider", "model_id", "protocol"} & spec.keys()
         if remote_fields:
             raise ValueError(
                 f"Model '{name}' with engine='{engine}' must not set remote-engine fields: "

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .gpu import kv_overhead_gib, probe_free_vram_gib
+from .providers import PROVIDERS
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONFIG_PATH = Path(
     os.environ.get("LLMCLI_CONFIG", Path.home() / ".config" / "llmcli" / "llmcli.toml")
 )
+
+_VALID_PROTOCOLS = frozenset({"openai", "anthropic"})
+_LOCAL_ENGINES = frozenset({"llamacpp", "llamacpp_tq3", "vllm"})
+_REMOTE_LOCAL_FIELDS = frozenset({"repo", "file", "port", "vram_gib", "flags", "mmproj"})
 
 
 @dataclass(frozen=True)
@@ -29,12 +34,19 @@ class HostSettings:
 class ModelSpec:
     name: str
     engine: str
-    repo: str
-    port: int
-    vram_gib: float
+    # Local-engine fields — optional (forbidden for engine="remote")
+    repo: str = ""
+    port: int = 0
+    vram_gib: float = 0.0
     file: str = ""
     flags: list[str] = field(default_factory=list)
     mmproj: str | None = None
+    # Remote-engine fields — forbidden for local engines
+    provider: str = ""
+    model_id: str = ""
+    protocol: str = "openai"
+    # Per-machine filter — empty = all hosts
+    machines: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -44,11 +56,59 @@ class Catalog:
 
 
 def _parse_model_spec(name: str, spec: dict) -> ModelSpec:
-    if "repo" not in spec:
+    engine = spec.get("engine", "")
+    valid_engines = _LOCAL_ENGINES | {"remote"}
+
+    if engine not in valid_engines:
         raise ValueError(
-            f"Model '{name}' is missing required field 'repo'. "
-            "Add a 'repo' key pointing to the HuggingFace repository (e.g. 'Org/Model-GGUF')."
+            f"Model '{name}' has unknown engine '{engine}'. Valid engines: {sorted(valid_engines)}."
         )
+
+    if engine == "remote":
+        # Validate required remote fields
+        provider = spec.get("provider", "")
+        model_id = spec.get("model_id", "")
+        protocol = spec.get("protocol", "openai")
+
+        if not provider:
+            raise ValueError(
+                f"Model '{name}' with engine='remote' is missing required field 'provider'."
+            )
+        if provider not in PROVIDERS:
+            raise ValueError(
+                f"Model '{name}' references unknown provider '{provider}'. "
+                f"Valid providers: {sorted(PROVIDERS.keys())}."
+            )
+        if not model_id:
+            raise ValueError(
+                f"Model '{name}' with engine='remote' is missing required field 'model_id'."
+            )
+        if protocol not in _VALID_PROTOCOLS:
+            raise ValueError(
+                f"Model '{name}' has invalid protocol '{protocol}'. "
+                f"Valid protocols: {sorted(_VALID_PROTOCOLS)}."
+            )
+        # Reject mixing remote with local-only fields
+        mixed = _REMOTE_LOCAL_FIELDS & spec.keys()
+        if mixed:
+            raise ValueError(
+                f"Model '{name}' with engine='remote' must not set local-engine fields: "
+                f"{sorted(mixed)}. Remove them or use a local engine."
+            )
+    else:
+        # Local engine — require repo, reject remote fields
+        if "repo" not in spec:
+            raise ValueError(
+                f"Model '{name}' is missing required field 'repo'. "
+                "Add a 'repo' key pointing to the HuggingFace repository (e.g. 'Org/Model-GGUF')."
+            )
+        remote_fields = {"provider", "model_id"} & spec.keys()
+        if remote_fields:
+            raise ValueError(
+                f"Model '{name}' with engine='{engine}' must not set remote-engine fields: "
+                f"{sorted(remote_fields)}. Remove them or use engine='remote'."
+            )
+
     return ModelSpec(name=name, **spec)
 
 
@@ -57,7 +117,9 @@ def load(path: Path = DEFAULT_CONFIG_PATH) -> Catalog:
         data = tomllib.load(f)
 
     host_data = data.get("host", {})
-    host = HostSettings(**{k: v for k, v in host_data.items() if k in HostSettings.__dataclass_fields__})
+    host = HostSettings(
+        **{k: v for k, v in host_data.items() if k in HostSettings.__dataclass_fields__}
+    )
 
     # Inline models — kept for backward compat (single-file configs still work)
     models: dict[str, ModelSpec] = {
@@ -72,7 +134,9 @@ def load(path: Path = DEFAULT_CONFIG_PATH) -> Catalog:
             with model_file.open("rb") as f:
                 spec_data = tomllib.load(f)
             if name in models:
-                logger.warning("Model '%s' defined both inline and in models/; using models/ version", name)
+                logger.warning(
+                    "Model '%s' defined both inline and in models/; using models/ version", name
+                )
             models[name] = _parse_model_spec(name, spec_data)
 
     return Catalog(host=host, models=models)

--- a/src/llmcli/daemon.py
+++ b/src/llmcli/daemon.py
@@ -163,6 +163,12 @@ class Daemon:
             "llamacpp_tq3": LlamaCppTQ3Engine,
             "vllm": VLLMEngine,
         }
+        if spec.engine == "remote":
+            raise ValueError(
+                f"Model '{spec.name}' uses engine='remote' — cloud-passthrough models are "
+                f"managed by LiteLLM, not the local daemon. Use 'llmcli register-proxy' to "
+                f"expose this model via the proxy."
+            )
         engine_cls = _ENGINE_REGISTRY.get(spec.engine)
         if engine_cls is None:
             raise ValueError(
@@ -183,7 +189,8 @@ class Daemon:
         spec = self.catalog.models[name]
 
         # VRAM budget guard (C2) — reject before touching current engine
-        if self.catalog is not None:
+        # Remote specs need no local GPU; skip VRAM check.
+        if self.catalog is not None and spec.engine != "remote":
             try:
                 check_vram_budget(spec, self.catalog.host)
             except ValueError as exc:

--- a/src/llmcli/engines/llamacpp.py
+++ b/src/llmcli/engines/llamacpp.py
@@ -78,9 +78,12 @@ class LlamaCppEngine:
         gguf = self._gguf_path(spec)
         cmd: list[str] = [
             self.binary,
-            "--model", str(gguf),
-            "--host", "0.0.0.0",
-            "--port", str(spec.port),
+            "--model",
+            str(gguf),
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(spec.port),
         ]
         if spec.flags:
             cmd.extend(spec.flags)

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -16,7 +16,9 @@ from ._common import _wait_ready
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_WAIT_TIMEOUT = 180  # vLLM needs longer: safetensors load + NVFP4 JIT compile can take 60–120 s on first start
+_WAIT_TIMEOUT = (
+    180  # vLLM needs longer: safetensors load + NVFP4 JIT compile can take 60–120 s on first start
+)
 
 
 # ---------------------------------------------------------------------------
@@ -33,7 +35,9 @@ class VLLMEngine:
 
     def _build_cmd(self, spec: ModelSpec) -> list[str]:
         """Build the subprocess argument list for `vllm serve`."""
-        return ["vllm", "serve", spec.repo, "--port", str(spec.port), "--host", "0.0.0.0"] + list(spec.flags)
+        return ["vllm", "serve", spec.repo, "--port", str(spec.port), "--host", "0.0.0.0"] + list(
+            spec.flags
+        )
 
     # ------------------------------------------------------------------
     # Engine Protocol

--- a/src/llmcli/litellm_config.py
+++ b/src/llmcli/litellm_config.py
@@ -35,7 +35,13 @@ def build_block(catalog: Catalog, public_base_url: str, *, hostname: str | None 
             continue
 
         if spec.engine == "remote":
-            provider = PROVIDERS[spec.provider]
+            provider_cfg = PROVIDERS.get(spec.provider)
+            if provider_cfg is None:
+                raise ValueError(
+                    f"Unknown provider '{spec.provider}' in spec '{name}'. "
+                    f"Valid providers: {sorted(PROVIDERS.keys())}."
+                )
+            provider = provider_cfg
             if spec.protocol == "anthropic":
                 entry = {
                     "model_name": name,

--- a/src/llmcli/litellm_config.py
+++ b/src/llmcli/litellm_config.py
@@ -1,32 +1,62 @@
 from __future__ import annotations
 
+import socket
 import subprocess
 from pathlib import Path
 
 import yaml
 
 from .config import Catalog
+from .providers import PROVIDERS
 
 LITELLM_CONFIG = Path.home() / ".litellm" / "config.yaml"
 BLOCK_START = "# --- llmCLI managed block start ---"
 BLOCK_END = "# --- llmCLI managed block end ---"
 
 
-def build_block(catalog: Catalog, public_base_url: str) -> str:
+def build_block(catalog: Catalog, public_base_url: str, *, hostname: str | None = None) -> str:
     """Build a namespaced model_list block for the proxy config.
 
     Args:
         catalog: Loaded catalog with host settings and model specs.
         public_base_url: Base URL for the host (e.g. 'http://roxabitower.lan').
+        hostname: Override hostname for machine filter (default: socket.gethostname()).
 
     Returns:
         YAML string wrapped in llmCLI sentinel comments.
     """
+    effective_hostname = hostname if hostname is not None else socket.gethostname()
     api_key_ref = f"os.environ/{catalog.host.api_key_env}"
 
-    if catalog.models:
-        model_list = [
-            {
+    model_list = []
+    for name, spec in catalog.models.items():
+        # Per-machine filter: skip if machines is set and hostname not in list
+        if spec.machines and effective_hostname not in spec.machines:
+            continue
+
+        if spec.engine == "remote":
+            provider = PROVIDERS[spec.provider]
+            if spec.protocol == "anthropic":
+                entry = {
+                    "model_name": name,
+                    "litellm_params": {
+                        "model": f"anthropic/{spec.model_id}",
+                        "api_key": f"os.environ/{provider.key_env}",
+                    },
+                }
+            else:
+                # protocol == "openai"
+                entry = {
+                    "model_name": name,
+                    "litellm_params": {
+                        "model": f"openai/{spec.model_id}",
+                        "api_base": provider.api_base,
+                        "api_key": f"os.environ/{provider.key_env}",
+                    },
+                }
+        else:
+            # Local engines: llamacpp, llamacpp_tq3, vllm
+            entry = {
                 "model_name": name,
                 "litellm_params": {
                     "model": f"openai/{name}",
@@ -34,9 +64,12 @@ def build_block(catalog: Catalog, public_base_url: str) -> str:
                     "api_key": api_key_ref,
                 },
             }
-            for name, spec in catalog.models.items()
-        ]
-        inner = yaml.safe_dump({"model_list": model_list}, default_flow_style=False, sort_keys=False)
+        model_list.append(entry)
+
+    if model_list:
+        inner = yaml.safe_dump(
+            {"model_list": model_list}, default_flow_style=False, sort_keys=False
+        )
     else:
         inner = yaml.safe_dump({"model_list": None}, default_flow_style=False)
 

--- a/src/llmcli/nats/_generation.py
+++ b/src/llmcli/nats/_generation.py
@@ -51,15 +51,19 @@ class GenerationMixin:
             "trace_id": payload.get("trace_id"),
         }
         # builders.py does not accept worker_error= — build envelope manually.
-        data = LlmResponse(
-            contract_version=CONTRACT_VERSION,
-            trace_id=safe_payload.get("trace_id") or safe_payload["request_id"],
-            issued_at=datetime.now(timezone.utc),
-            request_id=safe_payload["request_id"],
-            ok=False,
-            error=worker_error.message,
-            worker_error=worker_error,
-        ).model_dump_json(exclude_none=True).encode()
+        data = (
+            LlmResponse(
+                contract_version=CONTRACT_VERSION,
+                trace_id=safe_payload.get("trace_id") or safe_payload["request_id"],
+                issued_at=datetime.now(timezone.utc),
+                request_id=safe_payload["request_id"],
+                ok=False,
+                error=worker_error.message,
+                worker_error=worker_error,
+            )
+            .model_dump_json(exclude_none=True)
+            .encode()
+        )
         await self.reply(msg, data)
 
     # ------------------------------------------------------------------
@@ -125,16 +129,20 @@ class GenerationMixin:
         if stream and msg.reply and self._nc:
             try:
                 # builders.py does not accept worker_error= — build envelope manually.
-                data = LlmChunkEvent(
-                    contract_version=CONTRACT_VERSION,
-                    trace_id=payload.get("trace_id") or request_id,
-                    issued_at=datetime.now(timezone.utc),
-                    request_id=request_id,
-                    done=True,
-                    is_error=True,
-                    error=we.message,
-                    worker_error=we,
-                ).model_dump_json(exclude_none=True).encode()
+                data = (
+                    LlmChunkEvent(
+                        contract_version=CONTRACT_VERSION,
+                        trace_id=payload.get("trace_id") or request_id,
+                        issued_at=datetime.now(timezone.utc),
+                        request_id=request_id,
+                        done=True,
+                        is_error=True,
+                        error=we.message,
+                        worker_error=we,
+                    )
+                    .model_dump_json(exclude_none=True)
+                    .encode()
+                )
                 await self._nc.publish(msg.reply, data)
             except Exception:  # noqa: BLE001
                 pass
@@ -148,9 +156,7 @@ class GenerationMixin:
     # HTTP calls
     # ------------------------------------------------------------------
 
-    async def _stream_response(
-        self, msg, payload: dict, body: dict, t0: float
-    ) -> None:
+    async def _stream_response(self, msg, payload: dict, body: dict, t0: float) -> None:
         body = {**body, "stream": True}
         nc = self._nc
 
@@ -169,11 +175,7 @@ class GenerationMixin:
                     chunk_data = json.loads(data)
                 except json.JSONDecodeError:
                     continue
-                delta = (
-                    chunk_data.get("choices", [{}])[0]
-                    .get("delta", {})
-                    .get("content")
-                )
+                delta = chunk_data.get("choices", [{}])[0].get("delta", {}).get("content")
                 if delta and msg.reply:
                     await nc.publish(
                         msg.reply,
@@ -191,9 +193,7 @@ class GenerationMixin:
                 build_llm_chunk(payload, done=True, duration_ms=duration_ms).encode(),
             )
 
-    async def _blocking_response(
-        self, msg, payload: dict, body: dict, t0: float
-    ) -> None:
+    async def _blocking_response(self, msg, payload: dict, body: dict, t0: float) -> None:
         body = {**body, "stream": False}
         resp = await self._client.post("/chat/completions", json=body)
         resp.raise_for_status()

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -86,9 +86,7 @@ class LlmNatsAdapter(GenerationMixin, NatsAdapterBase):
     # ------------------------------------------------------------------
 
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
-        await asyncio.get_running_loop().run_in_executor(
-            self._executor, self._ensure_model
-        )
+        await asyncio.get_running_loop().run_in_executor(self._executor, self._ensure_model)
         await super().run(nats_url, stop)
 
     def _ensure_model(self) -> None:

--- a/src/llmcli/providers.py
+++ b/src/llmcli/providers.py
@@ -1,0 +1,22 @@
+"""Provider registry for cloud-passthrough engines.
+
+Pure data — no I/O, no llmcli imports. Layer 0 (base).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Provider:
+    api_base: str
+    key_env: str
+
+
+PROVIDERS: dict[str, Provider] = {
+    "fireworks": Provider("https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY"),
+    "anthropic": Provider("https://api.anthropic.com", "ANTHROPIC_API_KEY"),
+    "openai": Provider("https://api.openai.com/v1", "OPENAI_API_KEY"),
+    "nvidia-nim": Provider("https://integrate.api.nvidia.com/v1", "NVIDIA_API_KEY"),
+}

--- a/tests/nats/conftest.py
+++ b/tests/nats/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for NATS adapter unit tests."""
+
 from __future__ import annotations
 
 import json

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -1,4 +1,5 @@
 """Unit tests for LlmNatsAdapter — issue #12."""
+
 from __future__ import annotations
 
 import json
@@ -45,9 +46,7 @@ async def test_blocking_reply_shape(adapter, fake_msg_factory, make_request_payl
 
     fake_resp = MagicMock()
     fake_resp.raise_for_status = MagicMock()
-    fake_resp.json = MagicMock(return_value={
-        "choices": [{"message": {"content": "hello world"}}]
-    })
+    fake_resp.json = MagicMock(return_value={"choices": [{"message": {"content": "hello world"}}]})
     adapter._client.post.return_value = fake_resp
 
     await adapter.handle(msg, payload)
@@ -94,9 +93,7 @@ async def test_stream_chunks_and_terminator(
 
 
 @pytest.mark.asyncio
-async def test_error_timeout_emits_worker_timeout(
-    adapter, fake_msg_factory, make_request_payload
-):
+async def test_error_timeout_emits_worker_timeout(adapter, fake_msg_factory, make_request_payload):
     payload = make_request_payload(stream=False)
     msg = fake_msg_factory(payload)
     adapter._client.post.side_effect = httpx.TimeoutException("upstream timeout")
@@ -110,9 +107,7 @@ async def test_error_timeout_emits_worker_timeout(
 
 
 @pytest.mark.asyncio
-async def test_error_5xx_emits_upstream_5xx(
-    adapter, fake_msg_factory, make_request_payload
-):
+async def test_error_5xx_emits_upstream_5xx(adapter, fake_msg_factory, make_request_payload):
     payload = make_request_payload(stream=False)
     msg = fake_msg_factory(payload)
 
@@ -145,9 +140,7 @@ async def test_error_connect_emits_upstream_unavailable(
 
 
 @pytest.mark.asyncio
-async def test_error_parse_emits_transport_parse(
-    adapter, fake_msg_factory, make_request_payload
-):
+async def test_error_parse_emits_transport_parse(adapter, fake_msg_factory, make_request_payload):
     payload = make_request_payload(stream=True)
     msg = fake_msg_factory(payload)
 
@@ -177,9 +170,7 @@ async def test_error_parse_emits_transport_parse(
 
 
 @pytest.mark.asyncio
-async def test_error_generic_emits_worker_internal(
-    adapter, fake_msg_factory, make_request_payload
-):
+async def test_error_generic_emits_worker_internal(adapter, fake_msg_factory, make_request_payload):
     payload = make_request_payload(stream=False)
     msg = fake_msg_factory(payload)
     adapter._client.post.side_effect = RuntimeError("kaboom")
@@ -317,9 +308,7 @@ def test_heartbeat_vram_used_zero_when_nvml_unavailable(adapter, monkeypatch):
     import llmcli.gpu as gpu_mod
 
     monkeypatch.setattr(gpu_mod, "probe_free_vram_gib", lambda: 8.0)
-    monkeypatch.setattr(
-        LlmNatsAdapter, "_get_nvml_handle", lambda self: None
-    )
+    monkeypatch.setattr(LlmNatsAdapter, "_get_nvml_handle", lambda self: None)
 
     p = adapter.heartbeat_payload()
 
@@ -332,9 +321,7 @@ def test_heartbeat_vram_used_zero_when_nvml_query_fails(adapter, monkeypatch):
     import llmcli.gpu as gpu_mod
 
     monkeypatch.setattr(gpu_mod, "probe_free_vram_gib", lambda: 8.0)
-    monkeypatch.setattr(
-        LlmNatsAdapter, "_get_nvml_handle", lambda self: "fake-handle"
-    )
+    monkeypatch.setattr(LlmNatsAdapter, "_get_nvml_handle", lambda self: "fake-handle")
 
     fake_pynvml = MagicMock()
     fake_pynvml.nvmlDeviceGetMemoryInfo.side_effect = RuntimeError("nvml query failed")

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -301,7 +301,9 @@ class TestProbeVramFallback:
 class TestEngineStartReapsZombie:
     """B3: LlamaCppEngine.start() reaps the subprocess when it exits before /health."""
 
-    def test_start_raises_on_early_exit(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_start_raises_on_early_exit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """start() raises RuntimeError (not hangs) when llama-server exits early."""
         # Create a fake GGUF so path resolution doesn't fail
         hub = tmp_path / "hub"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -149,18 +149,14 @@ class TestListCommand:
         # Act
         result = runner.invoke(app, ["list"])
         # Assert — RED: stub prints nothing
-        assert "6" in result.output, (
-            f"Expected VRAM (6.0) in output but got: {result.output!r}"
-        )
+        assert "6" in result.output, f"Expected VRAM (6.0) in output but got: {result.output!r}"
 
     def test_list_prints_port(self, fake_catalog, mock_daemon_socket) -> None:
         """list output contains the port number."""
         # Act
         result = runner.invoke(app, ["list"])
         # Assert — RED: stub prints nothing
-        assert "8091" in result.output, (
-            f"Expected port 8091 in output but got: {result.output!r}"
-        )
+        assert "8091" in result.output, f"Expected port 8091 in output but got: {result.output!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +177,9 @@ class TestPullCommand:
     def test_pull_invokes_hf_download_for_known_model(self, fake_catalog) -> None:
         """pull <known-model> calls the HF hub download function."""
         # Arrange
-        with patch("llmcli.cli.hf_hub_download", create=True, return_value="/tmp/fake.gguf") as mock_hf:
+        with patch(
+            "llmcli.cli.hf_hub_download", create=True, return_value="/tmp/fake.gguf"
+        ) as mock_hf:
             # Act
             runner.invoke(app, ["pull", "small-q4"])
         # Assert — RED: stub never calls hf_hub_download
@@ -192,9 +190,7 @@ class TestPullCommand:
         # Act
         result = runner.invoke(app, ["pull", "does-not-exist"])
         # Assert — RED: stub exits 0 for everything
-        assert result.exit_code != 0, (
-            "Expected non-zero exit for unknown model, got 0"
-        )
+        assert result.exit_code != 0, "Expected non-zero exit for unknown model, got 0"
 
     def test_pull_unknown_model_shows_available_names(self, fake_catalog) -> None:
         """pull <unknown-model> output mentions available model names as a helpful hint."""
@@ -260,9 +256,7 @@ class TestServeCommand:
         # Act
         result = runner.invoke(app, ["serve", "--name", "big-model"])
         # Assert — RED: stub exits 0 for everything
-        assert result.exit_code != 0, (
-            "Expected non-zero exit when model exceeds VRAM budget, got 0"
-        )
+        assert result.exit_code != 0, "Expected non-zero exit when model exceeds VRAM budget, got 0"
 
     def test_serve_vram_error_mentions_model_and_budget(self, fake_catalog) -> None:
         """serve --name <oversized-model> output contains helpful VRAM info."""
@@ -271,8 +265,7 @@ class TestServeCommand:
         combined = result.output + (result.stderr or "")
         # Assert — RED: stub outputs nothing
         assert any(
-            keyword in combined
-            for keyword in ("big-model", "13", "10", "vram", "VRAM", "budget")
+            keyword in combined for keyword in ("big-model", "13", "10", "vram", "VRAM", "budget")
         ), f"Expected VRAM error details in output, got: {combined!r}"
 
     def test_serve_unknown_model_exits_nonzero(self, fake_catalog) -> None:
@@ -349,9 +342,7 @@ class TestStatusCommand:
 
 
 class TestChatCommand:
-    def test_chat_exits_zero(
-        self, fake_catalog, mock_daemon_socket, mock_openai_client
-    ) -> None:
+    def test_chat_exits_zero(self, fake_catalog, mock_daemon_socket, mock_openai_client) -> None:
         """chat exits 0 on success."""
         # Act
         result = runner.invoke(app, ["chat", "small-q4", "ping"])
@@ -365,9 +356,7 @@ class TestChatCommand:
         # Act
         result = runner.invoke(app, ["chat", "small-q4", "ping"])
         # Assert — RED: stub prints nothing
-        assert "pong" in result.output, (
-            f"Expected 'pong' in chat output, got: {result.output!r}"
-        )
+        assert "pong" in result.output, f"Expected 'pong' in chat output, got: {result.output!r}"
 
     def test_chat_invokes_openai_completions(
         self, fake_catalog, mock_daemon_socket, mock_openai_client
@@ -552,9 +541,9 @@ class TestRegisterProxyCommand:
         ):
             result = runner.invoke(app, ["register-proxy", "--config", config_file])
         combined = result.output + (result.stderr or "")
-        assert any(
-            kw in combined.lower() for kw in ("reload", "warn", "failed", "succeeded")
-        ), f"Expected warning in output, got: {combined!r}"
+        assert any(kw in combined.lower() for kw in ("reload", "warn", "failed", "succeeded")), (
+            f"Expected warning in output, got: {combined!r}"
+        )
 
     def test_register_proxy_success_output_contains_path(self, fake_catalog, tmp_path) -> None:
         """Success output contains part of the config path that was updated (SC-9 confirmation).
@@ -588,13 +577,9 @@ class TestRegisterProxyCommand:
         ):
             result = runner.invoke(app, ["register-proxy", "--config", config_file])
         # fake_catalog has 2 models: small-q4 + big-model
-        assert "2" in result.output, (
-            f"Expected model count (2) in output, got: {result.output!r}"
-        )
+        assert "2" in result.output, f"Expected model count (2) in output, got: {result.output!r}"
 
-    def test_register_proxy_missing_parent_dir_exits_nonzero(
-        self, fake_catalog, tmp_path
-    ) -> None:
+    def test_register_proxy_missing_parent_dir_exits_nonzero(self, fake_catalog, tmp_path) -> None:
         """register-proxy exits non-zero with a helpful error when parent dir is missing."""
         nonexistent = str(tmp_path / "does_not_exist" / "config.yaml")
         with (
@@ -605,9 +590,7 @@ class TestRegisterProxyCommand:
             result = runner.invoke(app, ["register-proxy", "--config", nonexistent])
         assert result.exit_code != 0
 
-    def test_register_proxy_missing_parent_dir_mentions_mkdir(
-        self, fake_catalog, tmp_path
-    ) -> None:
+    def test_register_proxy_missing_parent_dir_mentions_mkdir(self, fake_catalog, tmp_path) -> None:
         """Friendly error for missing parent dir mentions how to create it."""
         nonexistent = str(tmp_path / "does_not_exist" / "config.yaml")
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -604,6 +604,80 @@ class TestRegisterProxyCommand:
             f"Expected mkdir hint or dir name in error output, got: {combined!r}"
         )
 
+    def test_register_proxy_mixed_catalog_writes_both_local_and_remote(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Mixed catalog: both local (llamacpp) and remote (fireworks/openai) entries appear
+        in the written litellm config block.
+        """
+        from llmcli import config as real_config
+        from llmcli.config import Catalog, HostSettings, ModelSpec
+        from llmcli.litellm_config import BLOCK_START, BLOCK_END
+
+        import yaml
+
+        # Build a catalog with 1 local + 1 remote spec.
+        host = HostSettings(
+            bind="0.0.0.0",
+            public_base_url="http://localhost",
+            api_key_env="LLMCLI_API_KEY",
+        )
+        local_spec = ModelSpec(
+            name="small-local",
+            engine="llamacpp",
+            repo="Org/Small-GGUF",
+            file="small.gguf",
+            port=8091,
+            vram_gib=5.0,
+        )
+        remote_spec = ModelSpec(
+            name="kimi-remote",
+            engine="remote",
+            provider="fireworks",
+            model_id="accounts/fireworks/models/kimi",
+            protocol="openai",
+        )
+        mixed_catalog = Catalog(
+            host=host, models={"small-local": local_spec, "kimi-remote": remote_spec}
+        )
+
+        config_path = tmp_path / "config.yaml"
+
+        with (
+            patch("llmcli.cli.config", create=True) as mock_config_mod,
+            patch("llmcli.cli.reload_proxy", create=True),
+        ):
+            mock_config_mod.load.return_value = mixed_catalog
+            mock_config_mod.check_vram_budget.side_effect = (
+                real_config.check_vram_budget
+            )
+            result = runner.invoke(
+                app, ["register-proxy", "--config", str(config_path)]
+            )
+
+        assert result.exit_code == 0, f"Unexpected exit: {result.output}"
+        assert config_path.exists(), "Config file was not created"
+
+        content = config_path.read_text()
+        assert BLOCK_START in content
+        assert BLOCK_END in content
+
+        inner = content.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        names_in_block = {entry["model_name"] for entry in parsed["model_list"]}
+        assert "small-local" in names_in_block, "Local entry missing from written block"
+        assert "kimi-remote" in names_in_block, "Remote entry missing from written block"
+
+        by_name = {e["model_name"]: e for e in parsed["model_list"]}
+        # Local entry: model=openai/<name>, local api_base
+        local_entry = by_name["small-local"]
+        assert local_entry["litellm_params"]["model"] == "openai/small-local"
+        assert "8091" in local_entry["litellm_params"]["api_base"]
+        # Remote entry: model=openai/<model_id>, provider api_base
+        remote_entry = by_name["kimi-remote"]
+        assert remote_entry["litellm_params"]["model"] == "openai/accounts/fireworks/models/kimi"
+        assert "fireworks" in remote_entry["litellm_params"]["api_base"]
+
 
 # ---------------------------------------------------------------------------
 # --help — all commands registered

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,12 +15,21 @@ from pathlib import Path
 
 import pytest
 
-from llmcli.config import Catalog, HostSettings, ModelSpec, _parse_model_spec, load, check_vram_budget
+from llmcli.config import (
+    Catalog,
+    HostSettings,
+    ModelSpec,
+    _parse_model_spec,
+    load,
+    check_vram_budget,
+)
+from llmcli.providers import PROVIDERS
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _write_toml(tmp_path: Path, content: str) -> Path:
     p = tmp_path / "llmcli.toml"
@@ -129,16 +138,18 @@ class TestLoad:
         assert isinstance(catalog.host, HostSettings)
         # models/ dir is sibling to llmcli.example.toml; must have at least one model
         assert len(catalog.models) >= 1
+        valid_engines = {"llamacpp", "llamacpp_tq3", "vllm", "remote"}
         for name, spec in catalog.models.items():
             assert spec.name == name
-            assert spec.port > 0
-            assert spec.vram_gib > 0
-            assert spec.engine in ("llamacpp", "llamacpp_tq3")
+            assert spec.engine in valid_engines
+            if spec.engine != "remote":
+                assert spec.port > 0
+                assert spec.vram_gib > 0
 
     def test_load_models_dir_loaded(self, tmp_path: Path) -> None:
         """Models defined in models/*.toml are merged into the catalog."""
         # Arrange
-        toml_path = _write_toml(tmp_path, "[host]\nbind = \"0.0.0.0\"\n")
+        toml_path = _write_toml(tmp_path, '[host]\nbind = "0.0.0.0"\n')
         models_dir = tmp_path / "models"
         models_dir.mkdir()
         (models_dir / "my-model.toml").write_text(
@@ -365,3 +376,126 @@ class TestFriendlyErrors:
         # Act / Assert
         with pytest.raises((TypeError, KeyError, ValueError)):
             load(toml_path)
+
+
+# ---------------------------------------------------------------------------
+# Remote engine specs (issue #36)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteEngineSpec:
+    def test_remote_openai_protocol_loads(self, tmp_path: Path) -> None:
+        """A remote spec with provider=fireworks and protocol=openai loads successfully."""
+        # Arrange
+        toml_path = _write_toml(
+            tmp_path,
+            '[host]\nbind = "0.0.0.0"\n\n[models.kimi]\nengine = "remote"\n'
+            'provider = "fireworks"\nmodel_id = "accounts/fireworks/models/kimi"\nprotocol = "openai"\n',
+        )
+        # Act
+        catalog = load(toml_path)
+        # Assert
+        spec = catalog.models["kimi"]
+        assert spec.engine == "remote"
+        assert spec.provider == "fireworks"
+        assert spec.model_id == "accounts/fireworks/models/kimi"
+        assert spec.protocol == "openai"
+
+    def test_remote_anthropic_protocol_loads(self, tmp_path: Path) -> None:
+        """A remote spec with provider=anthropic and protocol=anthropic loads successfully."""
+        # Arrange
+        toml_path = _write_toml(
+            tmp_path,
+            '[host]\nbind = "0.0.0.0"\n\n[models.claude]\nengine = "remote"\n'
+            'provider = "anthropic"\nmodel_id = "claude-sonnet-4-6"\nprotocol = "anthropic"\n',
+        )
+        # Act
+        catalog = load(toml_path)
+        # Assert
+        spec = catalog.models["claude"]
+        assert spec.engine == "remote"
+        assert spec.provider == "anthropic"
+        assert spec.model_id == "claude-sonnet-4-6"
+        assert spec.protocol == "anthropic"
+
+    def test_remote_unknown_provider_raises(self) -> None:
+        """engine='remote' with an unknown provider raises ValueError."""
+        # Arrange
+        raw = {
+            "engine": "remote",
+            "provider": "does-not-exist",
+            "model_id": "some/model",
+            "protocol": "openai",
+        }
+        # Act / Assert
+        with pytest.raises(ValueError, match="unknown provider"):
+            _parse_model_spec("test-model", raw)
+
+    def test_remote_with_repo_raises(self) -> None:
+        """engine='remote' mixed with local field 'repo' raises ValueError."""
+        # Arrange
+        raw = {
+            "engine": "remote",
+            "provider": "fireworks",
+            "model_id": "some/model",
+            "protocol": "openai",
+            "repo": "Org/Model-GGUF",
+        }
+        # Act / Assert
+        with pytest.raises(ValueError, match="local-engine fields"):
+            _parse_model_spec("test-model", raw)
+
+    def test_local_engine_with_provider_raises(self) -> None:
+        """engine='llamacpp' mixed with remote field 'provider' raises ValueError."""
+        # Arrange
+        raw = {
+            "engine": "llamacpp",
+            "repo": "Org/Model-GGUF",
+            "port": 8091,
+            "vram_gib": 6.0,
+            "provider": "fireworks",
+        }
+        # Act / Assert
+        with pytest.raises(ValueError, match="remote-engine fields"):
+            _parse_model_spec("test-model", raw)
+
+    def test_machines_defaults_to_empty_list(self) -> None:
+        """ModelSpec.machines defaults to [] when not specified."""
+        # Arrange
+        raw = {
+            "engine": "remote",
+            "provider": "fireworks",
+            "model_id": "some/model",
+            "protocol": "openai",
+        }
+        # Act
+        spec = _parse_model_spec("test-model", raw)
+        # Assert
+        assert spec.machines == []
+
+    def test_machines_parses_correctly(self) -> None:
+        """ModelSpec.machines parses a list of hostnames correctly."""
+        # Arrange
+        raw = {
+            "engine": "llamacpp",
+            "repo": "Org/Model-GGUF",
+            "port": 8091,
+            "vram_gib": 6.0,
+            "machines": ["roxabitower"],
+        }
+        # Act
+        spec = _parse_model_spec("test-model", raw)
+        # Assert
+        assert spec.machines == ["roxabitower"]
+
+    def test_all_known_providers_are_valid(self) -> None:
+        """Each key in PROVIDERS can be used as provider in a remote spec."""
+        for provider_key in PROVIDERS:
+            raw = {
+                "engine": "remote",
+                "provider": provider_key,
+                "model_id": "some/model",
+                "protocol": "openai",
+            }
+            spec = _parse_model_spec(f"test-{provider_key}", raw)
+            assert spec.provider == provider_key

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -459,20 +459,6 @@ class TestRemoteEngineSpec:
         with pytest.raises(ValueError, match="remote-engine fields"):
             _parse_model_spec("test-model", raw)
 
-    def test_machines_defaults_to_empty_list(self) -> None:
-        """ModelSpec.machines defaults to [] when not specified."""
-        # Arrange
-        raw = {
-            "engine": "remote",
-            "provider": "fireworks",
-            "model_id": "some/model",
-            "protocol": "openai",
-        }
-        # Act
-        spec = _parse_model_spec("test-model", raw)
-        # Assert
-        assert spec.machines == []
-
     def test_machines_parses_correctly(self) -> None:
         """ModelSpec.machines parses a list of hostnames correctly."""
         # Arrange
@@ -490,12 +476,91 @@ class TestRemoteEngineSpec:
 
     def test_all_known_providers_are_valid(self) -> None:
         """Each key in PROVIDERS can be used as provider in a remote spec."""
+        # implicit: no ValueError raised — purpose is to confirm all PROVIDERS pass validation.
         for provider_key in PROVIDERS:
+            # Anthropic requires protocol='anthropic'; all others use 'openai'.
+            protocol = "anthropic" if provider_key == "anthropic" else "openai"
             raw = {
                 "engine": "remote",
                 "provider": provider_key,
                 "model_id": "some/model",
-                "protocol": "openai",
+                "protocol": protocol,
             }
-            spec = _parse_model_spec(f"test-{provider_key}", raw)
-            assert spec.provider == provider_key
+            _parse_model_spec(f"test-{provider_key}", raw)
+
+    def test_unknown_provider_in_iteration_raises(self) -> None:
+        """A provider key NOT in PROVIDERS is rejected by _parse_model_spec."""
+        raw = {
+            "engine": "remote",
+            "provider": "not-a-real-provider",
+            "model_id": "some/model",
+            "protocol": "openai",
+        }
+        with pytest.raises(ValueError, match="unknown provider"):
+            _parse_model_spec("test-unknown", raw)
+
+    def test_machines_field_default_is_empty_list(self) -> None:
+        """ModelSpec.machines defaults to [] when not specified (direct construction)."""
+        # Arrange
+        raw = {
+            "engine": "remote",
+            "provider": "fireworks",
+            "model_id": "some/model",
+            "protocol": "openai",
+        }
+        # Act
+        spec = _parse_model_spec("test-model", raw)
+        # Assert
+        assert spec.machines == []
+
+    def test_machines_absent_from_toml_yields_empty_list(self, tmp_path: Path) -> None:
+        """ModelSpec.machines is [] when not present in TOML (load-path test)."""
+        toml_path = _write_toml(
+            tmp_path,
+            '[host]\nbind = "0.0.0.0"\n\n[models.kimi]\nengine = "remote"\n'
+            'provider = "fireworks"\nmodel_id = "accounts/fireworks/models/kimi"\nprotocol = "openai"\n',
+        )
+        catalog = load(toml_path)
+        assert catalog.models["kimi"].machines == []
+
+    def test_remote_with_extra_unknown_field_raises(self) -> None:
+        """engine='remote' with an unknown field raises TypeError from ModelSpec dataclass."""
+        raw = {
+            "engine": "remote",
+            "provider": "fireworks",
+            "model_id": "some/model",
+            "protocol": "openai",
+            "junk": "x",
+        }
+        with pytest.raises(TypeError):
+            _parse_model_spec("test-model", raw)
+
+    def test_remote_missing_provider_raises(self) -> None:
+        """engine='remote' without 'provider' raises ValueError matching 'missing required field'."""
+        raw = {"engine": "remote", "model_id": "m", "protocol": "openai"}
+        with pytest.raises(ValueError, match="missing required field 'provider'"):
+            _parse_model_spec("test-model", raw)
+
+    def test_remote_missing_model_id_raises(self) -> None:
+        """engine='remote' without 'model_id' raises ValueError matching 'missing required field'."""
+        raw = {"engine": "remote", "provider": "fireworks", "protocol": "openai"}
+        with pytest.raises(ValueError, match="missing required field 'model_id'"):
+            _parse_model_spec("test-model", raw)
+
+    def test_remote_invalid_protocol_raises(self) -> None:
+        """engine='remote' with unsupported protocol raises ValueError matching 'invalid protocol'."""
+        raw = {"engine": "remote", "provider": "fireworks", "model_id": "m", "protocol": "grpc"}
+        with pytest.raises(ValueError, match="invalid protocol"):
+            _parse_model_spec("test-model", raw)
+
+    def test_unknown_engine_raises(self) -> None:
+        """An unrecognised engine value raises ValueError matching 'unknown engine'."""
+        raw = {"engine": "deepspeed", "repo": "Org/M"}
+        with pytest.raises(ValueError, match="unknown engine"):
+            _parse_model_spec("test-model", raw)
+
+    def test_missing_engine_raises(self) -> None:
+        """A spec without 'engine' raises ValueError matching 'missing required field'."""
+        raw = {"repo": "Org/M"}
+        with pytest.raises(ValueError, match="missing required field 'engine'"):
+            _parse_model_spec("test-model", raw)

--- a/tests/test_daemon_socket.py
+++ b/tests/test_daemon_socket.py
@@ -14,6 +14,7 @@ Expected RED failures against current scaffold:
 
 All tests use tmp_path for socket path — no hardcoded /tmp.
 """
+
 from __future__ import annotations
 
 import socket
@@ -218,9 +219,7 @@ class TestStatusCommand:
         assert "qwen3-test" in response, (
             f"STATUS must include model name 'qwen3-test', got: {response!r}"
         )
-        assert "8091" in response, (
-            f"STATUS must include port '8091', got: {response!r}"
-        )
+        assert "8091" in response, f"STATUS must include port '8091', got: {response!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -263,9 +262,7 @@ class TestShutdownCommand:
             bad_conn.settimeout(1.0)
             bad_conn.connect(str(sock_path))
             bad_conn.close()
-            pytest.fail(
-                "Expected connection refused after SHUTDOWN, but connect succeeded"
-            )
+            pytest.fail("Expected connection refused after SHUTDOWN, but connect succeeded")
         except (ConnectionRefusedError, FileNotFoundError, OSError):
             pass  # expected
 
@@ -316,9 +313,7 @@ class TestShutdownCommand:
             time.sleep(0.05)
 
         # Assert
-        assert not sock_path.exists(), (
-            "Daemon must remove the socket file after SHUTDOWN"
-        )
+        assert not sock_path.exists(), "Daemon must remove the socket file after SHUTDOWN"
 
 
 # ---------------------------------------------------------------------------
@@ -465,9 +460,7 @@ class TestUnknownCommand:
             conn.close()
 
         # Assert
-        assert response.startswith("ERR"), (
-            f"Empty command must return ERR line, got: {response!r}"
-        )
+        assert response.startswith("ERR"), f"Empty command must return ERR line, got: {response!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine_instance.py
+++ b/tests/test_engine_instance.py
@@ -9,6 +9,7 @@ Expected RED failures against current scaffold:
 - EngineInstance lacks 'base_url' field / property
 - Engine Protocol still exposes 'base_url' (must be removed)
 """
+
 from __future__ import annotations
 
 import inspect

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -17,8 +17,11 @@ from pathlib import Path
 import pytest
 import yaml
 
+from unittest.mock import patch
+
 from llmcli.config import Catalog, HostSettings, ModelSpec
 from llmcli.litellm_config import BLOCK_END, BLOCK_START, build_block, write_block
+from llmcli.providers import PROVIDERS
 
 
 # ---------------------------------------------------------------------------
@@ -84,9 +87,7 @@ def _make_catalog(models: dict[str, dict] | None = None) -> Catalog:
                 vram_gib=12.4,
             ),
         }
-    model_specs = {
-        name: ModelSpec(name=name, **spec) for name, spec in models.items()
-    }
+    model_specs = {name: ModelSpec(name=name, **spec) for name, spec in models.items()}
     return Catalog(host=host, models=model_specs)
 
 
@@ -146,9 +147,7 @@ class TestBuildBlock:
         """Every model in catalog.models appears as a model_name entry."""
         # Arrange / Act
         result = build_block(catalog, PUBLIC_BASE_URL)
-        parsed = yaml.safe_load(
-            result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
-        )
+        parsed = yaml.safe_load(result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip())
         # Assert
         names_in_block = {entry["model_name"] for entry in parsed["model_list"]}
         assert names_in_block == set(catalog.models.keys())
@@ -157,9 +156,7 @@ class TestBuildBlock:
         """Each entry's litellm_params.model is prefixed with 'openai/'."""
         # Arrange / Act
         result = build_block(catalog, PUBLIC_BASE_URL)
-        parsed = yaml.safe_load(
-            result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
-        )
+        parsed = yaml.safe_load(result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip())
         # Assert
         for entry in parsed["model_list"]:
             assert entry["litellm_params"]["model"].startswith("openai/")
@@ -169,9 +166,7 @@ class TestBuildBlock:
         """api_base is '{public_base_url}:{model.port}/v1' for each model."""
         # Arrange / Act
         result = build_block(catalog, PUBLIC_BASE_URL)
-        parsed = yaml.safe_load(
-            result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
-        )
+        parsed = yaml.safe_load(result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip())
         # Assert
         by_name = {e["model_name"]: e for e in parsed["model_list"]}
         for name, spec in catalog.models.items():
@@ -182,9 +177,7 @@ class TestBuildBlock:
         """api_key is 'os.environ/<api_key_env>' from HostSettings."""
         # Arrange / Act
         result = build_block(catalog, PUBLIC_BASE_URL)
-        parsed = yaml.safe_load(
-            result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
-        )
+        parsed = yaml.safe_load(result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip())
         # Assert
         expected_key = f"os.environ/{catalog.host.api_key_env}"
         for entry in parsed["model_list"]:
@@ -430,3 +423,234 @@ class TestWriteBlockMalformed:
         # Act / Assert
         with pytest.raises((ValueError, RuntimeError, OSError)):
             write_block(block, config_path)
+
+
+# ---------------------------------------------------------------------------
+# Remote engine + hostname filter (issue #36)
+# ---------------------------------------------------------------------------
+
+
+def _make_remote_catalog(
+    engine_type: str = "openai",
+    machines: list[str] | None = None,
+) -> Catalog:
+    """Build a catalog with a single remote model spec."""
+    host = HostSettings(
+        bind="0.0.0.0",
+        public_base_url=PUBLIC_BASE_URL,
+        api_key_env="LLMCLI_API_KEY",
+    )
+    if engine_type == "anthropic":
+        spec = ModelSpec(
+            name="claude-sonnet",
+            engine="remote",
+            provider="anthropic",
+            model_id="claude-sonnet-4-6",
+            protocol="anthropic",
+            machines=machines or [],
+        )
+    else:
+        spec = ModelSpec(
+            name="kimi-k2",
+            engine="remote",
+            provider="fireworks",
+            model_id="accounts/fireworks/models/kimi",
+            protocol="openai",
+            machines=machines or [],
+        )
+    return Catalog(host=host, models={spec.name: spec})
+
+
+class TestBuildBlockRemoteEngines:
+    def test_remote_openai_entry_model_prefix(self) -> None:
+        """Remote+openai entry has model='openai/<model_id>' (NOT the catalog key)."""
+        # Arrange
+        catalog = _make_remote_catalog("openai")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["model"] == "openai/accounts/fireworks/models/kimi"
+
+    def test_remote_openai_entry_has_provider_api_base(self) -> None:
+        """Remote+openai entry uses provider's api_base (not a local port)."""
+        # Arrange
+        catalog = _make_remote_catalog("openai")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["api_base"] == PROVIDERS["fireworks"].api_base
+        # No port-based local URL
+        assert ":8091" not in entry["litellm_params"]["api_base"]
+
+    def test_remote_openai_entry_uses_provider_key_env(self) -> None:
+        """Remote+openai entry references provider's key_env, not LLMCLI_API_KEY."""
+        # Arrange
+        catalog = _make_remote_catalog("openai")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["api_key"] == f"os.environ/{PROVIDERS['fireworks'].key_env}"
+
+    def test_remote_anthropic_entry_model_prefix(self) -> None:
+        """Remote+anthropic entry has model='anthropic/<model_id>'."""
+        # Arrange
+        catalog = _make_remote_catalog("anthropic")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["model"] == "anthropic/claude-sonnet-4-6"
+
+    def test_remote_anthropic_entry_has_no_api_base(self) -> None:
+        """Remote+anthropic entry must NOT have api_base — LiteLLM resolves it natively."""
+        # Arrange
+        catalog = _make_remote_catalog("anthropic")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert "api_base" not in entry["litellm_params"]
+
+    def test_remote_anthropic_entry_uses_provider_key_env(self) -> None:
+        """Remote+anthropic entry references ANTHROPIC_API_KEY."""
+        # Arrange
+        catalog = _make_remote_catalog("anthropic")
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["api_key"] == f"os.environ/{PROVIDERS['anthropic'].key_env}"
+
+    def test_local_llamacpp_entry_unchanged(self) -> None:
+        """Local llamacpp entry still emits openai/<name> + local api_base."""
+        # Arrange
+        host = HostSettings(
+            bind="0.0.0.0",
+            public_base_url=PUBLIC_BASE_URL,
+            api_key_env="LLMCLI_API_KEY",
+        )
+        spec = ModelSpec(
+            name="qwen3-8b",
+            engine="llamacpp",
+            repo="Org/Qwen3-8B-GGUF",
+            file="qwen3-8b-q4_k_m.gguf",
+            port=8091,
+            vram_gib=5.5,
+        )
+        catalog = Catalog(host=host, models={"qwen3-8b": spec})
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        entry = parsed["model_list"][0]
+        assert entry["litellm_params"]["model"] == "openai/qwen3-8b"
+        assert entry["litellm_params"]["api_base"] == f"{PUBLIC_BASE_URL}:8091/v1"
+        assert entry["litellm_params"]["api_key"] == "os.environ/LLMCLI_API_KEY"
+
+
+class TestBuildBlockHostnameFilter:
+    def test_spec_without_machines_included_for_any_hostname(self) -> None:
+        """A spec with machines=[] is included regardless of hostname."""
+        # Arrange
+        catalog = _make_remote_catalog("openai", machines=[])
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="any-random-host")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert — spec included
+        assert parsed["model_list"] is not None
+        assert len(parsed["model_list"]) == 1
+
+    def test_spec_with_machines_included_when_hostname_matches(self) -> None:
+        """A spec with machines=["roxabitower"] is included when hostname matches."""
+        # Arrange
+        catalog = _make_remote_catalog("openai", machines=["roxabitower"])
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="roxabitower")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert
+        assert parsed["model_list"] is not None
+        assert len(parsed["model_list"]) == 1
+
+    def test_spec_with_machines_excluded_when_hostname_does_not_match(self) -> None:
+        """A spec with machines=["roxabitower"] is excluded when hostname differs."""
+        # Arrange
+        catalog = _make_remote_catalog("openai", machines=["roxabitower"])
+        # Act
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="roxabituwer")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert — spec filtered out, model_list is null/empty
+        model_list = parsed.get("model_list") if parsed else None
+        assert not model_list
+
+    def test_mixed_catalog_hostname_filter(self) -> None:
+        """Catalog with two specs: one pinned to 'other-host', one open — filtered correctly."""
+        # Arrange
+        host = HostSettings(
+            bind="0.0.0.0",
+            public_base_url=PUBLIC_BASE_URL,
+            api_key_env="LLMCLI_API_KEY",
+        )
+        pinned_spec = ModelSpec(
+            name="pinned-model",
+            engine="remote",
+            provider="fireworks",
+            model_id="accounts/fireworks/models/x",
+            protocol="openai",
+            machines=["other-host"],
+        )
+        open_spec = ModelSpec(
+            name="open-model",
+            engine="remote",
+            provider="openai",
+            model_id="gpt-4o",
+            protocol="openai",
+            machines=[],
+        )
+        catalog = Catalog(host=host, models={"pinned-model": pinned_spec, "open-model": open_spec})
+
+        # When hostname="other-host" → both included
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="other-host")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        names = {e["model_name"] for e in parsed["model_list"]}
+        assert names == {"pinned-model", "open-model"}
+
+        # When hostname="this-host" → only open-model included
+        result2 = build_block(catalog, PUBLIC_BASE_URL, hostname="this-host")
+        inner2 = result2.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed2 = yaml.safe_load(inner2)
+        names2 = {e["model_name"] for e in parsed2["model_list"]}
+        assert names2 == {"open-model"}
+
+    def test_build_block_uses_real_hostname_by_default(self) -> None:
+        """build_block uses socket.gethostname() when hostname kwarg is omitted."""
+        # Arrange — catalog with a spec pinned to a hostname that won't match real hostname
+        real_hostname = "definitely-not-this-host-12345"
+        catalog = _make_remote_catalog("openai", machines=[real_hostname])
+        # Act — no hostname kwarg → falls through to socket.gethostname()
+        with patch("llmcli.litellm_config.socket.gethostname", return_value="some-other-host"):
+            result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert — spec excluded because mocked hostname doesn't match
+        model_list = parsed.get("model_list") if parsed else None
+        assert not model_list

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -152,8 +152,12 @@ class TestBuildBlock:
         names_in_block = {entry["model_name"] for entry in parsed["model_list"]}
         assert names_in_block == set(catalog.models.keys())
 
-    def test_block_litellm_params_model_prefix(self, catalog: Catalog) -> None:
-        """Each entry's litellm_params.model is prefixed with 'openai/'."""
+    def test_local_block_litellm_params_model_prefix(self, catalog: Catalog) -> None:
+        """Each local-engine entry's litellm_params.model is 'openai/<name>'."""
+        # This test only applies to local-engine catalogs.
+        assert all(spec.engine != "remote" for spec in catalog.models.values()), (
+            "this test only applies to local-engine catalogs"
+        )
         # Arrange / Act
         result = build_block(catalog, PUBLIC_BASE_URL)
         parsed = yaml.safe_load(result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip())
@@ -652,5 +656,36 @@ class TestBuildBlockHostnameFilter:
         inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
         parsed = yaml.safe_load(inner)
         # Assert — spec excluded because mocked hostname doesn't match
+        model_list = parsed.get("model_list") if parsed else None
+        assert not model_list
+
+    def test_build_block_default_hostname_includes_when_matching(self) -> None:
+        """build_block includes spec when mocked gethostname() matches the machines list."""
+        # Arrange — catalog pinned to "matching-host"
+        catalog = _make_remote_catalog("openai", machines=["matching-host"])
+        # Act — no hostname kwarg → falls through to socket.gethostname() (mocked to match)
+        with patch("llmcli.litellm_config.socket.gethostname", return_value="matching-host"):
+            result = build_block(catalog, PUBLIC_BASE_URL)
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        # Assert — spec included because mocked hostname matches
+        assert parsed["model_list"] is not None
+        assert len(parsed["model_list"]) == 1
+
+    def test_machines_multi_host_includes_when_matching(self) -> None:
+        """Spec with machines=[host-a, host-b] is included when hostname is host-b."""
+        catalog = _make_remote_catalog("openai", machines=["host-a", "host-b"])
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="host-b")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
+        assert parsed["model_list"] is not None
+        assert len(parsed["model_list"]) == 1
+
+    def test_machines_multi_host_excludes_when_no_match(self) -> None:
+        """Spec with machines=[host-a, host-b] is excluded when hostname is host-c."""
+        catalog = _make_remote_catalog("openai", machines=["host-a", "host-b"])
+        result = build_block(catalog, PUBLIC_BASE_URL, hostname="host-c")
+        inner = result.replace(BLOCK_START, "").replace(BLOCK_END, "").strip()
+        parsed = yaml.safe_load(inner)
         model_list = parsed.get("model_list") if parsed else None
         assert not model_list

--- a/tests/test_llamacpp.py
+++ b/tests/test_llamacpp.py
@@ -15,6 +15,7 @@ Markers:
   no_gpu  — CI-safe; no real binary, no GPU required
   gpu     — requires real llama-server binary + GPU; skipped in CI
 """
+
 from __future__ import annotations
 
 import inspect
@@ -33,6 +34,7 @@ from llmcli.engines.llamacpp import LlamaCppEngine
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture()
 def spec() -> ModelSpec:
@@ -95,6 +97,7 @@ def fake_instance() -> EngineInstance:
 # 1. Engine Protocol conformance
 # ---------------------------------------------------------------------------
 
+
 class TestEngineProtocolConformance:
     """LlamaCppEngine must implement the Engine Protocol."""
 
@@ -108,7 +111,9 @@ class TestEngineProtocolConformance:
 
     @pytest.mark.no_gpu
     def test_has_health_method(self, engine: LlamaCppEngine) -> None:
-        assert callable(getattr(engine, "health", None)), "LlamaCppEngine must have a health() method"
+        assert callable(getattr(engine, "health", None)), (
+            "LlamaCppEngine must have a health() method"
+        )
 
     @pytest.mark.no_gpu
     def test_binary_attribute_is_llama_server(self, engine: LlamaCppEngine) -> None:
@@ -143,6 +148,7 @@ class TestEngineProtocolConformance:
 # ---------------------------------------------------------------------------
 # 2. GGUF path resolution from HF hub cache
 # ---------------------------------------------------------------------------
+
 
 class TestGgufPathResolution:
     """Engine must locate the GGUF file in the HF hub snapshot cache."""
@@ -215,6 +221,7 @@ class TestGgufPathResolution:
 # 3. Command-line construction
 # ---------------------------------------------------------------------------
 
+
 class TestCommandLineConstruction:
     """Engine must build a correct llama-server invocation."""
 
@@ -257,9 +264,7 @@ class TestCommandLineConstruction:
         cmd = self._get_cmd(engine, spec)
         assert "--host" in cmd, "command must pass --host flag"
         host_idx = cmd.index("--host")
-        assert cmd[host_idx + 1] == "0.0.0.0", (
-            f"--host must be 0.0.0.0, got {cmd[host_idx + 1]}"
-        )
+        assert cmd[host_idx + 1] == "0.0.0.0", f"--host must be 0.0.0.0, got {cmd[host_idx + 1]}"
 
     @pytest.mark.no_gpu
     def test_build_cmd_includes_catalog_flags(
@@ -346,6 +351,7 @@ class TestCommandLineConstruction:
 # 4. EngineInstance returned by start()
 # ---------------------------------------------------------------------------
 
+
 class TestEngineInstanceShape:
     """start(spec) must return an EngineInstance with required fields populated."""
 
@@ -431,6 +437,7 @@ class TestEngineInstanceShape:
 # 5. health() — HTTP probe
 # ---------------------------------------------------------------------------
 
+
 class TestHealthProbe:
     """health(instance) must probe the /health endpoint and return a bool."""
 
@@ -480,9 +487,7 @@ class TestHealthProbe:
         ):
             result = engine.health(fake_instance)
 
-        assert result is False, (
-            "health() must catch connection errors and return False, not raise"
-        )
+        assert result is False, "health() must catch connection errors and return False, not raise"
 
     @pytest.mark.no_gpu
     def test_health_probes_instance_port(
@@ -507,6 +512,7 @@ class TestHealthProbe:
 # 6. stop() — process teardown
 # ---------------------------------------------------------------------------
 
+
 class TestStopBehaviour:
     """stop(instance) must terminate the process cleanly."""
 
@@ -522,10 +528,7 @@ class TestStopBehaviour:
             with patch("llmcli.engines.llamacpp.os.waitpid", return_value=(fake_instance.pid, 0)):
                 engine.stop(fake_instance)
 
-        sigterm_calls = [
-            call for call in mock_kill.call_args_list
-            if call[0][1] == signal.SIGTERM
-        ]
+        sigterm_calls = [call for call in mock_kill.call_args_list if call[0][1] == signal.SIGTERM]
         assert len(sigterm_calls) >= 1, (
             f"stop() must send at least one SIGTERM; got calls: {mock_kill.call_args_list}"
         )
@@ -558,10 +561,7 @@ class TestStopBehaviour:
             except NotImplementedError:
                 pass  # RED phase — implementation missing
 
-        sigkill_calls = [
-            call for call in mock_kill.call_args_list
-            if call[0][1] == signal.SIGKILL
-        ]
+        sigkill_calls = [call for call in mock_kill.call_args_list if call[0][1] == signal.SIGKILL]
         # In RED this assertion will not be reached due to NotImplementedError above,
         # which causes the test to fail — correct RED behaviour.
         assert len(sigkill_calls) >= 1, "stop() must send SIGKILL after SIGTERM timeout"

--- a/tests/test_llamacpp_tq3.py
+++ b/tests/test_llamacpp_tq3.py
@@ -2,6 +2,7 @@
 
 All tests are @pytest.mark.no_gpu because none invoke a real binary.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -21,9 +22,9 @@ from llmcli.engines.llamacpp_tq3 import LlamaCppTQ3Engine
 def test_is_subclass_of_llamacpp_engine() -> None:
     """LlamaCppTQ3Engine must inherit from LlamaCppEngine to reuse cmd-building logic."""
     # Arrange / Act / Assert — pure reflection, no instantiation needed
-    assert issubclass(
-        LlamaCppTQ3Engine, LlamaCppEngine
-    ), "LlamaCppTQ3Engine must be a subclass of LlamaCppEngine"
+    assert issubclass(LlamaCppTQ3Engine, LlamaCppEngine), (
+        "LlamaCppTQ3Engine must be a subclass of LlamaCppEngine"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_swap.py
+++ b/tests/test_swap.py
@@ -98,13 +98,16 @@ def _make_engine_mock(start_return: EngineInstance) -> MagicMock:
     return engine
 
 
-def _make_instance(model_name: str, port: int, pid: int = 1000, started_at: float = 1.0) -> EngineInstance:
+def _make_instance(
+    model_name: str, port: int, pid: int = 1000, started_at: float = 1.0
+) -> EngineInstance:
     return EngineInstance(pid=pid, port=port, model_name=model_name, started_at=started_at)
 
 
 # ---------------------------------------------------------------------------
 # Helper: build a Daemon with catalog injected + engine factory patched
 # ---------------------------------------------------------------------------
+
 
 def _daemon_with_engines(catalog, engine_map: dict[str, MagicMock]) -> Daemon:
     """Return a Daemon whose _engine_for_spec() returns mock engines by spec.name."""
@@ -128,7 +131,10 @@ class TestDaemonCmdSwapNoEngine:
         # Arrange
         new_inst = _make_instance("model-b", port=8092, pid=2001)
         engine_b = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()},
+        )
         assert not daemon.instances  # no engine running
 
         # Act
@@ -143,7 +149,10 @@ class TestDaemonCmdSwapNoEngine:
         # Arrange
         new_inst = _make_instance("model-b", port=8092, pid=2001)
         engine_b = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()},
+        )
 
         # Act
         daemon._cmd_swap("model-b")
@@ -158,7 +167,10 @@ class TestDaemonCmdSwapNoEngine:
         # Arrange
         new_inst = _make_instance("model-b", port=8092, pid=2001)
         engine_b = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()},
+        )
 
         # Act
         daemon._cmd_swap("model-b")
@@ -171,7 +183,10 @@ class TestDaemonCmdSwapNoEngine:
         # Arrange
         new_inst = _make_instance("model-b", port=8092, pid=2001)
         engine_b = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()},
+        )
 
         # Act
         response = daemon._cmd_swap("model-b")
@@ -192,7 +207,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         call_order: list[str] = []
@@ -215,7 +232,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -232,7 +251,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -253,7 +274,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -272,7 +295,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -292,7 +317,9 @@ class TestDaemonCmdSwapWithRunningEngine:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -317,7 +344,10 @@ class TestDaemonCmdSwapSameModel:
         existing_inst = _make_instance("model-a", port=8091, pid=1001)
         engine_a = _make_engine_mock(existing_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()},
+        )
         daemon.instances["model-a"] = existing_inst
 
         # Act
@@ -337,14 +367,19 @@ class TestDaemonCmdSwapSameModel:
         existing_inst = _make_instance("model-a", port=8091, pid=1001)
         engine_a = _make_engine_mock(existing_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()},
+        )
         daemon.instances["model-a"] = existing_inst
 
         # Act
         response = daemon._cmd_swap("model-a")
 
         # Assert
-        assert response.startswith("OK"), f"Same-model fast-path must return OK line, got: {response!r}"
+        assert response.startswith("OK"), (
+            f"Same-model fast-path must return OK line, got: {response!r}"
+        )
 
 
 @pytest.mark.no_gpu
@@ -360,9 +395,7 @@ class TestDaemonCmdSwapUnknownModel:
         response = daemon._cmd_swap("model-does-not-exist")
 
         # Assert
-        assert response.startswith("ERR"), (
-            f"Unknown model must return ERR line, got: {response!r}"
-        )
+        assert response.startswith("ERR"), f"Unknown model must return ERR line, got: {response!r}"
 
     def test_swap_unknown_model_err_mentions_name(self, real_catalog: config.Catalog) -> None:
         """ERR response for unknown model includes the requested model name."""
@@ -377,13 +410,18 @@ class TestDaemonCmdSwapUnknownModel:
             f"ERR line must reference the unknown model name or 'unknown', got: {response!r}"
         )
 
-    def test_swap_unknown_model_leaves_running_engine_untouched(self, real_catalog: config.Catalog) -> None:
+    def test_swap_unknown_model_leaves_running_engine_untouched(
+        self, real_catalog: config.Catalog
+    ) -> None:
         """ERR on unknown model does not stop the currently running engine."""
         # Arrange
         existing_inst = _make_instance("model-a", port=8091, pid=1001)
         engine_a = _make_engine_mock(existing_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()},
+        )
         daemon.instances["model-a"] = existing_inst
 
         # Act
@@ -391,9 +429,7 @@ class TestDaemonCmdSwapUnknownModel:
 
         # Assert — current engine must not be touched
         engine_a.stop.assert_not_called()
-        assert "model-a" in daemon.instances, (
-            "Running engine must remain tracked after failed swap"
-        )
+        assert "model-a" in daemon.instances, "Running engine must remain tracked after failed swap"
 
 
 @pytest.mark.no_gpu
@@ -427,13 +463,18 @@ class TestDaemonCmdSwapVramGuard:
             f"ERR line must reference VRAM constraint, got: {response!r}"
         )
 
-    def test_swap_oversized_model_leaves_running_engine_untouched(self, real_catalog: config.Catalog) -> None:
+    def test_swap_oversized_model_leaves_running_engine_untouched(
+        self, real_catalog: config.Catalog
+    ) -> None:
         """VRAM-exceeded swap does not stop the currently running engine."""
         # Arrange
         existing_inst = _make_instance("model-a", port=8091, pid=1001)
         engine_a = _make_engine_mock(existing_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()},
+        )
         daemon.instances["model-a"] = existing_inst
 
         # Act
@@ -445,17 +486,22 @@ class TestDaemonCmdSwapVramGuard:
             "Running engine must remain tracked after VRAM-rejected swap"
         )
 
-    def test_swap_oversized_model_does_not_start_new_engine(self, real_catalog: config.Catalog) -> None:
+    def test_swap_oversized_model_does_not_start_new_engine(
+        self, real_catalog: config.Catalog
+    ) -> None:
         """VRAM-exceeded swap does not attempt to start the oversized engine."""
         # Arrange
         engine_oversized = MagicMock()
         engine_oversized.start.return_value = _make_instance("model-oversized", port=8093)
 
-        daemon = _daemon_with_engines(real_catalog, {
-            "model-a": MagicMock(),
-            "model-b": MagicMock(),
-            "model-oversized": engine_oversized,
-        })
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {
+                "model-a": MagicMock(),
+                "model-b": MagicMock(),
+                "model-oversized": engine_oversized,
+            },
+        )
 
         # Act
         daemon._cmd_swap("model-oversized")
@@ -476,18 +522,20 @@ class TestDaemonCmdSwapStartFailure:
         engine_b = MagicMock()
         engine_b.start.side_effect = RuntimeError("llama-server failed to start")
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
         response = daemon._cmd_swap("model-b")
 
         # Assert
-        assert response.startswith("ERR"), (
-            f"Failed start must return ERR line, got: {response!r}"
-        )
+        assert response.startswith("ERR"), f"Failed start must return ERR line, got: {response!r}"
 
-    def test_swap_start_failure_response_contains_error_info(self, real_catalog: config.Catalog) -> None:
+    def test_swap_start_failure_response_contains_error_info(
+        self, real_catalog: config.Catalog
+    ) -> None:
         """ERR line from start failure contains useful context (model or error hint)."""
         # Arrange
         old_inst = _make_instance("model-a", port=8091, pid=1001)
@@ -495,7 +543,9 @@ class TestDaemonCmdSwapStartFailure:
         engine_b = MagicMock()
         engine_b.start.side_effect = RuntimeError("llama-server failed to start")
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         # Act
@@ -519,7 +569,9 @@ class TestDaemonCmdSwapVramOrdering:
         engine_a = _make_engine_mock(old_inst)
         engine_b = _make_engine_mock(new_inst)
 
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog, {"model-a": engine_a, "model-b": engine_b, "model-oversized": MagicMock()}
+        )
         daemon.instances["model-a"] = old_inst
 
         manager = MagicMock()
@@ -554,7 +606,10 @@ class TestDaemonCmdSwapResponseFormat:
         # Arrange — the wire layer adds the newline; _cmd_swap must NOT include one
         new_inst = _make_instance("model-b", port=8092, pid=2002)
         engine_b = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": MagicMock(), "model-b": engine_b, "model-oversized": MagicMock()},
+        )
 
         # Act
         response = daemon._cmd_swap("model-b")
@@ -582,7 +637,10 @@ class TestDaemonCmdSwapResponseFormat:
         # Arrange
         new_inst = _make_instance("model-a", port=8091, pid=1001)
         engine_a = _make_engine_mock(new_inst)
-        daemon = _daemon_with_engines(real_catalog, {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()})
+        daemon = _daemon_with_engines(
+            real_catalog,
+            {"model-a": engine_a, "model-b": MagicMock(), "model-oversized": MagicMock()},
+        )
 
         # Act
         response = daemon._cmd_swap("model-a")
@@ -614,7 +672,9 @@ class TestCliSwapCommand:
     def test_swap_sends_swap_command_to_daemon(self, fake_catalog_patch) -> None:
         """llmcli swap <name> calls daemon_request with 'SWAP <name>' and timeout=300.0 (B1)."""
         # Arrange
-        with patch("llmcli.cli.daemon_request", return_value="OK model-b pid=2002 port=8092") as mock_req:
+        with patch(
+            "llmcli.cli.daemon_request", return_value="OK model-b pid=2002 port=8092"
+        ) as mock_req:
             # Act
             runner.invoke(app, ["swap", "model-b"])
 
@@ -712,7 +772,9 @@ class TestCliSwapCommand:
     def test_swap_sends_exact_model_name(self, fake_catalog_patch) -> None:
         """daemon_request receives the exact model name passed to llmcli swap."""
         # Arrange
-        with patch("llmcli.cli.daemon_request", return_value="OK model-a pid=1001 port=8091") as mock_req:
+        with patch(
+            "llmcli.cli.daemon_request", return_value="OK model-a pid=1001 port=8091"
+        ) as mock_req:
             # Act
             runner.invoke(app, ["swap", "model-a"])
 

--- a/tests/test_vllm.py
+++ b/tests/test_vllm.py
@@ -16,6 +16,7 @@ Markers:
   no_gpu  — CI-safe; no real binary, no GPU required
   gpu     — requires real vllm binary + GPU; skipped in CI
 """
+
 from __future__ import annotations
 
 import inspect
@@ -59,12 +60,15 @@ def vllm_spec_no_flags() -> ModelSpec:
 
 @pytest.fixture()
 def fake_instance() -> EngineInstance:
-    return EngineInstance(pid=12345, port=8093, model_name="qwen3-27b-nvfp4", started_at=1_700_000_000.0)
+    return EngineInstance(
+        pid=12345, port=8093, model_name="qwen3-27b-nvfp4", started_at=1_700_000_000.0
+    )
 
 
 @pytest.fixture()
 def engine():
     from llmcli.engines.vllm import VLLMEngine
+
     return VLLMEngine()
 
 
@@ -180,7 +184,7 @@ class TestVLLMCommandBuild:
         cmd = engine._build_cmd(vllm_spec)
         host_idx = cmd.index("--host")
         # Flags start after "--host" "0.0.0.0"
-        tail = cmd[host_idx + 2:]
+        tail = cmd[host_idx + 2 :]
         for flag in vllm_spec.flags:
             assert flag in tail, (
                 f"catalog flag '{flag}' must appear after '--host 0.0.0.0'; tail={tail}"
@@ -283,9 +287,7 @@ class TestVLLMStop:
     """stop(instance) must use os.killpg/os.getpgid (not os.kill) for process-group teardown."""
 
     @pytest.mark.no_gpu
-    def test_stop_sends_sigterm_via_killpg(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_stop_sends_sigterm_via_killpg(self, engine, fake_instance: EngineInstance) -> None:
         """stop() must call os.killpg(os.getpgid(pid), SIGTERM)."""
         with (
             patch("llmcli.engines.vllm.os.getpgid", return_value=55555) as mock_getpgid,
@@ -296,10 +298,7 @@ class TestVLLMStop:
             mock_getpgid.side_effect = [55555, ProcessLookupError("gone")]
             engine.stop(fake_instance)
 
-        sigterm_calls = [
-            c for c in mock_killpg.call_args_list
-            if c[0][1] == signal.SIGTERM
-        ]
+        sigterm_calls = [c for c in mock_killpg.call_args_list if c[0][1] == signal.SIGTERM]
         assert len(sigterm_calls) >= 1, (
             f"stop() must send at least one SIGTERM via killpg; calls={mock_killpg.call_args_list}"
         )
@@ -308,9 +307,7 @@ class TestVLLMStop:
         )
 
     @pytest.mark.no_gpu
-    def test_stop_escalates_to_sigkill(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_stop_escalates_to_sigkill(self, engine, fake_instance: EngineInstance) -> None:
         """stop() must escalate to SIGKILL when waitpid raises ChildProcessError after SIGTERM."""
         waitpid_calls = 0
 
@@ -328,18 +325,13 @@ class TestVLLMStop:
         ):
             engine.stop(fake_instance)
 
-        sigkill_calls = [
-            c for c in mock_killpg.call_args_list
-            if c[0][1] == signal.SIGKILL
-        ]
+        sigkill_calls = [c for c in mock_killpg.call_args_list if c[0][1] == signal.SIGKILL]
         assert len(sigkill_calls) >= 1, (
             f"stop() must escalate to SIGKILL; calls={mock_killpg.call_args_list}"
         )
 
     @pytest.mark.no_gpu
-    def test_stop_idempotent_when_process_gone(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_stop_idempotent_when_process_gone(self, engine, fake_instance: EngineInstance) -> None:
         """stop() must return without raising when os.getpgid raises ProcessLookupError."""
         with patch(
             "llmcli.engines.vllm.os.getpgid",
@@ -353,9 +345,7 @@ class TestVLLMStop:
                 )
 
     @pytest.mark.no_gpu
-    def test_stop_uses_getpgid_not_os_kill(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_stop_uses_getpgid_not_os_kill(self, engine, fake_instance: EngineInstance) -> None:
         """stop() must use os.killpg (process-group) rather than os.kill (single pid)."""
         with (
             patch("llmcli.engines.vllm.os.getpgid", return_value=55555),
@@ -379,9 +369,7 @@ class TestVLLMHealth:
     """health(instance) must probe /health and return a bool."""
 
     @pytest.mark.no_gpu
-    def test_health_returns_true_on_200(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_health_returns_true_on_200(self, engine, fake_instance: EngineInstance) -> None:
         mock_response = MagicMock()
         mock_response.status_code = 200
 
@@ -391,14 +379,10 @@ class TestVLLMHealth:
         assert result is True, f"health() must return True on HTTP 200, got {result!r}"
         mock_get.assert_called_once()
         call_url: str = mock_get.call_args[0][0]
-        assert "/health" in call_url, (
-            f"health() must probe a /health endpoint, got URL: {call_url}"
-        )
+        assert "/health" in call_url, f"health() must probe a /health endpoint, got URL: {call_url}"
 
     @pytest.mark.no_gpu
-    def test_health_returns_false_on_503(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_health_returns_false_on_503(self, engine, fake_instance: EngineInstance) -> None:
         mock_response = MagicMock()
         mock_response.status_code = 503
 
@@ -417,14 +401,10 @@ class TestVLLMHealth:
         ):
             result = engine.health(fake_instance)
 
-        assert result is False, (
-            "health() must catch connection errors and return False, not raise"
-        )
+        assert result is False, "health() must catch connection errors and return False, not raise"
 
     @pytest.mark.no_gpu
-    def test_health_probes_instance_port(
-        self, engine, fake_instance: EngineInstance
-    ) -> None:
+    def test_health_probes_instance_port(self, engine, fake_instance: EngineInstance) -> None:
         mock_response = MagicMock()
         mock_response.status_code = 200
 
@@ -451,6 +431,7 @@ class TestVLLMImportGuard:
         """Importing VLLMEngine must not require the vllm package at import time."""
         # The import at module level in the fixture already proves this if we got here.
         from llmcli.engines.vllm import VLLMEngine  # noqa: F401  # re-import is fine
+
         assert True, "Import of VLLMEngine must succeed without vllm installed"
 
     @pytest.mark.no_gpu
@@ -555,7 +536,9 @@ class TestWaitReady:
             patch("llmcli.engines._common.time.sleep"),
             patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 0.1]),
         ):
-            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=10.0, engine_name="vllm serve")
+            _wait_ready(
+                "http://localhost:8093/v1", mock_proc, timeout=10.0, engine_name="vllm serve"
+            )
         # Should complete without raising
 
     @pytest.mark.no_gpu
@@ -587,7 +570,9 @@ class TestWaitReady:
                 side_effect=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
             ),
         ):
-            _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve")
+            _wait_ready(
+                "http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve"
+            )
 
         assert call_count >= 3, "Must poll at least 3 times (2× 503 + 1× 200)"
 
@@ -606,7 +591,9 @@ class TestWaitReady:
             patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 0.5]),
         ):
             with pytest.raises(RuntimeError, match="exited with code 1"):
-                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve")
+                _wait_ready(
+                    "http://localhost:8093/v1", mock_proc, timeout=60.0, engine_name="vllm serve"
+                )
 
     @pytest.mark.no_gpu
     def test_raises_on_timeout(self) -> None:
@@ -627,4 +614,6 @@ class TestWaitReady:
             patch("llmcli.engines._common.time.monotonic", side_effect=[0.0, 100.0]),
         ):
             with pytest.raises(RuntimeError, match="did not become ready"):
-                _wait_ready("http://localhost:8093/v1", mock_proc, timeout=1.0, engine_name="vllm serve")
+                _wait_ready(
+                    "http://localhost:8093/v1", mock_proc, timeout=1.0, engine_name="vllm serve"
+                )

--- a/tests/test_vram_guard.py
+++ b/tests/test_vram_guard.py
@@ -64,9 +64,7 @@ def patched_prod_catalog(prod_catalog):
 class TestVramGuardProdScenario:
     """End-to-end VRAM guard verification: 12 GiB model vs 10 GiB host budget."""
 
-    def test_serve_exits_nonzero_when_model_exceeds_prod_budget(
-        self, patched_prod_catalog
-    ) -> None:
+    def test_serve_exits_nonzero_when_model_exceeds_prod_budget(self, patched_prod_catalog) -> None:
         """serve exits non-zero when model VRAM exceeds prod host budget (SC-13)."""
         result = runner.invoke(app, ["serve", "--name", "qwen3-14b-q5"])
         assert result.exit_code != 0, (
@@ -86,28 +84,21 @@ class TestVramGuardProdScenario:
         """Error output contains the required VRAM amount (12 GiB) (SC-13)."""
         result = runner.invoke(app, ["serve", "--name", "qwen3-14b-q5"])
         combined = result.output + (result.stderr or "")
-        assert "12" in combined, (
-            f"Expected required VRAM (12) in output. Got: {combined!r}"
-        )
+        assert "12" in combined, f"Expected required VRAM (12) in output. Got: {combined!r}"
 
     def test_serve_vram_error_states_available_budget(self, patched_prod_catalog) -> None:
         """Error output contains the host VRAM budget (10 GiB) (SC-13)."""
         result = runner.invoke(app, ["serve", "--name", "qwen3-14b-q5"])
         combined = result.output + (result.stderr or "")
-        assert "10" in combined, (
-            f"Expected budget (10) in output. Got: {combined!r}"
-        )
+        assert "10" in combined, f"Expected budget (10) in output. Got: {combined!r}"
 
     def test_serve_vram_error_includes_remediation_hint(self, patched_prod_catalog) -> None:
         """Error output includes a remediation hint (smaller model / deployment docs) (SC-13)."""
         result = runner.invoke(app, ["serve", "--name", "qwen3-14b-q5"])
         combined = result.output + (result.stderr or "")
         assert any(
-            kw in combined.lower()
-            for kw in ("smaller", "budget", "deployment", "docs", "catalog")
-        ), (
-            f"Expected remediation hint in output. Got: {combined!r}"
-        )
+            kw in combined.lower() for kw in ("smaller", "budget", "deployment", "docs", "catalog")
+        ), f"Expected remediation hint in output. Got: {combined!r}"
 
     def test_serve_vram_error_does_not_start_daemon(self, patched_prod_catalog) -> None:
         """Daemon.serve is never called when VRAM guard rejects the model (SC-13)."""
@@ -116,13 +107,10 @@ class TestVramGuardProdScenario:
             runner.invoke(app, ["serve", "--name", "qwen3-14b-q5"])
         mock_daemon_instance.serve.assert_not_called()
 
-    def test_serve_default_model_also_blocked_by_vram_guard(
-        self, patched_prod_catalog
-    ) -> None:
+    def test_serve_default_model_also_blocked_by_vram_guard(self, patched_prod_catalog) -> None:
         """serve with no --name uses default_model and still applies VRAM guard (SC-13)."""
         # default_model = "qwen3-14b-q5" which is 12 GiB > 10 GiB budget
         result = runner.invoke(app, ["serve"])
         assert result.exit_code != 0, (
-            f"Expected non-zero exit for oversized default model. "
-            f"Output: {result.output!r}"
+            f"Expected non-zero exit for oversized default model. Output: {result.output!r}"
         )


### PR DESCRIPTION
## Summary

- **A (config.py):** Extended `ModelSpec` with `machines`, `provider`, `model_id`, `protocol` fields; made local-engine fields optional with safe defaults; added validation in `_parse_model_spec` rejecting mixed local+remote fields and unknown providers/engines
- **B (providers.py):** New layer-0 module with `Provider` dataclass and `PROVIDERS` registry (fireworks, anthropic, openai, nvidia-nim)
- **C (litellm_config.py):** `build_block` now filters by hostname (`spec.machines`), emits three entry shapes (local / remote-openai / remote-anthropic), accepts `hostname` kwarg for testability
- **D (models/):** Added `kimi-k2.6.toml` (Fireworks/OpenAI) and `claude-sonnet-4-6.toml` (Anthropic) example files; pinned existing local models to `machines=["roxabitower"]`; updated `llmcli.example.toml` with cloud passthrough notes
- **E (tests):** 20 new test cases across `test_config.py` and `test_litellm_config.py` covering all engine types, validation errors, and hostname filter

Closes #36

## Test plan

- [x] `uv run ruff format .` — clean
- [x] `uv run ruff check .` — clean
- [x] `uv run lint-imports` — 3 contracts kept, 0 broken
- [x] `uv run pytest --ignore=tests/nats` — 300 passed (nats exclusion is pre-existing on staging; `roxabi_nats` module not installed)
- [x] Backward compat: existing local TOML files (`qwen3_6-35b-a3b-tq3.toml`, `qwen3-14b-q5.toml`) continue to load unchanged (only added `machines` field)
- [x] `test_load_example_toml_realistic` updated to accept `engine="remote"` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)