### PR TITLE
feat(config): migrate default catalog path ~/.config/llmcli/ → ~/.roxabi/llmcli/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,12 @@ Unified CLI for local LLM serving. OpenAI-compatible HTTP on LAN via `llama.cpp`
 | `roxabitower` (local, dev) | RTX 5070 Ti | 16 GB | on-demand | Qwen3.6-35B-A3B-TQ3_4S (12.4 GiB), 14B Q5, 32B quants |
 | `roxabituwer` (prod) | RTX 3080 | 10 GB | always-on | Qwen3-8B-Q4, Qwen3-4B, Gemma-3-4B |
 
-Per-host catalog at `~/.config/llmcli/llmcli.toml`. Local catalog holds heavy models; prod pins smaller always-on models and is the LiteLLM fallback.
+Per-host catalog at `~/.roxabi/llmcli/llmcli.toml`. Local catalog holds heavy models; prod pins smaller always-on models and is the LiteLLM fallback.
 
 ## Project Layout
 
 ```
-llmcli.example.toml       — copy to ~/.config/llmcli/llmcli.toml and customize
+llmcli.example.toml       — copy to ~/.roxabi/llmcli/llmcli.toml and customize
 src/llmcli/
   cli.py                  — Typer app: pull, serve, stop, status, swap, chat, list, register-proxy
   config.py               — TOML catalog loader (HostSettings + ModelSpec)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Unified CLI for local LLM serving — `llama.cpp` + TurboQuant GGUF backends, Op
 
 ```bash
 uv sync
-mkdir -p ~/.config/llmcli/models
-cp llmcli.example.toml ~/.config/llmcli/llmcli.toml
-cp models/*.toml ~/.config/llmcli/models/   # copy example model files, edit as needed
+mkdir -p ~/.roxabi/llmcli/models
+cp llmcli.example.toml ~/.roxabi/llmcli/llmcli.toml
+cp models/*.toml ~/.roxabi/llmcli/models/   # copy example model files, edit as needed
 make register            # wire supervisor hub
 llmcli pull qwen3_6-35b-a3b-tq3             # download model into HF hub cache
 make llm                 # start serving default model on :8091
@@ -35,13 +35,13 @@ Config is split into two parts:
 
 | File | Purpose |
 |---|---|
-| `~/.config/llmcli/llmcli.toml` | Host settings (`[host]` only) |
-| `~/.config/llmcli/models/<name>.toml` | One file per model — name = model key |
+| `~/.roxabi/llmcli/llmcli.toml` | Host settings (`[host]` only) |
+| `~/.roxabi/llmcli/models/<name>.toml` | One file per model — name = model key |
 
 Each model file is flat TOML (no section header):
 
 ```toml
-# ~/.config/llmcli/models/qwen3-14b-q5.toml
+# ~/.roxabi/llmcli/models/qwen3-14b-q5.toml
 engine   = "llamacpp"
 repo     = "Qwen/Qwen3-14B-GGUF"
 file     = "qwen3-14b-q5_k_m.gguf"
@@ -50,7 +50,7 @@ vram_gib = 11
 flags    = ["-ngl", "99", "-c", "8192", "-fa", "on", "--jinja"]
 ```
 
-To add a model: copy any file from `models/` in this repo, drop it in `~/.config/llmcli/models/`, and edit. No restart needed — `llmcli list` picks it up immediately.
+To add a model: copy any file from `models/` in this repo, drop it in `~/.roxabi/llmcli/models/`, and edit. No restart needed — `llmcli list` picks it up immediately.
 
 Inline `[models.*]` in the main toml still works for backward compat; the `models/` dir takes precedence on name conflict. Local host (roxabitower, 5070 Ti 16 GB) holds heavy models; prod (roxabituwer, 3080 10 GB) pins small always-on models.
 

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -18,7 +18,7 @@ Secret=llmcli-nats-nkey,type=mount,target=/home/llmcli/.config/llmcli/nkeys/seed
 Secret=llmcli-litellm-key,type=env,target=LLMCLI_LITELLM_API_KEY
 AddDevice=nvidia.com/gpu=all
 UserNS=keep-id:uid=1502,gid=1502
-EnvironmentFile=%h/.config/llmcli/worker.env
+EnvironmentFile=%h/.roxabi/llmcli/worker.env
 Environment=LLMCLI_NATS_NKEY_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
 Environment=NATS_NKEY_SEED_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
 Environment=LLMCLI_LITELLM_URL=http://localhost:4000/v1

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -18,6 +18,11 @@ Secret=llmcli-nats-nkey,type=mount,target=/home/llmcli/.config/llmcli/nkeys/seed
 Secret=llmcli-litellm-key,type=env,target=LLMCLI_LITELLM_API_KEY
 AddDevice=nvidia.com/gpu=all
 UserNS=keep-id:uid=1502,gid=1502
+# Path namespaces: %h/.roxabi/llmcli/ (line above) is HOST-side per Roxabi data-dir
+# convention. The /home/llmcli/.config/llmcli/ paths below are CONTAINER-internal
+# (the llmcli service-account home in the image) where Podman mounts the secret —
+# they intentionally remain on the container's XDG default and are unrelated to the
+# host catalog path migration.
 EnvironmentFile=%h/.roxabi/llmcli/worker.env
 Environment=LLMCLI_NATS_NKEY_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed
 Environment=NATS_NKEY_SEED_PATH=/home/llmcli/.config/llmcli/nkeys/seed.seed

--- a/docs/deploy/remote-worker.md
+++ b/docs/deploy/remote-worker.md
@@ -29,7 +29,7 @@ rm /tmp/llm-worker.seed
 printf 'sk-...' | podman secret create llmcli-litellm-key -
 
 # 4. Write the worker env file (provides LLMCLI_NATS_URL to the container)
-mkdir -p ~/.roxabi/llmcli
+install -d -m 700 ~/.roxabi/llmcli
 printf 'LLMCLI_NATS_URL=nats://<hub-tailnet-fqdn>:4222\n' \
     > ~/.roxabi/llmcli/worker.env
 chmod 600 ~/.roxabi/llmcli/worker.env
@@ -79,6 +79,22 @@ The `EnvironmentFile` value from the base unit is superseded by the inline
 `Environment=` in the drop-in for `LLMCLI_NATS_URL`. The base unit's
 `worker.env` file must still exist (even if empty) to avoid a systemd
 fail-fast, or remove the `EnvironmentFile=` line in a second drop-in stanza.
+
+## Migration from ~/.config/llmcli/
+
+If you deployed an older version of the worker that read from `~/.config/llmcli/`, run this
+sequence on the worker host to move to the new path:
+
+```bash
+systemctl --user stop llmcli-nats-worker
+mv ~/.config/llmcli ~/.roxabi/llmcli
+systemctl --user daemon-reload
+systemctl --user start llmcli-nats-worker
+systemctl --user status llmcli-nats-worker  # verify
+```
+
+If you cannot migrate immediately, set `LLMCLI_CONFIG=~/.config/llmcli/llmcli.toml` in
+`~/.roxabi/llmcli/worker.env` to pin the old path explicitly.
 
 ## Gotchas / Production Notes
 

--- a/docs/deploy/remote-worker.md
+++ b/docs/deploy/remote-worker.md
@@ -29,10 +29,10 @@ rm /tmp/llm-worker.seed
 printf 'sk-...' | podman secret create llmcli-litellm-key -
 
 # 4. Write the worker env file (provides LLMCLI_NATS_URL to the container)
-mkdir -p ~/.config/llmcli
+mkdir -p ~/.roxabi/llmcli
 printf 'LLMCLI_NATS_URL=nats://<hub-tailnet-fqdn>:4222\n' \
-    > ~/.config/llmcli/worker.env
-chmod 600 ~/.config/llmcli/worker.env
+    > ~/.roxabi/llmcli/worker.env
+chmod 600 ~/.roxabi/llmcli/worker.env
 
 # 5. Install the Quadlet unit
 mkdir -p ~/.config/containers/systemd

--- a/docs/guides/claude-code-aliases.md
+++ b/docs/guides/claude-code-aliases.md
@@ -33,32 +33,32 @@ Add to `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 # llmCLI — claude-code aliases
-# Model names must match catalog keys in ~/.config/llmcli/llmcli.toml
+# Model names must match catalog keys in ~/.roxabi/llmcli/llmcli.toml
 
 # Local (roxabitower) — normal + fast (same model in v1)
 alias ccl='ANTHROPIC_BASE_URL=http://localhost:4000 \
            ANTHROPIC_MODEL=qwen3_6-35b-a3b-tq3 \
            ANTHROPIC_SMALL_FAST_MODEL=qwen3_6-35b-a3b-tq3 \
-           ANTHROPIC_API_KEY=$(cat ~/.config/llmcli/api_key) \
+           ANTHROPIC_API_KEY=$(cat ~/.roxabi/llmcli/api_key) \
            claude'
 
 alias cccl='ANTHROPIC_BASE_URL=http://localhost:4000 \
             ANTHROPIC_MODEL=qwen3_6-35b-a3b-tq3 \
             ANTHROPIC_SMALL_FAST_MODEL=qwen3_6-35b-a3b-tq3 \
-            ANTHROPIC_API_KEY=$(cat ~/.config/llmcli/api_key) \
+            ANTHROPIC_API_KEY=$(cat ~/.roxabi/llmcli/api_key) \
             claude'
 
 # Prod (roxabituwer) — normal + fast (same model in v1)
 alias ccp='ANTHROPIC_BASE_URL=http://roxabituwer.lan:4000 \
            ANTHROPIC_MODEL=qwen3-8b-q4 \
            ANTHROPIC_SMALL_FAST_MODEL=qwen3-8b-q4 \
-           ANTHROPIC_API_KEY=$(cat ~/.config/llmcli/api_key) \
+           ANTHROPIC_API_KEY=$(cat ~/.roxabi/llmcli/api_key) \
            claude'
 
 alias cccp='ANTHROPIC_BASE_URL=http://roxabituwer.lan:4000 \
             ANTHROPIC_MODEL=qwen3-8b-q4 \
             ANTHROPIC_SMALL_FAST_MODEL=qwen3-8b-q4 \
-            ANTHROPIC_API_KEY=$(cat ~/.config/llmcli/api_key) \
+            ANTHROPIC_API_KEY=$(cat ~/.roxabi/llmcli/api_key) \
             claude'
 ```
 
@@ -78,7 +78,7 @@ llmcli list   # prints catalog with name, engine, port, vram, status
 ```
 
 The example TOML (`llmcli.example.toml`) ships with `qwen3_6-35b-a3b-tq3` (local) and
-`qwen3-8b-q4` (prod). If your `~/.config/llmcli/llmcli.toml` uses different keys, update
+`qwen3-8b-q4` (prod). If your `~/.roxabi/llmcli/llmcli.toml` uses different keys, update
 the alias model names to match.
 
 ### v1 note: fast model
@@ -106,7 +106,7 @@ to `~/.claude/settings.json.local`:
 
 ```json
 {
-  "apiKeyHelper": "cat ~/.config/llmcli/api_key",
+  "apiKeyHelper": "cat ~/.roxabi/llmcli/api_key",
   "env": {
     "ANTHROPIC_BASE_URL": "http://localhost:4000",
     "ANTHROPIC_MODEL": "qwen3_6-35b-a3b-tq3",
@@ -125,7 +125,7 @@ to `~/.claude/settings.json.local`:
 
 ```json
 {
-  "apiKeyHelper": "cat ~/.config/llmcli/api_key",
+  "apiKeyHelper": "cat ~/.roxabi/llmcli/api_key",
   "env": {
     "ANTHROPIC_BASE_URL": "http://roxabituwer.lan:4000",
     "ANTHROPIC_MODEL": "qwen3-8b-q4",
@@ -135,7 +135,7 @@ to `~/.claude/settings.json.local`:
 ```
 
 Update `ANTHROPIC_MODEL` and `ANTHROPIC_SMALL_FAST_MODEL` to match the catalog keys in
-`~/.config/llmcli/llmcli.toml` on the target host.
+`~/.roxabi/llmcli/llmcli.toml` on the target host.
 
 ---
 
@@ -168,15 +168,15 @@ Expected: non-empty text response for `-p "ping"`. If `--help` fails, `claude` i
 echo $LLMCLI_API_KEY
 
 # Check the key file
-cat ~/.config/llmcli/api_key
+cat ~/.roxabi/llmcli/api_key
 ```
 
 If the file is missing, create it:
 
 ```bash
-mkdir -p ~/.config/llmcli
-echo "your-key-here" > ~/.config/llmcli/api_key
-chmod 600 ~/.config/llmcli/api_key
+mkdir -p ~/.roxabi/llmcli
+echo "your-key-here" > ~/.roxabi/llmcli/api_key
+chmod 600 ~/.roxabi/llmcli/api_key
 ```
 
 ### Connection refused
@@ -212,7 +212,7 @@ If the proxy routes to the wrong host, check `public_base_url` in your catalog m
 what `llmcli register-proxy` emits:
 
 ```bash
-grep 'public_base_url' ~/.config/llmcli/llmcli.toml
+grep 'public_base_url' ~/.roxabi/llmcli/llmcli.toml
 grep 'api_base' ~/.litellm/config.yaml
 ```
 

--- a/docs/guides/claude-code-aliases.md
+++ b/docs/guides/claude-code-aliases.md
@@ -174,7 +174,7 @@ cat ~/.roxabi/llmcli/api_key
 If the file is missing, create it:
 
 ```bash
-mkdir -p ~/.roxabi/llmcli
+install -d -m 700 ~/.roxabi/llmcli
 echo "your-key-here" > ~/.roxabi/llmcli/api_key
 chmod 600 ~/.roxabi/llmcli/api_key
 ```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -74,9 +74,9 @@ if installed). No extra setup needed — `llmcli pull` downloads into this locat
 ### 2.5 API key
 
 ```bash
-mkdir -p ~/.config/llmcli
-echo "your-api-key-here" > ~/.config/llmcli/api_key
-chmod 600 ~/.config/llmcli/api_key
+mkdir -p ~/.roxabi/llmcli
+echo "your-api-key-here" > ~/.roxabi/llmcli/api_key
+chmod 600 ~/.roxabi/llmcli/api_key
 ```
 
 The supervisor wrapper (`supervisor/scripts/run_serve.sh`) sources
@@ -84,7 +84,7 @@ The supervisor wrapper (`supervisor/scripts/run_serve.sh`) sources
 
 ```bash
 cat > ~/projects/llmCLI/.env <<'EOF'
-LLMCLI_API_KEY=$(cat ~/.config/llmcli/api_key)
+LLMCLI_API_KEY=$(cat ~/.roxabi/llmcli/api_key)
 EOF
 ```
 
@@ -101,10 +101,10 @@ cd ~/projects/llmCLI
 uv sync
 
 # Set up catalog
-cp llmcli.example.toml ~/.config/llmcli/llmcli.toml
+cp llmcli.example.toml ~/.roxabi/llmcli/llmcli.toml
 ```
 
-Edit `~/.config/llmcli/llmcli.toml` for prod. Replace the dev models with small models
+Edit `~/.roxabi/llmcli/llmcli.toml` for prod. Replace the dev models with small models
 that fit within 10 GB VRAM. See `llmcli.example.toml` for the full schema.
 
 Minimal prod catalog:
@@ -223,7 +223,7 @@ Verify the proxy forwards to llmCLI:
 ```bash
 curl -s http://localhost:4000/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $(cat ~/.config/llmcli/api_key)" \
+  -H "Authorization: Bearer $(cat ~/.roxabi/llmcli/api_key)" \
   -d '{"model":"qwen3-8b-q4","messages":[{"role":"user","content":"ping"}]}' \
   | jq .choices[0].message.content
 ```

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -74,7 +74,7 @@ if installed). No extra setup needed — `llmcli pull` downloads into this locat
 ### 2.5 API key
 
 ```bash
-mkdir -p ~/.roxabi/llmcli
+install -d -m 700 ~/.roxabi/llmcli
 echo "your-api-key-here" > ~/.roxabi/llmcli/api_key
 chmod 600 ~/.roxabi/llmcli/api_key
 ```
@@ -304,7 +304,30 @@ prod catalog without updating `vram_budget_gib`.
 
 ---
 
-## 9. Troubleshooting
+## 9. Migration from ~/.config/llmcli/
+
+If you deployed an older version of llmCLI that stored its catalog at `~/.config/llmcli/`,
+run this sequence on the prod host to move to the new Roxabi data-dir path:
+
+```bash
+make llm stop
+mv ~/.config/llmcli ~/.roxabi/llmcli
+make llm start
+llmcli list  # verify catalog loads
+```
+
+If you cannot migrate immediately, set `LLMCLI_CONFIG=~/.config/llmcli/llmcli.toml` in
+your supervisor env (e.g. in `~/projects/llmCLI/.env`) to pin the old path explicitly.
+
+### Environment variable reference
+
+| Variable | Description |
+|---|---|
+| `LLMCLI_CONFIG` | Path to llmcli.toml. Defaults to `~/.roxabi/llmcli/llmcli.toml`. Useful as a migration escape hatch or for multi-tenant catalogs. |
+
+---
+
+## 10. Troubleshooting
 
 ### Stale socket after crash
 

--- a/docs/guides/examples/settings.json.local.example
+++ b/docs/guides/examples/settings.json.local.example
@@ -1,5 +1,5 @@
 {
-  "apiKeyHelper": "cat ~/.config/llmcli/api_key",
+  "apiKeyHelper": "cat ~/.roxabi/llmcli/api_key",
   "env": {
     "ANTHROPIC_BASE_URL": "http://localhost:4000",
     "ANTHROPIC_MODEL": "qwen3_6-35b-a3b-tq3",

--- a/docs/guides/examples/settings.json.local.prod.example
+++ b/docs/guides/examples/settings.json.local.prod.example
@@ -1,5 +1,5 @@
 {
-  "apiKeyHelper": "cat ~/.config/llmcli/api_key",
+  "apiKeyHelper": "cat ~/.roxabi/llmcli/api_key",
   "env": {
     "ANTHROPIC_BASE_URL": "http://roxabituwer.lan:4000",
     "ANTHROPIC_MODEL": "qwen3-8b-q4",

--- a/docs/guides/lyra-integration.md
+++ b/docs/guides/lyra-integration.md
@@ -79,7 +79,7 @@ that `llama-server` validates on each request.
 
 ```bash
 # ~/projects/lyra/.env
-LLMCLI_API_KEY=$(cat ~/.config/llmcli/api_key)
+LLMCLI_API_KEY=$(cat ~/.roxabi/llmcli/api_key)
 ```
 
 **Prod (`roxabituwer`):** add to the supervisor env block in
@@ -94,7 +94,7 @@ environment =
 Then set the var in `~/projects/lyra/.env` on prod (sourced by `run_*.sh` wrappers):
 
 ```bash
-LLMCLI_API_KEY=<the-same-key-in-~/.config/llmcli/api_key>
+LLMCLI_API_KEY=<the-same-key-in-~/.roxabi/llmcli/api_key>
 ```
 
 The key value on both hosts must match the key that `llmcli serve` is configured to

--- a/llmcli.example.toml
+++ b/llmcli.example.toml
@@ -1,5 +1,5 @@
-# llmCLI host config — copy to ~/.config/llmcli/llmcli.toml and edit.
-# Model definitions live in ~/.config/llmcli/models/<name>.toml (one file per model).
+# llmCLI host config — copy to ~/.roxabi/llmcli/llmcli.toml and edit.
+# Model definitions live in ~/.roxabi/llmcli/models/<name>.toml (one file per model).
 # See models/ in this repo for examples to copy and adapt.
 #
 # Cloud passthrough examples (engine="remote", no GPU required):

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_CONFIG_PATH = Path(
-    os.environ.get("LLMCLI_CONFIG", Path.home() / ".config" / "llmcli" / "llmcli.toml")
+    os.environ.get("LLMCLI_CONFIG", Path.home() / ".roxabi" / "llmcli" / "llmcli.toml")
 )
 
 _VALID_PROTOCOLS = frozenset({"openai", "anthropic"})

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -12,6 +12,7 @@ from .providers import PROVIDERS
 logger = logging.getLogger(__name__)
 
 
+# Resolved at import time — set LLMCLI_CONFIG before import or pass path= to load().
 DEFAULT_CONFIG_PATH = Path(
     os.environ.get("LLMCLI_CONFIG", Path.home() / ".roxabi" / "llmcli" / "llmcli.toml")
 )
@@ -130,8 +131,16 @@ def _parse_model_spec(name: str, spec: dict) -> ModelSpec:
 
 
 def load(path: Path = DEFAULT_CONFIG_PATH) -> Catalog:
-    with path.open("rb") as f:
-        data = tomllib.load(f)
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            f"llmCLI catalog not found at {path}.\n"
+            f"If you're upgrading from ~/.config/llmcli/, run:\n"
+            f"  mv ~/.config/llmcli ~/.roxabi/llmcli\n"
+            f"Or set LLMCLI_CONFIG=<path> to point at a custom location."
+        ) from e
 
     host_data = data.get("host", {})
     host = HostSettings(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,38 @@ OVERSIZED_TOML = """\
 
 
 # ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_default_config_path_matches_roxabi_convention(self) -> None:
+        """DEFAULT_CONFIG_PATH resolves to ~/.roxabi/llmcli/llmcli.toml absent override.
+
+        Verified in a subprocess to avoid module-reload side-effects on other tests.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import os; os.environ.pop('LLMCLI_CONFIG', None); "
+                    "import llmcli.config as cfg; from pathlib import Path; "
+                    "expected = Path.home() / '.roxabi' / 'llmcli' / 'llmcli.toml'; "
+                    "assert cfg.DEFAULT_CONFIG_PATH == expected, "
+                    "f'Got {cfg.DEFAULT_CONFIG_PATH!r}, expected {expected!r}'"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
 # SC-1 / C10 — catalog load
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Migrates `DEFAULT_CONFIG_PATH` in `src/llmcli/config.py` from `~/.config/llmcli/llmcli.toml` to `~/.roxabi/llmcli/llmcli.toml`
- Updates all forward-facing docs and examples to reflect the new path
- The `models/` subdir automatically follows (`path.parent / "models"` — no separate change needed)

**Clean break — no backward-compat fallback.** Operators must migrate or set `LLMCLI_CONFIG` explicitly.

## Migration note (operator action required per host)

**M₂ (roxabitower — existing deployment):**
```bash
mv ~/.config/llmcli ~/.roxabi/llmcli
# then restart the supervised service to pick up the new default
make llm reload
```

**M₁ (roxabituwer — if not already using LLMCLI_CONFIG):**
```bash
mkdir -p ~/.roxabi/llmcli/models
# seed with your catalog; move api_key if stored there
mv ~/.config/llmcli/api_key ~/.roxabi/llmcli/api_key
```

If `LLMCLI_CONFIG` is already set in the `.env`, the default is irrelevant — no action needed on that host.

## Files changed

- `src/llmcli/config.py` — one-line constant change (the only code change)
- `llmcli.example.toml` — header comment
- `CLAUDE.md` — Host Topology section + Project Layout comment
- `README.md` — Quick start + Catalog table
- `docs/guides/deployment.md` — all path references
- `docs/guides/lyra-integration.md` — api_key path references
- `docs/guides/claude-code-aliases.md` — all path references
- `docs/guides/examples/settings.json.local.example` — apiKeyHelper
- `docs/guides/examples/settings.json.local.prod.example` — apiKeyHelper
- `docs/deploy/remote-worker.md` — worker.env path
- `deploy/quadlet/llmcli-nats-worker.container` — `EnvironmentFile=%h/...` host-side path (nkey container-internal paths left unchanged — those are inside the container image)

CHANGELOG historical entries intentionally untouched.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run lint-imports` — 3 contracts kept, 0 broken
- [x] `uv run pytest --ignore=tests/nats` — 312 passed (nats collection error is pre-existing: missing optional `roxabi_nats` dep, unrelated to this change)
- [x] `grep -rn "\.config/llmcli" . --exclude-dir=.git` — zero hits in source/docs/supervisor (remaining hits are container-internal nkey paths in the Quadlet unit and historical plan artifact, both out of scope)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)