### PR TITLE
feat(proxy): add llmcli proxy — catalog-driven LiteLLM portal on :18091

### DIFF
--- a/artifacts/frames/40-llmcli-proxy-portal-frame.mdx
+++ b/artifacts/frames/40-llmcli-proxy-portal-frame.mdx
@@ -1,0 +1,62 @@
+---
+title: feat(proxy) — add `llmcli proxy` catalog-driven LiteLLM portal on :18091
+issue: 40
+status: approved
+tier: F-lite
+date: 2026-05-19
+---
+
+## Problem
+
+The LiteLLM proxy lifecycle is currently split across two owners: **config** is written by `llmcli register-proxy` (sentinel block in `~/.litellm/config.yaml`) while **process** is owned by the lyra supervisor (`~/projects/lyra/deploy/supervisor/conf.d/litellm.conf`, bound to `:4000`). This split blocks the next infrastructure step — packaging llmcli as a Podman Quadlet (lyra/voiceCLI pattern) — because Quadlet needs a single command that owns both config generation and the process.
+
+Trigger: Step 3 of the central-portal plan. Phases 1 (#36/#37 — catalog cloud-passthrough with `engine="remote"`) and 2 (#38/#39 — `~/.roxabi/llmcli/` data-dir migration) are merged. With the catalog now the source of truth for both local and remote models, the proxy that exposes it should be owned by the same tool.
+
+Observable impact today: M₁ (cloud-only, no lyra supervisor required) cannot host a proxy without dragging in lyra's supervisor stack. M₂ requires manual coordination between two repos to add/remove models.
+
+## Who
+
+- **Primary:** Mickael (ops + dev) — needs Quadlet-deployable proxy on M₁ and M₂
+- **Secondary:**
+  - lyra (NATS satellite client of llmcli) — already migrated to `LLMCLI_API_KEY`
+  - Claude Code (HTTP client via `cccc/cccfk/ccd` aliases) — currently targets `:4000`; will move to `:18091` after Quadlet ships
+  - hermes (future Telegram bots) — will adopt `:18091` natively
+
+## Constraints
+
+- Reuse `litellm_config.build_block()` logic — do not duplicate catalog → YAML mapping
+- Preserve `machines = [...]` filtering semantics (same as `register-proxy`)
+- Process model: foreground subprocess (`Popen` + signal forwarding) — no daemonization, systemd/Quadlet handles supervision
+- Migration strategy: **Replace** the existing `:4000` instance (lyra supervisor retired in a follow-up ops task after Quadlet ships) — code itself is migration-strategy-agnostic
+- Python 3.12, Typer + Rich, no new heavy deps (litellm is already an install target)
+- Quality gates: file-length 300 LOC, folder-size 12 files, importlinter on pre-push
+
+## Out of Scope
+
+- Replacing the running `:4000` lyra-supervisor instance — separate ops task after Quadlet
+- `llmcli.container` Quadlet definition — Step 4 of the central-portal plan
+- Catalog support for `pass_through_endpoints` (e.g. Fireworks `/fw-anthropic`) — separate follow-up issue; for now passthroughs stay in a user-managed extras file or get manually patched in
+- Hot reload of catalog (SIGHUP) — explicit non-goal; restart on change
+- Authentication beyond a single `LLMCLI_API_KEY` (no virtual keys, no RBAC)
+- Moving `deepseek-v4-pro` (currently hand-written in `~/.litellm/config.yaml`) into the catalog — Step 5 of the plan
+- Deprecating `llmcli register-proxy` — stays functional this cycle, removed in a later one
+
+## Premise Validity
+
+**Success in 6 months:** `llmcli proxy` runs as a Quadlet on M₁ (cloud-only) and M₂ (mixed), bound to `:18091`, with `~/.roxabi/llmcli/` catalog as the single source of truth for all routed models. The `:4000` lyra-supervisor proxy is retired. NATS (lyra), HTTP/OpenAI (hermes), and HTTP/Anthropic (Claude Code) clients all transit through llmcli. Adding a new cloud model is a single TOML file under `models/` plus a `systemctl --user restart llmcli.service`.
+
+**Failure in 6 months:** Despite a "migration completed" announcement, either (a) at least one of M₁/M₂ still has a hand-managed `:4000` instance running because `llmcli proxy` couldn't be made reliable enough, OR (b) `≥ 1 prod incident per month` on M₁ where the proxy fails to start (signal-handling races, child reaping, port binding) and requires manual `podman` intervention. Either condition is a falsifiable rollback signal.
+
+**Simplest alternative:** Keep the `:4000` lyra-supervisor model. Change `llmcli register-proxy` to write the **entire** `~/.litellm/config.yaml` (not just a sentinel block) and let supervisor own the lifecycle as today.
+**Why not simplest:** (1) lyra-supervisor is a hard dependency for any proxy host, which is wasted complexity on M₁ (no lyra service runs there anyway). (2) Quadlet-ification requires a single binary that owns both config and process; supervisor-coupled flows don't translate cleanly into systemd units. (3) Two-repo coordination for every catalog change creates real friction (Step 1+2 of this plan already paid that cost twice).
+
+## Complexity
+
+**Tier: F-lite** — single new Typer command, reuses an existing generator (`build_block`), bounded process-lifecycle work (subprocess + signal forwarding), no new architecture or cross-domain coupling.
+
+Signals observed:
+- 1 new file in `src/llmcli/cli/proxy.py` (or extension of existing) + 1 helper refactor in `litellm_config.py` to return dict instead of YAML string
+- No frontend, no DB, no new external dependency
+- Test surface bounded: config dict assertions + subprocess signal mocks
+- Risk concentration: signal handling correctness (one well-trodden pattern) + startup validation (deterministic env-check)
+- Issue label: `enhancement` (no size label assigned; F-lite confirmed by scope review)

--- a/artifacts/plans/40-llmcli-proxy-portal-plan.mdx
+++ b/artifacts/plans/40-llmcli-proxy-portal-plan.mdx
@@ -1,0 +1,520 @@
+---
+title: "Plan: feat(proxy) — add `llmcli proxy` catalog-driven LiteLLM portal on :18091"
+issue: 40
+spec: artifacts/specs/40-llmcli-proxy-portal-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-19
+---
+
+## Summary
+
+Refactor `litellm_config.build_block` to expose a dict-returning `build_full_config`; add a new `proxy` Typer command in the existing `src/llmcli/cli/proxy.py` (sibling of `register-proxy`) that generates a complete LiteLLM YAML from the catalog, validates provider keys, and spawns `litellm` as a foreground subprocess on `:18091` with SIGTERM/SIGINT forwarding. Three vertical slices: refactor → dry-run (`--config-out`) → full lifecycle.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+    subgraph catalog_files["~/.roxabi/llmcli/"]
+        TOML[llmcli.toml]
+        MOD[models/*.toml]
+    end
+    subgraph config_py["config.py"]
+        LOAD[config.load]
+        CAT[Catalog]
+    end
+    subgraph litellm_py["litellm_config.py"]
+        BFC[build_full_config<br/>dict]
+        BB[build_block<br/>YAML str wrapper]
+    end
+    subgraph proxy_py["cli/proxy.py"]
+        VAL[_validate_provider_keys]
+        WRITE[_write_config]
+        SPAWN[_spawn_litellm]
+        SIG[_install_signal_handlers]
+        CMD[proxy_cmd]
+        RP[register_proxy<br/>existing]
+    end
+    subgraph state_dir["~/.local/state/llmcli/"]
+        YAML[proxy.config.yaml]
+    end
+    LITELLM[litellm subprocess<br/>:18091]
+
+    TOML --> LOAD
+    MOD --> LOAD
+    LOAD --> CAT
+    CAT --> BFC
+    BFC --> BB
+    CAT --> VAL
+    BFC --> WRITE
+    WRITE --> YAML
+    YAML --> LITELLM
+    CMD --> VAL
+    CMD --> WRITE
+    CMD --> SPAWN
+    SPAWN --> LITELLM
+    CMD --> SIG
+    SIG -.SIGTERM/SIGINT.-> LITELLM
+    RP --> BB
+
+    style BFC stroke:#0a0,stroke-width:2px
+    style CMD stroke:#0a0,stroke-width:2px
+    style RP stroke:#888,stroke-dasharray:3 3
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+    subgraph src_litellm_config["src/llmcli/litellm_config.py"]
+        bfc[build_full_config]
+        bb[build_block]
+        wb[write_block]
+        rp_helper[reload_proxy]
+    end
+    subgraph src_cli_proxy["src/llmcli/cli/proxy.py"]
+        rp_cmd[register_proxy<br/>@app.command existing]
+        proxy_cmd[proxy<br/>@app.command NEW]
+        val_keys[_validate_provider_keys]
+        write_cfg[_write_config]
+        spawn[_spawn_litellm]
+        signals[_install_signal_handlers]
+    end
+    subgraph tests_litellm["tests/test_litellm_config.py"]
+        t_bfc[test_build_full_config_*]
+        t_bb[test_build_block_*<br/>existing + new empty-list]
+    end
+    subgraph tests_proxy["tests/test_proxy_cmd.py NEW"]
+        t_val[test_validate_provider_keys_*]
+        t_write[test_write_config_*]
+        t_dry[test_config_out_dry_run_*]
+        t_spawn[test_spawn_litellm_*]
+        t_sig[test_signal_forwarding_*]
+        t_exit[test_exit_code_propagation_*]
+    end
+
+    bb --> bfc
+    rp_cmd --> bb
+    proxy_cmd --> val_keys
+    proxy_cmd --> bfc
+    proxy_cmd --> write_cfg
+    proxy_cmd --> spawn
+    proxy_cmd --> signals
+    val_keys -.tested by.-> t_val
+    write_cfg -.tested by.-> t_write
+    proxy_cmd -.tested by.-> t_dry
+    spawn -.tested by.-> t_spawn
+    signals -.tested by.-> t_sig
+    proxy_cmd -.tested by.-> t_exit
+    bfc -.tested by.-> t_bfc
+    bb -.tested by.-> t_bb
+```
+
+## Bootstrap Context
+
+| Item | Path / value |
+|---|---|
+| Existing pattern: Typer command in same file | `src/llmcli/cli/proxy.py` (`register-proxy`) |
+| Existing pattern: subprocess wrapper | `src/llmcli/engines/llamacpp.py` (`_common.py` helpers) |
+| Existing pattern: catalog filter by machines | `src/llmcli/litellm_config.py:34-35` |
+| Existing tests style | `tests/test_litellm_config.py` (block-builder), `tests/test_cli.py` (Typer runner) |
+| Quality gates | `.claude/stack.yml`: file_length 300 LOC, folder_size 12 files, importlinter pre-push |
+| stdout/stderr inheritance reference | LiteLLM logs are structured JSON — inherit directly; no Rich wrapping post-spawn |
+
+## Agents
+
+| Agent | Instances | Files touched | Task count |
+|---|---|---|---|
+| backend-dev | A (refactor), B (new cmd) | `src/llmcli/litellm_config.py`, `src/llmcli/cli/proxy.py` | 8 |
+| tester | A (refactor), B (dry-run), C (lifecycle) | `tests/test_litellm_config.py`, `tests/test_proxy_cmd.py` (new) | 9 |
+| doc-writer | — | `docs/guides/deployment.md` | 1 |
+| devops | — | quality-gates verification | 1 |
+
+## Wave Structure
+
+5 waves, max 4 parallel agents. Elapsed ~3 sequential-equivalent units vs ~8 fully serial.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 3 ∥ | backend-dev-A: T1 · backend-dev-B: T6→T7 · tester-A: T3 |
+| 2 | Wave 1 done | 4 ∥ | backend-dev-A: T2 · backend-dev-B: T8→T12 · tester-A: T4 · tester-B: T9 |
+| 3 | Wave 2 done | 4 ∥ | backend-dev-B: T13→T14 · tester-A: T5 (RED-GATE) · tester-B: T10 · tester-C: T15 |
+| 4 | Wave 3 done | 4 ∥ | tester-B: T11 (RED-GATE) · tester-C: T16→T17 · doc-writer: T19 · devops: T20 |
+| 5 | Wave 4 done | 1 | tester-C: T18 (RED-GATE) |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 build_full_config | 1 fn | bounded | 3 | — |
+| T2 build_block wrapper | 1 fn | trivial | 2 | — |
+| T3 test build_full_config | 4 cases | bounded | 4 | — |
+| T4 test build_block empty-list | 1 case | trivial | 2 | — |
+| T5 RED-GATE slice 1 | — | trivial | 1 | — |
+| T6 proxy command shell | 1 fn | bounded | 3 | — |
+| T7 _validate_provider_keys | 1 fn | bounded | 3 | — |
+| T8 wire dry-run path | 1 control flow | judgmental | 5 | — |
+| T9 test _validate_provider_keys | 3 cases | bounded | 3 | — |
+| T10 test --config-out | 2 cases | bounded | 3 | — |
+| T11 RED-GATE slice 2 | — | trivial | 1 | — |
+| T12 _spawn_litellm | 1 fn | bounded | 3 | — |
+| T13 _install_signal_handlers | 1 fn (poll-loop) | judgmental | 5 | — |
+| T14 wire full lifecycle | 1 control flow | judgmental | 4 | — |
+| T15 test _spawn_litellm | 2 cases | bounded | 3 | — |
+| T16 test signal forwarding | 2 cases | judgmental | 4 | — |
+| T17 test missing-binary | 2 cases | bounded | 3 | — |
+| T18 RED-GATE slice 3 | — | trivial | 1 | — |
+| T19 docs deployment.md | 1 section | bounded | 3 | — |
+| T20 quality gates check | lint+importlinter | trivial | 2 | — |
+
+**Total estimated ops: 58** — max per-task = 5 (T8, T13). None exceed 50/task threshold. No splits required.
+
+## Consistency Report
+
+| | |
+|---|---|
+| Spec success criteria | 8 automated + 3 manual smoke |
+| Coverage (automated) | 8/8 — see Spec Trace column in micro-tasks |
+| Untraced tasks | 0 |
+| Uncovered criteria | 0 |
+| Exemptions | Manual smokes (SC-9, SC-10, SC-11) → tested via mocks in T15/T16/T17; real-binary smoke deferred to `docs/guides/deployment.md` |
+
+## Micro-Tasks
+
+### Slice V1 — Refactor `build_block` → `build_full_config`
+
+**T1 [P] · backend-dev-A · RED+GREEN · Difficulty 2**
+- **Description:** Add `build_full_config(catalog, public_base_url, hostname=None) -> dict[str, Any]` to `litellm_config.py`. Returns `{"general_settings": {...}, "litellm_settings": {"drop_params": True}, "model_list": [...]}`. Empty model_list → empty list `[]`, NOT `None`.
+- **File:** `src/llmcli/litellm_config.py`
+- **Snippet:**
+  ```python
+  def build_full_config(
+      catalog: Catalog, public_base_url: str, *, hostname: str | None = None
+  ) -> dict[str, Any]:
+      effective_hostname = hostname if hostname is not None else socket.gethostname()
+      api_key_ref = f"os.environ/{catalog.host.api_key_env}"
+      model_list = [_model_entry(name, spec, api_key_ref, public_base_url)
+                    for name, spec in catalog.models.items()
+                    if not spec.machines or effective_hostname in spec.machines]
+      return {
+          "general_settings": {"master_key": api_key_ref},
+          "litellm_settings": {"drop_params": True},
+          "model_list": model_list,
+      }
+  ```
+- **Verify:** `uv run python -c "from llmcli.litellm_config import build_full_config; print(build_full_config.__doc__)"`
+- **Expected:** No ImportError, function exists.
+- **Spec trace:** SC-1 (build_full_config exists with exact keys)
+- **Difficulty:** 2
+
+**T2 · backend-dev-A · REFACTOR · Difficulty 2** (depends T1)
+- **Description:** Refactor existing `build_block` to wrap `build_full_config`. Extract the same model_list, wrap in sentinel comments. Preserve `model_list: null` on empty (NOT `[]`) for register-proxy back-compat.
+- **File:** `src/llmcli/litellm_config.py`
+- **Snippet:**
+  ```python
+  def build_block(catalog, public_base_url, *, hostname=None) -> str:
+      cfg = build_full_config(catalog, public_base_url, hostname=hostname)
+      ml = cfg["model_list"]
+      if ml:
+          inner = yaml.safe_dump({"model_list": ml}, default_flow_style=False, sort_keys=False)
+      else:
+          inner = yaml.safe_dump({"model_list": None}, default_flow_style=False)
+      return f"{BLOCK_START}\n{inner}{BLOCK_END}\n"
+  ```
+- **Verify:** `uv run pytest tests/test_litellm_config.py -k build_block -q`
+- **Expected:** All existing build_block tests pass with no changes to assertions.
+- **Spec trace:** SC-2 (build_block preserves YAML string sentinel form)
+- **Difficulty:** 2
+
+**T3 [P] · tester-A · RED · Difficulty 2** (depends T1)
+- **Description:** Add tests covering `build_full_config`: (a) catalog with 1 remote + 1 local model returns dict with all 3 keys, (b) machines filter excludes models not matching hostname, (c) host.api_key_env propagates to general_settings.master_key, (d) empty filtered catalog → `model_list == []`.
+- **File:** `tests/test_litellm_config.py`
+- **Snippet:**
+  ```python
+  class TestBuildFullConfig:
+      def test_returns_dict_with_required_keys(self, sample_catalog): ...
+      def test_machines_filter_excludes_non_matching(self, sample_catalog): ...
+      def test_master_key_from_api_key_env(self, sample_catalog): ...
+      def test_empty_filter_yields_empty_list(self, sample_catalog): ...
+  ```
+- **Verify:** `uv run pytest tests/test_litellm_config.py::TestBuildFullConfig -v`
+- **Expected:** 4 tests pass.
+- **Spec trace:** SC-1
+- **Difficulty:** 2
+
+**T4 · tester-A · RED · Difficulty 1** (depends T2)
+- **Description:** Add one regression test for `build_block` empty-list invariant: empty filtered catalog → output contains `model_list: null`, NOT `model_list: []`.
+- **File:** `tests/test_litellm_config.py`
+- **Verify:** `uv run pytest tests/test_litellm_config.py -k empty -v`
+- **Expected:** Test passes; assertion: `"model_list: null" in build_block(catalog_with_no_matching, url)`.
+- **Spec trace:** SC-2
+- **Difficulty:** 1
+
+**T5 · tester-A · RED-GATE · Difficulty 1** (depends T2, T3, T4)
+- **Description:** Slice 1 RED-GATE — full `pytest tests/test_litellm_config.py` green.
+- **Verify:** `uv run pytest tests/test_litellm_config.py -v`
+- **Expected:** All tests (existing + new) pass.
+- **Spec trace:** SC-1, SC-2
+- **Difficulty:** 1
+
+### Slice V2 — `llmcli proxy --config-out PATH` (dry-run)
+
+**T6 [P] · backend-dev-B · GREEN · Difficulty 2** (no deps — same file as register-proxy but new function)
+- **Description:** Add `proxy` Typer command shell in `src/llmcli/cli/proxy.py`. Accepts `--port` (default 18091, env `LLMCLI_PROXY_PORT`), `--host` (default `0.0.0.0`, env `LLMCLI_PROXY_HOST`), `--config-out` (Path | None). Body: TODO placeholder (filled in T8/T14).
+- **File:** `src/llmcli/cli/proxy.py`
+- **Snippet:**
+  ```python
+  @app.command()
+  def proxy(
+      port: int = typer.Option(18091, "--port", envvar="LLMCLI_PROXY_PORT"),
+      host: str = typer.Option("0.0.0.0", "--host", envvar="LLMCLI_PROXY_HOST"),
+      config_out: Optional[Path] = typer.Option(None, "--config-out"),
+  ) -> None:
+      """Run a managed LiteLLM proxy on :{port} from the catalog."""
+      raise NotImplementedError  # filled in T8
+  ```
+- **Verify:** `uv run llmcli proxy --help`
+- **Expected:** Help text lists the three options.
+- **Spec trace:** U1, U2, U3, U4
+- **Difficulty:** 2
+
+**T7 [P] · backend-dev-B · GREEN · Difficulty 2** (no deps — pure helper)
+- **Description:** Add `_validate_provider_keys(catalog) -> list[str]` helper in `cli/proxy.py`. Returns list of missing-key error strings; empty list = OK. For each `engine="remote"` spec on the effective host (machines filter applied), look up `providers.PROVIDERS[spec.provider].key_env`, check `os.environ.get(...)`; missing → append `f"Missing provider key for '{name}': set {key_env} (in environment or ~/.litellm/.env)"`.
+- **File:** `src/llmcli/cli/proxy.py`
+- **Snippet:**
+  ```python
+  def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> list[str]:
+      effective = hostname or socket.gethostname()
+      errors: list[str] = []
+      for name, spec in catalog.models.items():
+          if spec.engine != "remote":
+              continue
+          if spec.machines and effective not in spec.machines:
+              continue
+          provider = PROVIDERS.get(spec.provider)
+          if provider is None:
+              continue  # surfaced as ValueError by build_full_config later
+          if not os.environ.get(provider.key_env):
+              errors.append(
+                  f"Missing provider key for '{name}': set {provider.key_env} "
+                  "(in environment or ~/.litellm/.env)"
+              )
+      return errors
+  ```
+- **Verify:** `uv run python -c "from llmcli.cli.proxy import _validate_provider_keys; print(_validate_provider_keys.__doc__)"`
+- **Expected:** No ImportError.
+- **Spec trace:** N2
+- **Difficulty:** 2
+
+**T8 · backend-dev-B · GREEN · Difficulty 3** (depends T6, T7, T2)
+- **Description:** Wire `--config-out` dry-run path inside `proxy_cmd`: (1) `config.load()`, (2) `_validate_provider_keys` → if non-empty, print all errors to stderr and `raise typer.Exit(1)`, (3) `build_full_config(catalog, host.public_base_url)`, (4) write yaml.safe_dump to `config_out` (when set) OR to `~/.local/state/llmcli/proxy.config.yaml` (default state path). When `config_out` is set, `raise typer.Exit(0)` after write (dry-run). Spawn path stays NotImplementedError this slice — done in T14. State dir creation: `mkdir(parents=True, exist_ok=True, mode=0o700)`; file mode `0o600` via `os.umask` or `os.chmod` after write.
+- **File:** `src/llmcli/cli/proxy.py`
+- **Verify:** `LLMCLI_CONFIG=tests/fixtures/cloud-only.toml uv run llmcli proxy --config-out /tmp/out.yaml && yq .general_settings.master_key /tmp/out.yaml`
+- **Expected:** Exits 0; file exists at `/tmp/out.yaml`; `master_key` resolves to `os.environ/LLMCLI_API_KEY`.
+- **Spec trace:** U4, N3, N4
+- **Difficulty:** 3
+
+**T9 [P] · tester-B · RED · Difficulty 2** (depends T7)
+- **Description:** Tests for `_validate_provider_keys`: (a) all keys set → returns `[]`, (b) one remote model with unset key → returns 1 error message containing the key_env name, (c) local models ignored (no validation).
+- **File:** `tests/test_proxy_cmd.py` (new file)
+- **Verify:** `uv run pytest tests/test_proxy_cmd.py::TestValidateProviderKeys -v`
+- **Expected:** 3 tests pass.
+- **Spec trace:** SC-4
+- **Difficulty:** 2
+
+**T10 · tester-B · RED · Difficulty 2** (depends T8)
+- **Description:** Tests for `--config-out` dry-run: (a) writes a valid YAML to PATH and exits 0, (b) missing provider env → exit 1 + stderr contains key_env name, no file written.
+- **File:** `tests/test_proxy_cmd.py`
+- **Verify:** `uv run pytest tests/test_proxy_cmd.py -k config_out -v`
+- **Expected:** 2 tests pass; uses Typer's `CliRunner` + monkeypatch for env vars.
+- **Spec trace:** SC-3, SC-4
+- **Difficulty:** 2
+
+**T11 · tester-B · RED-GATE · Difficulty 1** (depends T5, T9, T10)
+- **Description:** Slice 2 RED-GATE — slice-1 tests + slice-2 dry-run tests all green.
+- **Verify:** `uv run pytest tests/test_litellm_config.py tests/test_proxy_cmd.py -v`
+- **Expected:** Both files all green.
+- **Spec trace:** SC-1..SC-4
+- **Difficulty:** 1
+
+### Slice V3 — Full lifecycle (spawn + signals + exit-code)
+
+**T12 · backend-dev-B · GREEN · Difficulty 2** (depends T6)
+- **Description:** Add `_spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen`. Locates `litellm` via `shutil.which("litellm")`; missing → typer.echo(error) + `raise typer.Exit(127)`. Spawns `Popen(["litellm", "--config", str(config_path), "--port", str(port), "--host", host])` with inherited stdout/stderr.
+- **File:** `src/llmcli/cli/proxy.py`
+- **Snippet:**
+  ```python
+  def _spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen:
+      binary = shutil.which("litellm")
+      if binary is None:
+          err_console.print("litellm binary not found on PATH.")
+          raise typer.Exit(127)
+      return subprocess.Popen(
+          [binary, "--config", str(config_path), "--port", str(port), "--host", host]
+      )
+  ```
+- **Verify:** `uv run python -c "from llmcli.cli.proxy import _spawn_litellm"`
+- **Expected:** No ImportError.
+- **Spec trace:** N5, SC-8
+- **Difficulty:** 2
+
+**T13 · backend-dev-B · GREEN · Difficulty 3** (depends T12)
+- **Description:** Add `_install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.0)`. Installs SIGTERM + SIGINT handlers. Handler logic: call `child.terminate()`, then poll `child.poll()` in a loop sleeping 0.1s until either child exits OR drain_timeout elapses; if still alive after drain → `child.kill()`. Reentrant (second SIGINT during drain → immediate `child.kill()` + exit 130).
+- **File:** `src/llmcli/cli/proxy.py`
+- **Snippet:**
+  ```python
+  def _install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.0) -> None:
+      drain_state = {"active": False}
+      def handler(signum, frame):
+          if drain_state["active"] and signum == signal.SIGINT:
+              child.kill()
+              raise SystemExit(130)
+          drain_state["active"] = True
+          child.terminate()
+          deadline = time.monotonic() + drain_timeout
+          while time.monotonic() < deadline:
+              if child.poll() is not None:
+                  return
+              time.sleep(0.1)
+          child.kill()
+      signal.signal(signal.SIGTERM, handler)
+      signal.signal(signal.SIGINT, handler)
+  ```
+- **Verify:** `uv run python -c "from llmcli.cli.proxy import _install_signal_handlers"`
+- **Expected:** No ImportError.
+- **Spec trace:** N6, SC-6, SC-7
+- **Difficulty:** 3
+
+**T14 · backend-dev-B · GREEN · Difficulty 3** (depends T8, T13)
+- **Description:** Wire full lifecycle in `proxy_cmd` (replace NotImplementedError): when `config_out is None`, write to default state path (`~/.local/state/llmcli/proxy.config.yaml`), spawn litellm via `_spawn_litellm`, install signal handlers, `child.wait()`, `raise typer.Exit(child.returncode)`. Edge: child OOM (`returncode == -9`) → `raise typer.Exit(137)` (POSIX convention).
+- **File:** `src/llmcli/cli/proxy.py`
+- **Verify:** `uv run llmcli proxy --help | grep -i "managed LiteLLM"`
+- **Expected:** Command registered with the full docstring.
+- **Spec trace:** U1, U5, SC-5, SC-7
+- **Difficulty:** 3
+
+**T15 [P] · tester-C · RED · Difficulty 2** (depends T12)
+- **Description:** Tests for `_spawn_litellm` using `unittest.mock.patch`: (a) happy path → Popen called with `[litellm_path, "--config", str(p), "--port", "18091", "--host", "0.0.0.0"]`, (b) missing binary → typer.Exit(127) with "litellm binary not found" in stderr.
+- **File:** `tests/test_proxy_cmd.py`
+- **Verify:** `uv run pytest tests/test_proxy_cmd.py -k spawn -v`
+- **Expected:** 2 tests pass.
+- **Spec trace:** SC-5, SC-8
+- **Difficulty:** 2
+
+**T16 · tester-C · RED · Difficulty 3** (depends T13)
+- **Description:** Tests for `_install_signal_handlers` using mock Popen: (a) SIGTERM → `child.terminate()` called, then `child.poll()` polled, no `kill()` if child exits within drain, (b) child still alive after drain_timeout (set to 0.05s for test speed) → `child.kill()` called. Use `monkeypatch.setattr(signal, "signal", ...)` to capture handler then invoke synthetically.
+- **File:** `tests/test_proxy_cmd.py`
+- **Verify:** `uv run pytest tests/test_proxy_cmd.py -k signal -v`
+- **Expected:** 2 tests pass; no actual signals sent.
+- **Spec trace:** SC-6
+- **Difficulty:** 3
+
+**T17 · tester-C · RED · Difficulty 2** (depends T14)
+- **Description:** Test exit-code propagation: mock `_spawn_litellm` to return a fake Popen whose `wait()` returns 0 → command exits 0; returns 42 → command exits 42; returns -9 → command exits 137.
+- **File:** `tests/test_proxy_cmd.py`
+- **Verify:** `uv run pytest tests/test_proxy_cmd.py -k exit -v`
+- **Expected:** 3 tests pass.
+- **Spec trace:** SC-7
+- **Difficulty:** 2
+
+**T18 · tester-C · RED-GATE · Difficulty 1** (depends T11, T15, T16, T17)
+- **Description:** Full Slice 3 RED-GATE — entire `pytest tests/` green; no regressions.
+- **Verify:** `uv run pytest tests/ -q`
+- **Expected:** All tests pass.
+- **Spec trace:** SC-1..SC-8
+- **Difficulty:** 1
+
+### Slice V4 — Docs + lint (concurrent with V3)
+
+**T19 [P] · doc-writer · GREEN · Difficulty 2** (depends T14)
+- **Description:** Update `docs/guides/deployment.md` with a new section "Running `llmcli proxy` (managed LiteLLM portal)". Cover: command invocation, `--config-out` dry-run, expected health endpoint, manual smoke commands (curl liveliness, pgrep no-orphan), env vars (`LLMCLI_API_KEY`, `FIREWORKS_API_KEY`, etc.), expected exit codes.
+- **File:** `docs/guides/deployment.md`
+- **Verify:** `grep -c "llmcli proxy" docs/guides/deployment.md`
+- **Expected:** ≥ 5 (heading + invocations + smoke).
+- **Spec trace:** SC-9, SC-10, SC-11 (smoke documentation)
+- **Difficulty:** 2
+
+**T20 · devops · GREEN · Difficulty 1** (depends T14)
+- **Description:** Run quality gates: `uv run ruff check .` + `uv run ruff format --check .` + `uv run lint-imports`. Verify file-length quality-gate: `wc -l src/llmcli/cli/proxy.py < 300`.
+- **File:** (verification only)
+- **Verify:** `uv run ruff check . && uv run ruff format --check . && uv run lint-imports && [ $(wc -l < src/llmcli/cli/proxy.py) -lt 300 ]`
+- **Expected:** Exit 0 from each.
+- **Spec trace:** SC-10, SC-11, SC-12
+- **Difficulty:** 1
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs). -->
+
+### Wave 1 — start, 3 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | Add build_full_config returning dict |
+| T6 | backend-dev-B | — | Add proxy Typer command shell |
+| T7 | backend-dev-B | T6 | Add _validate_provider_keys helper |
+| T3 | tester-A | T1 | Tests for build_full_config (4 cases) |
+
+### Wave 2 — after T1, T7 land, 4 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T2 | backend-dev-A | T1 | Refactor build_block to wrap build_full_config |
+| T8 | backend-dev-B | T2,T6,T7 | Wire --config-out dry-run path |
+| T4 | tester-A | T2 | Test build_block empty-list invariant |
+| T9 | tester-B | T7 | Tests for _validate_provider_keys |
+
+### Wave 3 — after slice-1 tests pass + T8, 4 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T12 | backend-dev-B | T6 | Add _spawn_litellm helper |
+| T5 | tester-A | T2,T3,T4 | RED-GATE Slice 1 |
+| T10 | tester-B | T8 | Tests for --config-out dry-run |
+| T15 | tester-C | T12 | Tests for _spawn_litellm |
+
+### Wave 4 — after T12 + slice-1/2 gates, 4 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | backend-dev-B | T12 | Add _install_signal_handlers (poll-loop) |
+| T11 | tester-B | T5,T9,T10 | RED-GATE Slice 2 |
+| T16 | tester-C | T13 | Tests for signal forwarding |
+| T17 | tester-C | T14 | Tests for exit-code propagation |
+
+### Wave 5 — after T13 + slice-2 gate, 4 ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T14 | backend-dev-B | T8,T13 | Wire full lifecycle (spawn+signals+exit) |
+| T19 | doc-writer | T14 | Update docs/guides/deployment.md |
+| T20 | devops | T14 | Quality gates (ruff + importlinter + file-length) |
+| T18 | tester-C | T11,T15,T16,T17 | RED-GATE Slice 3 (full pytest green) |
+
+## Task IDs
+
+<!-- Generated by /plan on Approve. Used by /implement to resume after restart. -->
+- T1: #29 — Add build_full_config returning dict
+- T2: #30 — Refactor build_block to wrap build_full_config
+- T3: #31 — Tests for build_full_config (4 cases)
+- T4: #32 — Test build_block empty-list invariant
+- T5: #33 — RED-GATE Slice 1 (litellm_config tests green)
+- T6: #34 — Add proxy Typer command shell
+- T7: #35 — Add _validate_provider_keys helper
+- T8: #36 — Wire --config-out dry-run path
+- T9: #37 — Tests for _validate_provider_keys (3 cases)
+- T10: #38 — Tests for --config-out dry-run (2 cases)
+- T11: #39 — RED-GATE Slice 2 (slice 1 + dry-run tests green)
+- T12: #40 — Add _spawn_litellm helper
+- T13: #41 — Add _install_signal_handlers (poll-loop drain)
+- T14: #42 — Wire full lifecycle (spawn+signals+exit)
+- T15: #43 — Tests for _spawn_litellm (2 cases)
+- T16: #44 — Tests for signal forwarding (2 cases)
+- T17: #45 — Tests for exit-code propagation (3 cases)
+- T18: #46 — RED-GATE Slice 3 (full pytest green)
+- T19: #47 — Update docs/guides/deployment.md
+- T20: #48 — Quality gates (ruff + importlinter + file-length)

--- a/artifacts/specs/40-llmcli-proxy-portal-spec.mdx
+++ b/artifacts/specs/40-llmcli-proxy-portal-spec.mdx
@@ -1,0 +1,259 @@
+---
+title: "feat(proxy): add `llmcli proxy` — catalog-driven LiteLLM portal on :18091"
+issue: 40
+status: approved
+tier: F-lite
+date: 2026-05-19
+last_revised: 2026-05-19
+source: artifacts/frames/40-llmcli-proxy-portal-frame.mdx
+---
+
+## Context
+
+Promoted from [`40-llmcli-proxy-portal-frame.mdx`](../frames/40-llmcli-proxy-portal-frame.mdx).
+
+Step 3 of the **llmcli central-portal** plan. Phases 1 (`#36/#37`, cloud-passthrough catalog with `engine="remote"`) and 2 (`#38/#39`, `~/.roxabi/llmcli/` data-dir migration) are merged. With the catalog now the source of truth for both local and remote models, the LiteLLM proxy that exposes them should be owned end-to-end by llmcli — config generation **and** process lifecycle — so it composes cleanly into a Podman Quadlet (Step 4 of the plan, separate issue).
+
+Today's state:
+- `~/.litellm/config.yaml` is a hybrid: hand-written `general_settings` + `pass_through_endpoints` + `model_list` (NVIDIA deepseek), plus a sentinel-managed `# --- llmCLI managed block ---` rewritten by `llmcli register-proxy`.
+- The proxy process is owned by **lyra supervisor** (`~/projects/lyra/deploy/supervisor/conf.d/litellm.conf`, port `:4000`).
+- M₁ has no GPU and no lyra-supervisor reason-to-exist beyond hosting this proxy. M₂ requires two-repo coordination for every catalog change.
+
+This spec adds `llmcli proxy` — a sibling command of `llmcli serve` and `llmcli nats-serve` — that reads the catalog, emits a complete LiteLLM config to a managed tempfile, spawns `litellm` as a foreground subprocess, and forwards signals. **Strategy: Replace** (per `/frame` decision) — the existing `:4000` instance is retired in a follow-up ops task after Quadlet ships.
+
+Existing `llmcli register-proxy` stays functional this cycle (manual sentinel-block management for users who want to keep the `:4000` instance during migration); deprecation is a later issue.
+
+## Goal
+
+A single command — `llmcli proxy` — that owns the LiteLLM proxy lifecycle on a host: generates a complete, self-contained config from the catalog, spawns `litellm` on `:18091` by default, validates provider-key environment up front, and forwards SIGTERM/SIGINT cleanly to the child so systemd/Quadlet (Step 4) and supervisord (transition) can supervise it as any other long-running process.
+
+## Users
+
+**Current beneficiary (this issue alone):**
+- **Mickael (ops + dev)** — runs `llmcli proxy` on M₁ (cloud-only) and M₂ (mixed local + cloud), uses `--config-out` for debugging catalog → YAML mapping. Foreground run under supervisord during the migration window also works.
+
+**Deferred beneficiaries (require follow-up ops tasks):**
+- **systemd / Quadlet (Step 4)** — supervises `llmcli proxy` as a foreground unit; receives exit code from the child to drive restart policy
+- **lyra NATS satellite** (`llmcli nats-serve llm`) — points `LLMCLI_LITELLM_URL` at this proxy via the worker.env file
+- **Claude Code (`cccc/cccfk/ccd` aliases)** — current `:4000` consumers; migrate to `:18091` after Quadlet ships
+
+Not in scope: virtual keys, RBAC, hot-reload (catalog change → restart).
+
+## Expected Behavior
+
+### Happy path: `llmcli proxy`
+
+1. User runs `llmcli proxy` (no args) on a host that has `~/.roxabi/llmcli/llmcli.toml` + `models/*.toml` and `LLMCLI_API_KEY` exported.
+2. llmcli loads the catalog, applies the `machines = [...]` filter against `socket.gethostname()`, and computes the effective model set for this host.
+3. For each `engine="remote"` model in the effective set, llmcli looks up the provider in the registry (`fireworks` → `FIREWORKS_API_KEY`, `nvidia-nim` → `NVIDIA_API_KEY`, `anthropic` → `ANTHROPIC_API_KEY`, etc.) and checks the env var is present. Missing key → exit `1` with one-line actionable error per missing provider.
+4. llmcli writes the complete config YAML to `~/.local/state/llmcli/proxy.config.yaml` (overwriting any prior run), with file mode `0600`.
+5. llmcli `Popen`s `litellm --config <path> --port 18091 --host 0.0.0.0`, inheriting stdout/stderr.
+6. llmcli installs SIGTERM and SIGINT handlers that forward the signal to the child, wait up to 10s (`drain_timeout`), then send SIGKILL if the child is still alive.
+7. llmcli blocks on the child until it exits, then propagates the child's exit code as its own.
+
+### `--config-out PATH`
+
+Same as happy path through step 4, but instead of writing to the default state path and spawning litellm, write to `PATH` and exit `0` immediately. Used for debugging and dry runs. **No subprocess spawned, no signal handlers installed.**
+
+### `--port` / `--host`
+
+Override defaults (env vars `LLMCLI_PROXY_PORT` / `LLMCLI_PROXY_HOST` honored). No other behavioral change.
+
+### Failure modes
+
+| Failure | Exit code | User-facing output |
+|---|---|---|
+| Catalog missing/malformed | `2` | Existing `config.load()` error path (no change) |
+| Missing provider env var (e.g. `FIREWORKS_API_KEY`) | `1` | `Missing provider key for 'kimi-k2.6': set FIREWORKS_API_KEY (in environment or ~/.litellm/.env)` |
+| `litellm` binary missing on PATH | `127` | `litellm binary not found on PATH. Install with: uv tool install litellm` |
+| Port already in use | child's exit code | litellm's native stderr passes through |
+| SIGTERM during startup (before child spawn) | `143` | Clean exit, no temp file leaked |
+| Child exits non-zero | child's exit code | Passes through |
+
+### Catalog → LiteLLM YAML mapping
+
+Each model spec in the filtered catalog produces one `model_list` entry. Mapping is identical to the existing `build_block()` (PR #37) — this spec **reuses** that function, refactored to return a `dict` so the proxy command can wrap it in the larger config envelope. For `engine="llamacpp"` / `"llamacpp_tq3"` / `"vllm"` local specs, `api_base` is derived from `host.public_base_url` + `:{spec.port}/v1` (see `litellm_config.build_block` for the canonical formula; `build_full_config` inherits identical semantics).
+
+**Empty catalog invariant:** when the filtered catalog yields zero models, `build_full_config` returns `{"general_settings": {...}, "litellm_settings": {...}, "model_list": []}` (empty list, not `null`). `build_block` (the YAML-string wrapper) still emits `model_list: null` to preserve backwards compatibility with `register-proxy` and its existing tests.
+
+```yaml
+general_settings:
+  master_key: os.environ/LLMCLI_API_KEY       # from host.api_key_env
+litellm_settings:
+  drop_params: true                            # preserved from current behavior
+model_list:
+  - model_name: kimi-k2.6                      # engine=remote, provider=fireworks
+    litellm_params:
+      model: openai/accounts/fireworks/.../kimi-k2p6-turbo
+      api_base: https://api.fireworks.ai/inference/v1
+      api_key: os.environ/FIREWORKS_API_KEY
+  - model_name: claude-sonnet-4-6              # engine=remote, provider=anthropic
+    litellm_params:
+      model: anthropic/claude-sonnet-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+  - model_name: qwen3-8b                       # engine=llamacpp, local
+    litellm_params:
+      model: openai/qwen3-8b
+      api_base: http://roxabitower.lan:8091/v1 # from host.public_base_url + spec.port
+      api_key: os.environ/LLMCLI_API_KEY
+```
+
+No `pass_through_endpoints` in the generated config — these stay catalog-unaware this cycle (separate follow-up issue).
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class HostSettings {
+      <<frozen>>
+      +str bind
+      +str public_base_url
+      +str api_key_env
+      +str? default_model
+    }
+    class ModelSpec {
+      <<frozen>>
+      +str name
+      +str engine
+      +str? provider
+      +str? protocol
+      +str? model_id
+      +int? port
+      +list~str~ machines
+    }
+    class Catalog {
+      <<frozen>>
+      +HostSettings host
+      +dict~str,ModelSpec~ models
+    }
+    class ProxyArgs {
+      <<frozen>>
+      +int port
+      +str host
+      +Path? config_out
+    }
+    class GeneratedConfig {
+      <<dict>>
+      +dict general_settings
+      +dict litellm_settings
+      +list~dict~ model_list
+    }
+    Catalog "1" *-- "1" HostSettings
+    Catalog "1" *-- "n" ModelSpec
+    GeneratedConfig <.. Catalog : built from
+```
+
+`HostSettings`, `ModelSpec`, `Catalog` are pre-existing and unchanged. `ProxyArgs` is just the Typer command's parameter set — there is no separate dataclass at runtime. `GeneratedConfig` is a plain `dict[str, Any]` (no Pydantic) — it gets serialized to YAML and never round-trips. **Note:** `port` and `host` from `ProxyArgs` are passed to `litellm` via CLI flags (`--port`, `--host`); they do not appear in `GeneratedConfig`.
+
+### Consumers
+
+```mermaid
+flowchart LR
+    Catalog[~/.roxabi/llmcli/<br/>llmcli.toml + models/]
+    Gen[build_full_config dict]
+    YAML[~/.local/state/llmcli/<br/>proxy.config.yaml]
+    LL[litellm subprocess<br/>:18091]
+    Cli1[Claude Code<br/>cccc/cccfk/ccd]
+    Cli2[lyra NATS satellite<br/>llmcli nats-serve]
+    Cli3[hermes<br/>future]
+
+    Catalog --> Gen
+    Gen --> YAML
+    YAML --> LL
+    LL --> Cli1
+    LL --> Cli2
+    LL -.-> Cli3
+```
+
+### Consumer summary
+
+| Consumer | Field/Path consumed | When | Status |
+|---|---|---|---|
+| `build_full_config` | `catalog.host.api_key_env`, `host.public_base_url`, every `ModelSpec` | Each `llmcli proxy` invocation | This issue |
+| `litellm` subprocess | `proxy.config.yaml` (read-once at startup) | `--config` flag | This issue |
+| Signal handler | Child PID + exit code | On SIGTERM/SIGINT | This issue |
+| Claude Code | HTTP `:18091/v1/chat/completions`, `:18091/v1/messages` | At alias invocation | Future ops (replace `:4000` aliases) |
+| lyra NATS satellite | `LLMCLI_LITELLM_URL=http://M.lan:18091/v1` | Each NATS request | Future ops (worker.env update) |
+
+## Breadboard
+
+### Affordances (CLI)
+
+| ID | Element | Handler | Data in / out |
+|---|---|---|---|
+| U1 | `llmcli proxy` (no args) | `proxy.proxy_cmd` | Reads catalog + env → spawns `litellm`, blocks |
+| U2 | `--port N` / `LLMCLI_PROXY_PORT` | `proxy.proxy_cmd` | Overrides default `18091` |
+| U3 | `--host H` / `LLMCLI_PROXY_HOST` | `proxy.proxy_cmd` | Overrides default `0.0.0.0` |
+| U4 | `--config-out PATH` | `proxy.proxy_cmd` (dry-run branch) | Writes generated YAML to PATH, exits `0` |
+| U5 | SIGTERM / SIGINT to parent | `proxy._install_signal_handlers` | Forwards to child, waits 10s, SIGKILL |
+
+### Internals
+
+| ID | Node | Function | Owner module |
+|---|---|---|---|
+| N1 | Catalog loader | `config.load()` (existing, reused) | `llmcli.config` |
+| N2 | Provider-key validator | `proxy._validate_provider_keys(catalog)` | `llmcli.cli.proxy` |
+| N3 | Config dict builder | `litellm_config.build_full_config(catalog, public_base_url, hostname=None)` | `llmcli.litellm_config` |
+| N4 | YAML writer | `proxy._write_config(path, cfg)` (mode `0600`, parent mkdir) | `llmcli.cli.proxy` |
+| N5 | Process spawner | `proxy._spawn_litellm(config_path, port, host)` → `Popen` | `llmcli.cli.proxy` |
+| N6 | Signal forwarder | `proxy._install_signal_handlers(child, drain_timeout=10.0)` — uses `Popen.poll()` in a timed loop during drain (not blocking `wait()`) so a second SIGINT during the drain window is catchable | `llmcli.cli.proxy` |
+| N7 | Existing `build_block` (returns YAML string) | Now a thin wrapper over N3 — preserves `model_list: null` on empty for `register-proxy` backwards compat. **Exercised by existing `tests/test_litellm_config.py`** (no new wiring entry needed in slices). | `llmcli.litellm_config` |
+
+**File-placement note:** the new `proxy` Typer command is added to the **existing** `src/llmcli/cli/proxy.py` (which currently hosts `register-proxy`). Both commands coexist in the same file under the same `app`. No new module file is created.
+
+### Wiring
+
+- `U1` (+ `U2`, `U3` override defaults) → `N1` → `N2` → `N3` → `N4` → `N5(config_path, port, host)` → `N6` → blocks on child
+- `U4` → `N1` → `N2` → `N3` → `N4(PATH)` → exit
+- `U5` → `N6` → child SIGTERM → poll-loop drain → SIGKILL → propagate exit
+- `register-proxy` (existing, unchanged) → `N7` → writes sentinel block in `~/.litellm/config.yaml`
+
+## Slices
+
+| # | Slice | Demo-able outcome |
+|---|---|---|
+| 1 | **Refactor `build_block` → `build_full_config`** | `pytest tests/test_litellm_config.py` green; `build_full_config(catalog, url)` returns a complete dict with `general_settings`, `litellm_settings`, `model_list`. Existing `build_block` reduced to a wrapper that YAML-serializes the dict in sentinel-block form (no behavior change for `register-proxy`). |
+| 2 | **`llmcli proxy --config-out PATH` (dry-run only)** | `llmcli proxy --config-out /tmp/out.yaml` exits `0` and writes a valid LiteLLM config. Provider-key validation runs and fails fast on missing env. No subprocess spawned in this slice. |
+| 3 | **`llmcli proxy` full lifecycle (Popen + signals + exit-code)** | `llmcli proxy --port 18091` spawns litellm; `curl :18091/health/liveliness` returns 200; SIGTERM stops cleanly within 10s; orphan child after `SIGKILL` path tested via subprocess mocks. |
+
+Each slice is independently mergeable; slices 2 and 3 depend on slice 1's refactor.
+
+## Success Criteria
+
+- [ ] `build_full_config(catalog, public_base_url, hostname=None)` exists and returns a dict with exactly the keys `{"general_settings", "litellm_settings", "model_list"}` for a non-empty catalog
+- [ ] `build_block(catalog, public_base_url, hostname=None)` still returns the sentinel-wrapped YAML string (backwards compatible — `register-proxy` keeps working without code change in its own module)
+- [ ] `llmcli proxy --config-out /tmp/out.yaml` writes a YAML file that `yaml.safe_load`s to a dict matching `build_full_config(...)` for the active catalog
+- [ ] `llmcli proxy --config-out /tmp/out.yaml` exits `1` and prints a one-line actionable error when at least one `engine="remote"` model on the active host references an unset provider env var
+- [ ] `llmcli proxy` (no args) spawns a `litellm` child process bound to `0.0.0.0:18091` (unit test asserts on `Popen` argv via mock)
+- [ ] Sending `SIGTERM` to `llmcli proxy`'s PID causes the signal handler to call `proc.terminate()` then poll up to 10s, then `proc.kill()` if still alive — verified via subprocess mock (no real `litellm` needed)
+- [ ] `llmcli proxy` exits with the child's exit code (mock: child exits `0` → parent `0`; child exits `42` → parent `42`)
+- [ ] Missing `litellm` binary on `PATH` → `llmcli proxy` exits `127` with `litellm binary not found on PATH.` in stderr
+- [ ] `uv run pytest tests/test_litellm_config.py tests/test_proxy_cmd.py` is green
+- [ ] `uv run ruff check .` and `uv run ruff format --check .` are clean
+- [ ] `uv run lint-imports` is green (no new layer violation; `cli.proxy` imports only from `cli._app`, `litellm_config`, `config`, stdlib)
+- [ ] File-length quality gate passes (`src/llmcli/cli/proxy.py` ≤ 300 LOC)
+
+### Out-of-band smoke (manual, not blocking PR merge)
+
+- `llmcli proxy --port 18091` and `curl -s http://localhost:18091/health/liveliness` returns HTTP `200`
+- `pgrep -f litellm` shows no orphaned process after `SIGTERM` of `llmcli proxy`
+- One `engine="remote"` model and one local model (M₂ only) both respond on `:18091/v1/chat/completions`
+
+These smokes require an actual `litellm` binary + reachable backends; documented in `docs/guides/deployment.md` but **not** asserted by `pytest`.
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| Active catalog has zero models on this host (after `machines` filter) | Generate config with `model_list: []` — litellm starts and serves a working `/health/liveliness` for ops parity, even though `/v1/models` is empty. Log a one-line warning at startup. |
+| Both `--config-out` and `--port` passed | `--config-out` wins (dry-run path), `--port` ignored, info-level log notes the override |
+| User Ctrl-C twice in rapid succession during shutdown | First SIGINT → forward + start drain timer. Second SIGINT within drain window → immediate SIGKILL of child + exit `130`. |
+| Child crashes before signal handler installed (race) | Wait on child PID; if `Popen.poll()` returns non-None before handler install completes, propagate exit code as-is. |
+| `~/.local/state/llmcli/` doesn't exist | `mkdir -p` with mode `0700` before writing config file |
+| `~/.local/state/llmcli/proxy.config.yaml` from previous run is stale | Always overwrite (`open(path, "w")`); no merge or backup — config is fully derived from catalog |
+| Catalog has `engine="remote"` model but provider not in registry | Existing `litellm_config.build_block` raises `ValueError` — surface to user as exit `2` with the error message |
+| `LLMCLI_API_KEY` is unset | Not validated by `llmcli proxy` itself (litellm receives the `os.environ/LLMCLI_API_KEY` reference and fails at first auth attempt). Documented in `--help` and the README. **Deliberate non-goal:** parent-side validation would re-implement litellm's own startup check. |
+| Child killed by OOM (`returncode == -9` / `137`) | `Popen.wait()` returns the negative signal number; parent maps `-9 → 137` (POSIX convention) and exits with that code. Same path as any other non-zero child exit — no special handling. |
+| `litellm` binary on PATH but wrong/incompatible CLI version (`--host` flag rejected, etc.) | No version gate. Child's stderr passes through; parent exits with child's exit code. Documented under troubleshooting in the README, not enforced. |

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -535,3 +535,99 @@ The `run_serve.sh` probe polls `/health` for up to 180 s before supervisor marks
 program ready (see [`supervisor/scripts/run_serve.sh`](../../supervisor/scripts/run_serve.sh),
 `LLMCLI_PROBE_TIMEOUT`). A timeout here means the model failed to load — check VRAM and
 binary availability.
+
+---
+
+## Running `llmcli proxy` (managed LiteLLM portal)
+
+`llmcli proxy` reads the llmcli catalog (`~/.roxabi/llmcli/llmcli.toml`), builds a
+complete LiteLLM config, and spawns `litellm` as a supervised foreground process on
+`:18091` by default. This replaces the hand-maintained `~/.litellm/config.yaml` + lyra
+supervisor pattern for new deployments.
+
+### Invocation
+
+```bash
+llmcli proxy                           # bind 0.0.0.0:18091 (defaults)
+llmcli proxy --port 4001 --host 127.0.0.1
+LLMCLI_PROXY_PORT=4002 llmcli proxy
+```
+
+`--port` and `--host` can also be set via environment variables `LLMCLI_PROXY_PORT` and
+`LLMCLI_PROXY_HOST`. The command blocks until the child exits; stdout and stderr from
+`litellm` are inherited directly (structured JSON logs, no Rich wrapping).
+
+### Dry-run mode (`--config-out`)
+
+```bash
+llmcli proxy --config-out /tmp/proxy.config.yaml
+cat /tmp/proxy.config.yaml | yq .general_settings.master_key
+```
+
+Writes the generated LiteLLM YAML to `PATH` and exits `0` without spawning `litellm`.
+Provider-key validation still runs — missing keys abort before writing. Useful for:
+
+- Inspecting the catalog-to-YAML mapping during development
+- `ExecStartPre` in a Podman Quadlet unit (validate config before the service starts)
+
+When `--config-out` is not provided, the generated config is written to
+`~/.local/state/llmcli/proxy.config.yaml` (file mode `0600`, directory mode `0700`)
+before `litellm` is spawned.
+
+### Required environment variables
+
+Set these in the process environment or in `~/.litellm/.env` (litellm reads this file at
+startup):
+
+| Variable | Purpose | When required |
+|---|---|---|
+| `LLMCLI_API_KEY` | Master key clients use to authenticate to the proxy (`Authorization: Bearer`) | Always |
+| `FIREWORKS_API_KEY` | Fireworks AI backend | Catalog has `provider = "fireworks"` remote models |
+| `ANTHROPIC_API_KEY` | Anthropic backend | Catalog has `provider = "anthropic"` remote models |
+| `NVIDIA_API_KEY` | NVIDIA NIM backend | Catalog has `provider = "nvidia-nim"` remote models |
+
+`LLMCLI_API_KEY` is passed to LiteLLM as an `os.environ/` reference in `general_settings.master_key`; litellm resolves it at startup. Missing provider keys are caught by `llmcli proxy` before the child spawns — the command exits `1` and prints one actionable line per missing key:
+
+```
+Missing provider key for 'kimi-k2.6': set FIREWORKS_API_KEY (in environment or ~/.litellm/.env)
+```
+
+### Manual smoke commands (post-spawn, separate terminal)
+
+```bash
+# Liveliness
+curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/health | jq .
+
+# Model list
+curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/v1/models | jq '.data[].id'
+
+# No orphan litellm processes after Ctrl-C
+pgrep -fa litellm
+```
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean exit from the child `litellm` process |
+| `1` | Missing provider key — pre-spawn validation failure |
+| `127` | `litellm` binary not found on `PATH` — install with `uv add 'litellm[proxy]'` |
+| `130` | Interrupted via Ctrl-C (POSIX convention: 128 + SIGINT 2) |
+| `137` | Child killed by SIGKILL — e.g. OOM (POSIX: 128 + 9) |
+| `143` | Child killed by SIGTERM (POSIX: 128 + 15) |
+
+Any other non-zero code is the child's own exit code, passed through unchanged.
+
+### Signal handling
+
+`llmcli proxy` installs handlers for both SIGTERM and SIGINT before blocking on the
+child:
+
+1. **First SIGTERM or SIGINT** — calls `child.terminate()` (sends SIGTERM to the litellm
+   process), then polls `child.poll()` in 0.1s ticks for up to 10 seconds. If the child
+   has not exited after the drain window, `child.kill()` (SIGKILL) is sent.
+2. **Second SIGINT during the drain window** — bypasses the remaining drain and calls
+   `child.kill()` immediately, then exits `130`.
+
+This ensures that `systemd`, `supervisord`, and interactive Ctrl-C all receive a clean
+shutdown while preventing the process from hanging indefinitely on an unresponsive child.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -596,7 +596,7 @@ Missing provider key for 'kimi-k2.6': set FIREWORKS_API_KEY (in environment or ~
 
 ```bash
 # Liveliness
-curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/health | jq .
+curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/health/liveliness | jq .
 
 # Model list
 curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/v1/models | jq '.data[].id'

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import socket
 import subprocess
 from pathlib import Path
@@ -122,3 +123,31 @@ def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> li
                 "(in environment or ~/.litellm/.env)"
             )
     return errors
+
+
+def _spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen:
+    """Spawn the litellm proxy subprocess with inherited stdout/stderr.
+
+    Locates the binary via shutil.which. Missing → typer.echo to stderr
+    and typer.Exit(127). Inherits parent stdout/stderr (LiteLLM logs are
+    structured JSON; no Rich wrapping post-spawn).
+
+    Args:
+        config_path: Path to the generated proxy config YAML.
+        port: TCP port (e.g. 18091).
+        host: Bind host (e.g. "0.0.0.0").
+
+    Returns:
+        subprocess.Popen handle for caller to wait()/signal.
+    """
+    binary = shutil.which("litellm")
+    if binary is None:
+        err_console.print(
+            "[red]litellm binary not found on PATH.[/red] "
+            "Install with: uv tool install 'litellm[proxy]' "
+            "or `uv add 'litellm[proxy]'`"
+        )
+        raise typer.Exit(127)
+    return subprocess.Popen(  # noqa: S603
+        [binary, "--config", str(config_path), "--port", str(port), "--host", host]
+    )

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -188,3 +188,31 @@ def _spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen:
     return subprocess.Popen(  # noqa: S603
         [binary, "--config", str(config_path), "--port", str(port), "--host", host]
     )
+
+
+def _install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.0) -> None:
+    """Forward SIGTERM/SIGINT to the litellm child with a poll-loop drain.
+
+    First signal: child.terminate() → poll child.poll() in 0.1s ticks until
+    child exits or drain_timeout elapses; if still alive → child.kill().
+
+    Reentrant: a second SIGINT during drain triggers immediate child.kill()
+    and raises SystemExit(130) (POSIX convention for SIGINT).
+    """
+    drain_state = {"active": False}
+
+    def handler(signum, frame):  # noqa: ARG001 (signature required by signal.signal)
+        if drain_state["active"] and signum == signal.SIGINT:
+            child.kill()
+            raise SystemExit(130)
+        drain_state["active"] = True
+        child.terminate()
+        deadline = time.monotonic() + drain_timeout
+        while time.monotonic() < deadline:
+            if child.poll() is not None:
+                return
+            time.sleep(0.1)
+        child.kill()
+
+    signal.signal(signal.SIGTERM, handler)
+    signal.signal(signal.SIGINT, handler)

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -106,7 +106,11 @@ def proxy(
     import llmcli.cli as _cli
 
     # 1. Load catalog
-    catalog = _cli.config.load()
+    try:
+        catalog = _cli.config.load()
+    except FileNotFoundError as exc:
+        err_console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1)
 
     # 2. Validate provider keys
     errors = _validate_provider_keys(catalog)
@@ -132,6 +136,10 @@ def proxy(
 
     # 6. If --config-out, dry-run exit
     if config_out is not None:
+        if port != 18091:
+            err_console.print(
+                f"[yellow]--port {port} ignored in --config-out (dry-run) mode[/yellow]"
+            )
         console.print(f"[green]Wrote proxy config to {target}[/green]")
         raise typer.Exit(0)
 
@@ -162,7 +170,11 @@ def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> li
             continue
         provider = PROVIDERS.get(spec.provider)
         if provider is None:
-            continue  # surfaced as ValueError by build_full_config later
+            errors.append(
+                f"Unknown provider '{spec.provider}' in model '{name}': "
+                f"valid providers are {sorted(PROVIDERS.keys())}."
+            )
+            continue
         if not os.environ.get(provider.key_env):
             errors.append(
                 f"Missing provider key for '{name}': set {provider.key_env} "

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -98,7 +98,9 @@ def register_proxy(
 def proxy(
     port: int = typer.Option(18091, "--port", envvar="LLMCLI_PROXY_PORT"),
     host: str = typer.Option("0.0.0.0", "--host", envvar="LLMCLI_PROXY_HOST"),
-    config_out: Optional[Path] = typer.Option(None, "--config-out", help="Write generated YAML to PATH and exit (dry-run)."),
+    config_out: Optional[Path] = typer.Option(
+        None, "--config-out", help="Write generated YAML to PATH and exit (dry-run)."
+    ),
 ) -> None:
     """Run a managed LiteLLM proxy bound to :{port} from the llmCLI catalog."""
     import llmcli.cli as _cli

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -17,6 +17,12 @@ from llmcli.config import Catalog
 from llmcli.litellm_config import build_full_config
 from llmcli.providers import PROVIDERS
 
+# Import style note: pure functions (build_full_config, PROVIDERS) are imported
+# directly because tests never patch them through the `llmcli.cli` namespace.
+# Patchable surface (config, build_block, write_block, reload_proxy) goes via
+# the lazy `_cli = llmcli.cli` indirection inside the command bodies — see the
+# patchable-surface docstring in `llmcli/cli/__init__.py`.
+
 
 # ---------------------------------------------------------------------------
 # register-proxy

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import socket
 import subprocess
 from pathlib import Path
@@ -8,6 +9,8 @@ from typing import Optional
 import typer
 
 from llmcli.cli._app import app, console, err_console
+from llmcli.config import Catalog
+from llmcli.providers import PROVIDERS
 
 
 # ---------------------------------------------------------------------------
@@ -94,3 +97,28 @@ def proxy(
 ) -> None:
     """Run a managed LiteLLM proxy bound to :{port} from the llmCLI catalog."""
     raise NotImplementedError  # body filled in T8 and T14
+
+
+def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> list[str]:
+    """Return list of missing-provider-key error messages; empty list = OK.
+
+    Skips local engines. For each engine="remote" spec on the effective host
+    (machines filter applied), looks up PROVIDERS[spec.provider].key_env and
+    checks os.environ; missing → append an actionable error string.
+    """
+    effective = hostname or socket.gethostname()
+    errors: list[str] = []
+    for name, spec in catalog.models.items():
+        if spec.engine != "remote":
+            continue
+        if spec.machines and effective not in spec.machines:
+            continue
+        provider = PROVIDERS.get(spec.provider)
+        if provider is None:
+            continue  # surfaced as ValueError by build_full_config later
+        if not os.environ.get(provider.key_env):
+            errors.append(
+                f"Missing provider key for '{name}': set {provider.key_env} "
+                "(in environment or ~/.litellm/.env)"
+            )
+    return errors

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -135,6 +135,16 @@ def proxy(
     else:
         target = Path.home() / ".local" / "state" / "llmcli" / "proxy.config.yaml"
 
+    # 4a. Spawn path: validate litellm binary exists BEFORE writing the config file
+    # so we never leave a stale ~/.local/state/llmcli/proxy.config.yaml on PATH failure.
+    if config_out is None:
+        if shutil.which("litellm") is None:
+            err_console.print(
+                "[red]litellm binary not found on PATH.[/red] "
+                "Install with: uv tool install 'litellm[proxy]' or `uv add 'litellm[proxy]'`"
+            )
+            raise typer.Exit(127)
+
     # 5. Write with 0o700 dir mode, 0o600 file mode
     target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     target.write_text(yaml_text)

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -133,8 +133,15 @@ def proxy(
         console.print(f"[green]Wrote proxy config to {target}[/green]")
         raise typer.Exit(0)
 
-    # 7. Full lifecycle (spawn+signals+wait) lands in T14
-    raise NotImplementedError("Full lifecycle wired in T14")
+    # 7. Spawn litellm, install signal handlers, wait, propagate exit code
+    child = _spawn_litellm(target, port, host)
+    _install_signal_handlers(child)
+    returncode = child.wait()
+    # POSIX convention: negative return = killed by signal N → exit 128+N
+    # Specifically, -9 (SIGKILL, e.g. OOM) → 137
+    if returncode < 0:
+        raise typer.Exit(128 + abs(returncode))
+    raise typer.Exit(returncode)
 
 
 def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> list[str]:

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -79,3 +79,18 @@ def register_proxy(
         f"models=[bold]{model_count}[/bold] "
         f"reload={reload_status}"
     )
+
+
+# ---------------------------------------------------------------------------
+# proxy
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def proxy(
+    port: int = typer.Option(18091, "--port", envvar="LLMCLI_PROXY_PORT"),
+    host: str = typer.Option("0.0.0.0", "--host", envvar="LLMCLI_PROXY_HOST"),
+    config_out: Optional[Path] = typer.Option(None, "--config-out", help="Write generated YAML to PATH and exit (dry-run)."),
+) -> None:
+    """Run a managed LiteLLM proxy bound to :{port} from the llmCLI catalog."""
+    raise NotImplementedError  # body filled in T8 and T14

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import socket
 import subprocess
+import time
 from pathlib import Path
 from typing import Optional
 
 import typer
+import yaml
 
 from llmcli.cli._app import app, console, err_console
 from llmcli.config import Catalog
+from llmcli.litellm_config import build_full_config
 from llmcli.providers import PROVIDERS
 
 
@@ -97,7 +101,40 @@ def proxy(
     config_out: Optional[Path] = typer.Option(None, "--config-out", help="Write generated YAML to PATH and exit (dry-run)."),
 ) -> None:
     """Run a managed LiteLLM proxy bound to :{port} from the llmCLI catalog."""
-    raise NotImplementedError  # body filled in T8 and T14
+    import llmcli.cli as _cli
+
+    # 1. Load catalog
+    catalog = _cli.config.load()
+
+    # 2. Validate provider keys
+    errors = _validate_provider_keys(catalog)
+    if errors:
+        for err in errors:
+            err_console.print(f"[red]{err}[/red]")
+        raise typer.Exit(1)
+
+    # 3. Build config dict + serialize to YAML
+    cfg = build_full_config(catalog, catalog.host.public_base_url)
+    yaml_text = yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False)
+
+    # 4. Choose target path
+    if config_out is not None:
+        target = config_out
+    else:
+        target = Path.home() / ".local" / "state" / "llmcli" / "proxy.config.yaml"
+
+    # 5. Write with 0o700 dir mode, 0o600 file mode
+    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    target.write_text(yaml_text)
+    target.chmod(0o600)
+
+    # 6. If --config-out, dry-run exit
+    if config_out is not None:
+        console.print(f"[green]Wrote proxy config to {target}[/green]")
+        raise typer.Exit(0)
+
+    # 7. Full lifecycle (spawn+signals+wait) lands in T14
+    raise NotImplementedError("Full lifecycle wired in T14")
 
 
 def _validate_provider_keys(catalog: Catalog, hostname: str | None = None) -> list[str]:

--- a/src/llmcli/litellm_config.py
+++ b/src/llmcli/litellm_config.py
@@ -101,6 +101,7 @@ def build_block(catalog: Catalog, public_base_url: str, *, hostname: str | None 
             {"model_list": model_list}, default_flow_style=False, sort_keys=False
         )
     else:
+        # null (not []) preserves register-proxy backwards-compat sentinel form
         inner = yaml.safe_dump({"model_list": None}, default_flow_style=False)
     return f"{BLOCK_START}\n{inner}{BLOCK_END}\n"
 

--- a/src/llmcli/litellm_config.py
+++ b/src/llmcli/litellm_config.py
@@ -94,60 +94,14 @@ def build_block(catalog: Catalog, public_base_url: str, *, hostname: str | None 
     Returns:
         YAML string wrapped in llmCLI sentinel comments.
     """
-    effective_hostname = hostname if hostname is not None else socket.gethostname()
-    api_key_ref = f"os.environ/{catalog.host.api_key_env}"
-
-    model_list = []
-    for name, spec in catalog.models.items():
-        # Per-machine filter: skip if machines is set and hostname not in list
-        if spec.machines and effective_hostname not in spec.machines:
-            continue
-
-        if spec.engine == "remote":
-            provider_cfg = PROVIDERS.get(spec.provider)
-            if provider_cfg is None:
-                raise ValueError(
-                    f"Unknown provider '{spec.provider}' in spec '{name}'. "
-                    f"Valid providers: {sorted(PROVIDERS.keys())}."
-                )
-            provider = provider_cfg
-            if spec.protocol == "anthropic":
-                entry = {
-                    "model_name": name,
-                    "litellm_params": {
-                        "model": f"anthropic/{spec.model_id}",
-                        "api_key": f"os.environ/{provider.key_env}",
-                    },
-                }
-            else:
-                # protocol == "openai"
-                entry = {
-                    "model_name": name,
-                    "litellm_params": {
-                        "model": f"openai/{spec.model_id}",
-                        "api_base": provider.api_base,
-                        "api_key": f"os.environ/{provider.key_env}",
-                    },
-                }
-        else:
-            # Local engines: llamacpp, llamacpp_tq3, vllm
-            entry = {
-                "model_name": name,
-                "litellm_params": {
-                    "model": f"openai/{name}",
-                    "api_base": f"{public_base_url}:{spec.port}/v1",
-                    "api_key": api_key_ref,
-                },
-            }
-        model_list.append(entry)
-
+    cfg = build_full_config(catalog, public_base_url, hostname=hostname)
+    model_list = cfg["model_list"]
     if model_list:
         inner = yaml.safe_dump(
             {"model_list": model_list}, default_flow_style=False, sort_keys=False
         )
     else:
         inner = yaml.safe_dump({"model_list": None}, default_flow_style=False)
-
     return f"{BLOCK_START}\n{inner}{BLOCK_END}\n"
 
 

--- a/src/llmcli/litellm_config.py
+++ b/src/llmcli/litellm_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import socket
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -12,6 +13,74 @@ from .providers import PROVIDERS
 LITELLM_CONFIG = Path.home() / ".litellm" / "config.yaml"
 BLOCK_START = "# --- llmCLI managed block start ---"
 BLOCK_END = "# --- llmCLI managed block end ---"
+
+
+def build_full_config(
+    catalog: Catalog, public_base_url: str, *, hostname: str | None = None
+) -> dict[str, Any]:
+    """Build a complete LiteLLM proxy config dict from the catalog.
+
+    Args:
+        catalog: Loaded catalog with host settings and model specs.
+        public_base_url: Base URL for the host (e.g. 'http://roxabitower.lan').
+        hostname: Override hostname for machine filter (default: socket.gethostname()).
+
+    Returns:
+        Dict with keys: general_settings, litellm_settings, model_list.
+        model_list is [] (not None) when the filtered catalog is empty.
+    """
+    effective_hostname = hostname if hostname is not None else socket.gethostname()
+    api_key_ref = f"os.environ/{catalog.host.api_key_env}"
+
+    model_list: list[dict[str, Any]] = []
+    for name, spec in catalog.models.items():
+        # Per-machine filter: skip if machines is set and hostname not in list
+        if spec.machines and effective_hostname not in spec.machines:
+            continue
+
+        if spec.engine == "remote":
+            provider_cfg = PROVIDERS.get(spec.provider)
+            if provider_cfg is None:
+                raise ValueError(
+                    f"Unknown provider '{spec.provider}' in spec '{name}'. "
+                    f"Valid providers: {sorted(PROVIDERS.keys())}."
+                )
+            provider = provider_cfg
+            if spec.protocol == "anthropic":
+                entry: dict[str, Any] = {
+                    "model_name": name,
+                    "litellm_params": {
+                        "model": f"anthropic/{spec.model_id}",
+                        "api_key": f"os.environ/{provider.key_env}",
+                    },
+                }
+            else:
+                # protocol == "openai"
+                entry = {
+                    "model_name": name,
+                    "litellm_params": {
+                        "model": f"openai/{spec.model_id}",
+                        "api_base": provider.api_base,
+                        "api_key": f"os.environ/{provider.key_env}",
+                    },
+                }
+        else:
+            # Local engines: llamacpp, llamacpp_tq3, vllm
+            entry = {
+                "model_name": name,
+                "litellm_params": {
+                    "model": f"openai/{name}",
+                    "api_base": f"{public_base_url}:{spec.port}/v1",
+                    "api_key": api_key_ref,
+                },
+            }
+        model_list.append(entry)
+
+    return {
+        "general_settings": {"master_key": api_key_ref},
+        "litellm_settings": {"drop_params": True},
+        "model_list": model_list,
+    }
 
 
 def build_block(catalog: Catalog, public_base_url: str, *, hostname: str | None = None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -648,12 +648,8 @@ class TestRegisterProxyCommand:
             patch("llmcli.cli.reload_proxy", create=True),
         ):
             mock_config_mod.load.return_value = mixed_catalog
-            mock_config_mod.check_vram_budget.side_effect = (
-                real_config.check_vram_budget
-            )
-            result = runner.invoke(
-                app, ["register-proxy", "--config", str(config_path)]
-            )
+            mock_config_mod.check_vram_budget.side_effect = real_config.check_vram_budget
+            result = runner.invoke(app, ["register-proxy", "--config", str(config_path)])
 
         assert result.exit_code == 0, f"Unexpected exit: {result.output}"
         assert config_path.exists(), "Config file was not created"

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -811,3 +811,30 @@ class TestBuildFullConfig:
         # Assert — model_list is present AND is an empty list (not None)
         assert "model_list" in result
         assert result["model_list"] == []
+
+    def test_anthropic_protocol_entry_has_no_api_base(self) -> None:
+        """Anthropic-protocol remote spec produces an entry without api_base, model prefixed anthropic/.
+
+        Mutation discipline: if the anthropic branch is removed (falling through to the openai
+        branch), api_base would be present and the model prefix would be 'openai/' rather than
+        'anthropic/'. Both assertions would fail, making this an iron-clad negative test.
+        """
+        # Arrange: catalog with engine="remote", protocol="anthropic", provider="anthropic"
+        catalog = _make_remote_catalog("anthropic")
+        # Act
+        result = build_full_config(catalog, PUBLIC_BASE_URL, hostname="any-host")
+        # Assert: exactly one entry with a claude model name
+        claude_entries = [m for m in result["model_list"] if m["model_name"].startswith("claude")]
+        assert len(claude_entries) == 1, (
+            f"Expected 1 claude entry, got {len(claude_entries)}: "
+            f"{[m['model_name'] for m in result['model_list']]}"
+        )
+        entry = claude_entries[0]
+        # api_base must be absent — LiteLLM resolves anthropic natively
+        assert "api_base" not in entry["litellm_params"], (
+            f"api_base must not be set for anthropic protocol, got: {entry['litellm_params']}"
+        )
+        # model must be prefixed with "anthropic/"
+        assert entry["litellm_params"]["model"].startswith("anthropic/"), (
+            f"Expected model to start with 'anthropic/', got: {entry['litellm_params']['model']}"
+        )

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -689,3 +689,93 @@ class TestBuildBlockHostnameFilter:
         parsed = yaml.safe_load(inner)
         model_list = parsed.get("model_list") if parsed else None
         assert not model_list
+
+
+# ---------------------------------------------------------------------------
+# build_full_config — complete proxy config dict (issue #40)
+# ---------------------------------------------------------------------------
+
+
+def _make_mixed_catalog(
+    remote_machines: list[str] | None = None,
+    local_machines: list[str] | None = None,
+) -> Catalog:
+    """Build a catalog with one remote (openai) model and one local (llamacpp) model."""
+    host = HostSettings(
+        bind="0.0.0.0",
+        public_base_url=PUBLIC_BASE_URL,
+        api_key_env="LLMCLI_API_KEY",
+    )
+    remote_spec = ModelSpec(
+        name="kimi-k2",
+        engine="remote",
+        provider="fireworks",
+        model_id="accounts/fireworks/models/kimi",
+        protocol="openai",
+        machines=remote_machines or [],
+    )
+    local_spec = ModelSpec(
+        name="qwen3-8b",
+        engine="llamacpp",
+        repo="Org/Qwen3-8B-GGUF",
+        file="qwen3-8b-q4_k_m.gguf",
+        port=8091,
+        vram_gib=5.5,
+        machines=local_machines or [],
+    )
+    return Catalog(host=host, models={"kimi-k2": remote_spec, "qwen3-8b": local_spec})
+
+
+from llmcli.litellm_config import build_full_config  # noqa: E402
+
+
+class TestBuildFullConfig:
+    def test_returns_dict_with_required_keys(self) -> None:
+        """Catalog with 1 remote + 1 local model → result has all 3 keys; litellm_settings correct."""
+        # Arrange
+        catalog = _make_mixed_catalog()
+        # Act
+        result = build_full_config(catalog, PUBLIC_BASE_URL, hostname="any-host")
+        # Assert — all three top-level keys present
+        assert "general_settings" in result
+        assert "litellm_settings" in result
+        assert "model_list" in result
+        # litellm_settings is exactly {"drop_params": True}
+        assert result["litellm_settings"] == {"drop_params": True}
+        # model_list contains entries for both models
+        names = {entry["model_name"] for entry in result["model_list"]}
+        assert names == {"kimi-k2", "qwen3-8b"}
+
+    def test_machines_filter_excludes_non_matching(self) -> None:
+        """Model with machines=["other-host"] is excluded when hostname="this-host"."""
+        # Arrange — remote pinned to "other-host", local open
+        catalog = _make_mixed_catalog(remote_machines=["other-host"], local_machines=[])
+        # Act
+        result = build_full_config(catalog, PUBLIC_BASE_URL, hostname="this-host")
+        # Assert — only the open local model survives the filter
+        names = {entry["model_name"] for entry in result["model_list"]}
+        assert "kimi-k2" not in names
+        assert "qwen3-8b" in names
+
+    def test_master_key_from_api_key_env(self) -> None:
+        """general_settings.master_key == 'os.environ/<api_key_env>'."""
+        # Arrange
+        catalog = _make_mixed_catalog()
+        expected_key = f"os.environ/{catalog.host.api_key_env}"
+        # Act
+        result = build_full_config(catalog, PUBLIC_BASE_URL, hostname="any-host")
+        # Assert
+        assert result["general_settings"]["master_key"] == expected_key
+
+    def test_empty_filter_yields_empty_list(self) -> None:
+        """All models filtered out → model_list is [] (not None, not absent)."""
+        # Arrange — both models pinned to "never-host"
+        catalog = _make_mixed_catalog(
+            remote_machines=["never-host"],
+            local_machines=["never-host"],
+        )
+        # Act
+        result = build_full_config(catalog, PUBLIC_BASE_URL, hostname="this-host")
+        # Assert — model_list is present AND is an empty list (not None)
+        assert "model_list" in result
+        assert result["model_list"] == []

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -690,6 +690,38 @@ class TestBuildBlockHostnameFilter:
         model_list = parsed.get("model_list") if parsed else None
         assert not model_list
 
+    def test_build_block_empty_filter_yields_null(self) -> None:
+        """Empty filtered catalog → block contains 'model_list: null', NOT 'model_list: []'."""
+        # Arrange — catalog where ALL models have non-matching machines
+        host = HostSettings(
+            bind="0.0.0.0",
+            public_base_url=PUBLIC_BASE_URL,
+            api_key_env="LLMCLI_API_KEY",
+        )
+        pinned_a = ModelSpec(
+            name="kimi-k2",
+            engine="remote",
+            provider="fireworks",
+            model_id="accounts/fireworks/models/kimi",
+            protocol="openai",
+            machines=["other-host"],
+        )
+        pinned_b = ModelSpec(
+            name="qwen3-8b",
+            engine="llamacpp",
+            repo="Org/Qwen3-8B-GGUF",
+            file="qwen3-8b-q4_k_m.gguf",
+            port=8091,
+            vram_gib=5.5,
+            machines=["other-host"],
+        )
+        catalog = Catalog(host=host, models={"kimi-k2": pinned_a, "qwen3-8b": pinned_b})
+        # Act — hostname mismatch ensures all specs are filtered out
+        block = build_block(catalog, "http://example.lan", hostname="some-other-host")
+        # Assert — YAML null (not []) preserves register-proxy back-compat
+        assert "model_list: null" in block
+        assert "model_list: []" not in block
+
 
 # ---------------------------------------------------------------------------
 # build_full_config — complete proxy config dict (issue #40)

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -812,6 +812,27 @@ class TestBuildFullConfig:
         assert "model_list" in result
         assert result["model_list"] == []
 
+    def test_unknown_provider_raises_value_error(self) -> None:
+        """build_full_config raises ValueError for an engine='remote' spec with unknown provider."""
+        # Arrange: catalog with engine="remote", provider not in PROVIDERS
+        host = HostSettings(
+            bind="0.0.0.0",
+            public_base_url=PUBLIC_BASE_URL,
+            api_key_env="LLMCLI_API_KEY",
+        )
+        bad_spec = ModelSpec(
+            name="unknown-model",
+            engine="remote",
+            provider="not-a-real-provider",
+            model_id="some/model",
+            protocol="openai",
+            machines=[],
+        )
+        catalog = Catalog(host=host, models={"unknown-model": bad_spec})
+        # Act + Assert
+        with pytest.raises(ValueError, match="Unknown provider"):
+            build_full_config(catalog, PUBLIC_BASE_URL)
+
     def test_anthropic_protocol_entry_has_no_api_base(self) -> None:
         """Anthropic-protocol remote spec produces an entry without api_base, model prefixed anthropic/.
 

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -87,14 +87,23 @@ class TestValidateProviderKeys:
         assert provider.key_env in result[0]
 
     def test_local_models_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Local engine models (e.g. llamacpp) are skipped regardless of environment state."""
-        # Arrange — ensure no stray provider keys that could mask a bug
-        for p in PROVIDERS.values():
-            monkeypatch.delenv(p.key_env, raising=False)
+        """Engine guard prevents local models from going through remote-key validation.
+
+        Mutation discipline: the local model uses a REAL valid provider string
+        ("fireworks") so the unknown-provider branch cannot catch it. The
+        fireworks key IS set in the environment, so a removed engine guard would
+        NOT cause a missing-key error — it would validate the local model against
+        fireworks, which is semantically wrong but invisible without the guard.
+        The test must distinguish "engine guard works" from "unknown-provider fallback works."
+        """
+        # Arrange: set fireworks key so removing the engine guard would not raise a
+        # missing-key error — the guard must be the only thing protecting local models.
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
         catalog = _make_catalog(
             models={
                 "qwen3-8b": dict(
                     engine="llamacpp",
+                    provider="fireworks",
                     repo="Org/Qwen3-8B-GGUF",
                     file="qwen3-8b-q4_k_m.gguf",
                     port=8091,
@@ -102,10 +111,51 @@ class TestValidateProviderKeys:
                 )
             }
         )
+
+        # Spy on PROVIDERS.get to confirm the engine guard short-circuits before
+        # PROVIDERS.get is called for this local model.
+        import llmcli.cli.proxy as proxy_mod
+
+        providers_mock = MagicMock(wraps=proxy_mod.PROVIDERS)
+        monkeypatch.setattr(proxy_mod, "PROVIDERS", providers_mock)
+
         # Act
-        result = _validate_provider_keys(catalog, hostname="roxabitower")
-        # Assert
-        assert result == []
+        errors = _validate_provider_keys(catalog, hostname="roxabitower")
+
+        # Assert: no errors (engine guard skipped the local model entirely)
+        assert errors == []
+        # Assert: PROVIDERS.get was never called — the engine guard short-circuited
+        providers_mock.get.assert_not_called()
+
+    def test_remote_model_pinned_to_other_host_is_not_validated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Machines filter excludes remote model on non-matching host — no key check.
+
+        Mutation discipline: if the machines filter is removed from _validate_provider_keys,
+        the remote fireworks model would be evaluated on "this-host" and the missing
+        FIREWORKS_API_KEY would produce an error. The test therefore fails when the filter
+        is deleted.
+        """
+        # Arrange: remote model pinned to "other-host", key NOT in env.
+        # If machines filter is removed, this remote model would generate a
+        # missing-key error on "this-host". If filter works, no error.
+        monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+        catalog = _make_catalog(
+            models={
+                "kimi-k2": dict(
+                    engine="remote",
+                    provider="fireworks",
+                    model_id="accounts/fireworks/models/kimi",
+                    protocol="openai",
+                    machines=["other-host"],
+                )
+            }
+        )
+        # Act
+        errors = _validate_provider_keys(catalog, hostname="this-host")
+        # Assert: no errors — the machines filter excluded the model before key check
+        assert errors == []
 
 
 # ---------------------------------------------------------------------------
@@ -328,6 +378,8 @@ class TestConfigOutDryRun:
         assert "litellm_settings" in cfg
         assert "model_list" in cfg
         assert cfg["general_settings"]["master_key"] == "os.environ/LLMCLI_API_KEY"
+        # Assert file mode is 0o600 (security invariant — credentials path)
+        assert oct(out_path.stat().st_mode & 0o777) == oct(0o600)
 
     def test_config_out_missing_provider_env_exits_one_no_file(
         self,

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -266,3 +266,98 @@ class TestSignalForwarding:
 
         assert exc_info.value.code == 130
         assert child.kill.called is True
+
+
+# ---------------------------------------------------------------------------
+# TestConfigOutDryRun
+# ---------------------------------------------------------------------------
+
+
+class TestConfigOutDryRun:
+    """Integration tests for the `proxy --config-out` dry-run path."""
+
+    def test_config_out_writes_yaml_and_exits_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """--config-out writes a valid YAML with expected top-level keys and exits 0."""
+        import yaml
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        # Arrange — env vars required by _validate_provider_keys + catalog.host.api_key_env
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+
+        catalog = _make_catalog(
+            models={
+                "kimi-k2": dict(
+                    engine="remote",
+                    provider="fireworks",
+                    model_id="accounts/fireworks/models/kimi",
+                    protocol="openai",
+                    machines=[],
+                )
+            }
+        )
+        out_path = tmp_path / "proxy.yaml"
+
+        runner = CliRunner()
+
+        # Act — patch catalog loader so test is hermetic (no real TOML on disk needed)
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            result = runner.invoke(typer_app, ["proxy", "--config-out", str(out_path)])
+
+        # Assert
+        assert result.exit_code == 0, f"Unexpected exit code; output: {result.output!r}"
+        assert out_path.exists(), "Output file was not created"
+
+        cfg = yaml.safe_load(out_path.read_text())
+        assert "general_settings" in cfg
+        assert "litellm_settings" in cfg
+        assert "model_list" in cfg
+        assert cfg["general_settings"]["master_key"] == "os.environ/LLMCLI_API_KEY"
+
+    def test_config_out_missing_provider_env_exits_one_no_file(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """--config-out exits 1 with key_env name in output and does NOT write the file."""
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        # Arrange — master key present, provider key absent
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        key_env = PROVIDERS["fireworks"].key_env  # FIREWORKS_API_KEY
+        monkeypatch.delenv(key_env, raising=False)
+
+        catalog = _make_catalog(
+            models={
+                "kimi-k2": dict(
+                    engine="remote",
+                    provider="fireworks",
+                    model_id="accounts/fireworks/models/kimi",
+                    protocol="openai",
+                    machines=[],
+                )
+            }
+        )
+        out_path = tmp_path / "proxy.yaml"
+
+        runner = CliRunner()
+
+        # Act
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            result = runner.invoke(typer_app, ["proxy", "--config-out", str(out_path)])
+
+        # Assert
+        assert result.exit_code == 1, f"Expected exit code 1; output: {result.output!r}"
+        combined_output = result.output + result.stderr
+        assert key_env in combined_output, (
+            f"Expected '{key_env}' in output/stderr but got: {combined_output!r}"
+        )
+        assert not out_path.exists(), "Output file must not be written on validation failure"

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -262,7 +262,9 @@ class TestSignalForwarding:
 
         # Arrange
         child = MagicMock(spec=subprocess.Popen)
-        # Child never exits — poll always returns None
+        # poll() set to None as a safety net but never reached in this scenario:
+        # drain_timeout=0.0 makes the deadline already-past on first check, so the
+        # while-loop body never executes; kill() is called right after the loop exits.
         child.poll.return_value = None
 
         captured_handlers: dict = {}
@@ -273,7 +275,7 @@ class TestSignalForwarding:
         monkeypatch.setattr(proxy_mod.signal, "signal", fake_signal_signal)
         monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
 
-        # Act — very short timeout so the deadline passes immediately
+        # Act — drain_timeout=0.0 → deadline expires immediately, loop skipped
         _install_signal_handlers(child, drain_timeout=0.0)
         handler = captured_handlers[signal.SIGTERM]
         handler(signal.SIGTERM, None)

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -149,3 +149,120 @@ class TestSpawnLitellm:
 
         assert exc_info.value.exit_code == 127
         assert "litellm binary not found" in stderr_buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# TestSignalForwarding
+# ---------------------------------------------------------------------------
+
+
+class TestSignalForwarding:
+    def test_sigterm_terminates_child_polls_then_returns_when_exited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Handler terminates child and returns without kill when child exits within drain."""
+        import signal
+        import subprocess
+        import time as time_mod
+
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _install_signal_handlers
+
+        # Arrange
+        child = MagicMock(spec=subprocess.Popen)
+        # Simulate child exiting after two polls
+        child.poll.side_effect = [None, None, 0]
+
+        captured_handlers: dict = {}
+
+        def fake_signal_signal(signum, handler):
+            captured_handlers[signum] = handler
+
+        monkeypatch.setattr(proxy_mod.signal, "signal", fake_signal_signal)
+        monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
+
+        # Act — register handlers, then invoke captured SIGTERM handler
+        _install_signal_handlers(child, drain_timeout=0.5)
+        handler = captured_handlers[signal.SIGTERM]
+        handler(signal.SIGTERM, None)
+
+        # Assert
+        assert child.terminate.called is True
+        assert child.poll.call_count >= 1
+        assert child.kill.called is False
+
+    def test_drain_timeout_exceeded_kills_child(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Handler calls kill when child does not exit within drain_timeout."""
+        import signal
+        import subprocess
+
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _install_signal_handlers
+
+        # Arrange
+        child = MagicMock(spec=subprocess.Popen)
+        # Child never exits — poll always returns None
+        child.poll.return_value = None
+
+        captured_handlers: dict = {}
+
+        def fake_signal_signal(signum, handler):
+            captured_handlers[signum] = handler
+
+        monkeypatch.setattr(proxy_mod.signal, "signal", fake_signal_signal)
+        monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
+
+        # Act — very short timeout so the deadline passes immediately
+        _install_signal_handlers(child, drain_timeout=0.0)
+        handler = captured_handlers[signal.SIGTERM]
+        handler(signal.SIGTERM, None)
+
+        # Assert
+        assert child.terminate.called is True
+        assert child.kill.called is True
+
+    def test_double_sigint_during_drain_kills_and_exits_130(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Second SIGINT during active drain raises SystemExit(130) and kills child."""
+        import signal
+        import subprocess
+
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _install_signal_handlers
+
+        # Arrange
+        child = MagicMock(spec=subprocess.Popen)
+        # Child never exits so drain stays active
+        child.poll.return_value = None
+
+        captured_handlers: dict = {}
+
+        def fake_signal_signal(signum, handler):
+            captured_handlers[signum] = handler
+
+        monkeypatch.setattr(proxy_mod.signal, "signal", fake_signal_signal)
+        monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
+
+        # Act — zero timeout so first SIGINT drains immediately and finishes
+        # then second SIGINT hits the reentrant path
+        _install_signal_handlers(child, drain_timeout=0.0)
+        handler = captured_handlers[signal.SIGINT]
+
+        # First SIGINT: triggers drain (timeout=0 so kill is called, but
+        # drain_state["active"] is set before kill)
+        # We need drain_state to be active, so patch time.monotonic to force
+        # the deadline to be already past on first invocation too — the first
+        # call will set active=True, terminate, then exhaust the loop and kill.
+        # To isolate the reentrant path, call handler once to set drain_state
+        # active, then call again.
+        handler(signal.SIGINT, None)  # first — sets active, drain exhausts, kills
+        child.kill.reset_mock()       # reset so we can assert the reentrant kill
+
+        with pytest.raises(SystemExit) as exc_info:
+            handler(signal.SIGINT, None)  # second — reentrant path
+
+        assert exc_info.value.code == 130
+        assert child.kill.called is True

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -1,0 +1,102 @@
+"""Tests for llmcli.cli.proxy — _validate_provider_keys."""
+
+from __future__ import annotations
+
+import pytest
+
+from llmcli.config import Catalog, HostSettings, ModelSpec
+from llmcli.cli.proxy import _validate_provider_keys
+from llmcli.providers import PROVIDERS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PUBLIC_BASE_URL = "http://roxabitower.lan"
+
+
+def _make_catalog(models: dict[str, dict] | None = None) -> Catalog:
+    """Build a Catalog with the given model specs."""
+    host = HostSettings(
+        bind="0.0.0.0",
+        public_base_url=PUBLIC_BASE_URL,
+        api_key_env="LLMCLI_API_KEY",
+        default_model="qwen3-8b",
+        vram_budget_gib=16.0,
+    )
+    if models is None:
+        models = {}
+    model_specs = {name: ModelSpec(name=name, **spec) for name, spec in models.items()}
+    return Catalog(host=host, models=model_specs)
+
+
+# ---------------------------------------------------------------------------
+# TestValidateProviderKeys
+# ---------------------------------------------------------------------------
+
+
+class TestValidateProviderKeys:
+    def test_all_keys_set_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No errors when all remote provider keys are present in the environment."""
+        # Arrange
+        provider = PROVIDERS["fireworks"]
+        monkeypatch.setenv(provider.key_env, "test-key")
+        catalog = _make_catalog(
+            models={
+                "kimi-k2": dict(
+                    engine="remote",
+                    provider="fireworks",
+                    model_id="accounts/fireworks/models/kimi",
+                    protocol="openai",
+                    machines=[],
+                )
+            }
+        )
+        # Act
+        result = _validate_provider_keys(catalog, hostname="roxabitower")
+        # Assert
+        assert result == []
+
+    def test_missing_remote_key_returns_one_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One error string is returned when the provider key is absent from the environment."""
+        # Arrange
+        provider = PROVIDERS["nvidia-nim"]
+        monkeypatch.delenv(provider.key_env, raising=False)
+        catalog = _make_catalog(
+            models={
+                "nvidia-llama": dict(
+                    engine="remote",
+                    provider="nvidia-nim",
+                    model_id="meta/llama-3.1-8b-instruct",
+                    protocol="openai",
+                    machines=[],
+                )
+            }
+        )
+        # Act
+        result = _validate_provider_keys(catalog, hostname="roxabitower")
+        # Assert
+        assert len(result) == 1
+        assert provider.key_env in result[0]
+
+    def test_local_models_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Local engine models (e.g. llamacpp) are skipped regardless of environment state."""
+        # Arrange — ensure no stray provider keys that could mask a bug
+        for p in PROVIDERS.values():
+            monkeypatch.delenv(p.key_env, raising=False)
+        catalog = _make_catalog(
+            models={
+                "qwen3-8b": dict(
+                    engine="llamacpp",
+                    repo="Org/Qwen3-8B-GGUF",
+                    file="qwen3-8b-q4_k_m.gguf",
+                    port=8091,
+                    vram_gib=5.5,
+                )
+            }
+        )
+        # Act
+        result = _validate_provider_keys(catalog, hostname="roxabitower")
+        # Assert
+        assert result == []

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -1,8 +1,14 @@
-"""Tests for llmcli.cli.proxy — _validate_provider_keys."""
+"""Tests for llmcli.cli.proxy — _validate_provider_keys and _spawn_litellm."""
 
 from __future__ import annotations
 
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
+import typer
+from rich.console import Console
 
 from llmcli.config import Catalog, HostSettings, ModelSpec
 from llmcli.cli.proxy import _validate_provider_keys
@@ -100,3 +106,46 @@ class TestValidateProviderKeys:
         result = _validate_provider_keys(catalog, hostname="roxabitower")
         # Assert
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestSpawnLitellm
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnLitellm:
+    def test_happy_path_calls_popen_with_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Popen is called with the correct argument list when the binary is found."""
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _spawn_litellm
+
+        # Arrange
+        fake_popen = MagicMock()
+        monkeypatch.setattr(proxy_mod.shutil, "which", lambda name: "/usr/local/bin/litellm" if name == "litellm" else None)
+        monkeypatch.setattr(proxy_mod.subprocess, "Popen", fake_popen)
+
+        # Act
+        _spawn_litellm(Path("/tmp/cfg.yaml"), 18091, "0.0.0.0")
+
+        # Assert
+        fake_popen.assert_called_once_with(
+            ["/usr/local/bin/litellm", "--config", "/tmp/cfg.yaml", "--port", "18091", "--host", "0.0.0.0"]
+        )
+
+    def test_missing_binary_exits_127(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """typer.Exit(127) is raised and stderr contains the expected message when litellm is not on PATH."""
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _spawn_litellm
+
+        # Arrange
+        monkeypatch.setattr(proxy_mod.shutil, "which", lambda name: None)
+        stderr_buffer = StringIO()
+        fake_err_console = Console(file=stderr_buffer, highlight=False)
+        monkeypatch.setattr(proxy_mod, "err_console", fake_err_console)
+
+        # Act + Assert
+        with pytest.raises(typer.Exit) as exc_info:
+            _spawn_litellm(Path("/tmp/cfg.yaml"), 18091, "0.0.0.0")
+
+        assert exc_info.value.exit_code == 127
+        assert "litellm binary not found" in stderr_buffer.getvalue()

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -361,3 +361,131 @@ class TestConfigOutDryRun:
             f"Expected '{key_env}' in output/stderr but got: {combined_output!r}"
         )
         assert not out_path.exists(), "Output file must not be written on validation failure"
+
+
+# ---------------------------------------------------------------------------
+# TestExitCodePropagation
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodePropagation:
+    """Integration tests for exit-code propagation through the proxy lifecycle."""
+
+    def _make_remote_catalog(self) -> "Catalog":
+        """Build a Catalog with a single remote model (fireworks) for lifecycle tests."""
+        return _make_catalog(
+            models={
+                "kimi-k2": dict(
+                    engine="remote",
+                    provider="fireworks",
+                    model_id="accounts/fireworks/models/kimi",
+                    protocol="openai",
+                    machines=[],
+                )
+            }
+        )
+
+    def test_exit_zero_propagates_as_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """proxy returns exit code 0 when litellm exits with code 0."""
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        # Arrange
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        # Redirect Path.home() to tmp_path so state-dir writes go to a temp location
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        fake_child = MagicMock()
+        fake_child.wait.return_value = 0
+        fake_spawn = MagicMock(return_value=fake_child)
+
+        catalog = self._make_remote_catalog()
+        runner = CliRunner()
+
+        # Act
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
+            monkeypatch.setattr(
+                "llmcli.cli.proxy._install_signal_handlers",
+                lambda *a, **k: None,
+            )
+            result = runner.invoke(typer_app, ["proxy"])
+
+        # Assert
+        assert result.exit_code == 0, f"Expected 0; got {result.exit_code}; output: {result.output!r}"
+
+    def test_exit_forty_two_propagates(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """proxy returns exit code 42 when litellm exits with code 42."""
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        # Arrange
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        fake_child = MagicMock()
+        fake_child.wait.return_value = 42
+        fake_spawn = MagicMock(return_value=fake_child)
+
+        catalog = self._make_remote_catalog()
+        runner = CliRunner()
+
+        # Act
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
+            monkeypatch.setattr(
+                "llmcli.cli.proxy._install_signal_handlers",
+                lambda *a, **k: None,
+            )
+            result = runner.invoke(typer_app, ["proxy"])
+
+        # Assert
+        assert result.exit_code == 42, f"Expected 42; got {result.exit_code}; output: {result.output!r}"
+
+    def test_negative_nine_maps_to_137(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """proxy returns exit code 137 when litellm is SIGKILL-ed (wait() returns -9)."""
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        # Arrange
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        fake_child = MagicMock()
+        # POSIX: negative return code means killed by signal abs(returncode)
+        # -9 = SIGKILL (e.g. OOM), expected propagated code = 128 + 9 = 137
+        fake_child.wait.return_value = -9
+        fake_spawn = MagicMock(return_value=fake_child)
+
+        catalog = self._make_remote_catalog()
+        runner = CliRunner()
+
+        # Act
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
+            monkeypatch.setattr(
+                "llmcli.cli.proxy._install_signal_handlers",
+                lambda *a, **k: None,
+            )
+            result = runner.invoke(typer_app, ["proxy"])
+
+        # Assert
+        assert result.exit_code == 137, f"Expected 137 (128+9); got {result.exit_code}; output: {result.output!r}"

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -473,6 +473,14 @@ class TestExitCodePropagation:
         # Act
         with patch("llmcli.cli.config") as mock_config:
             mock_config.load.return_value = catalog
+            # Mock shutil.which so the early binary check passes regardless of host env
+            import llmcli.cli.proxy as proxy_mod
+
+            monkeypatch.setattr(
+                proxy_mod.shutil,
+                "which",
+                lambda name: "/usr/local/bin/litellm" if name == "litellm" else None,
+            )
             monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
             monkeypatch.setattr(
                 "llmcli.cli.proxy._install_signal_handlers",
@@ -509,6 +517,14 @@ class TestExitCodePropagation:
         # Act
         with patch("llmcli.cli.config") as mock_config:
             mock_config.load.return_value = catalog
+            # Mock shutil.which so the early binary check passes regardless of host env
+            import llmcli.cli.proxy as proxy_mod
+
+            monkeypatch.setattr(
+                proxy_mod.shutil,
+                "which",
+                lambda name: "/usr/local/bin/litellm" if name == "litellm" else None,
+            )
             monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
             monkeypatch.setattr(
                 "llmcli.cli.proxy._install_signal_handlers",
@@ -547,6 +563,14 @@ class TestExitCodePropagation:
         # Act
         with patch("llmcli.cli.config") as mock_config:
             mock_config.load.return_value = catalog
+            # Mock shutil.which so the early binary check passes regardless of host env
+            import llmcli.cli.proxy as proxy_mod
+
+            monkeypatch.setattr(
+                proxy_mod.shutil,
+                "which",
+                lambda name: "/usr/local/bin/litellm" if name == "litellm" else None,
+            )
             monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
             monkeypatch.setattr(
                 "llmcli.cli.proxy._install_signal_handlers",

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -121,7 +121,11 @@ class TestSpawnLitellm:
 
         # Arrange
         fake_popen = MagicMock()
-        monkeypatch.setattr(proxy_mod.shutil, "which", lambda name: "/usr/local/bin/litellm" if name == "litellm" else None)
+        monkeypatch.setattr(
+            proxy_mod.shutil,
+            "which",
+            lambda name: "/usr/local/bin/litellm" if name == "litellm" else None,
+        )
         monkeypatch.setattr(proxy_mod.subprocess, "Popen", fake_popen)
 
         # Act
@@ -129,7 +133,15 @@ class TestSpawnLitellm:
 
         # Assert
         fake_popen.assert_called_once_with(
-            ["/usr/local/bin/litellm", "--config", "/tmp/cfg.yaml", "--port", "18091", "--host", "0.0.0.0"]
+            [
+                "/usr/local/bin/litellm",
+                "--config",
+                "/tmp/cfg.yaml",
+                "--port",
+                "18091",
+                "--host",
+                "0.0.0.0",
+            ]
         )
 
     def test_missing_binary_exits_127(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -163,7 +175,6 @@ class TestSignalForwarding:
         """Handler terminates child and returns without kill when child exits within drain."""
         import signal
         import subprocess
-        import time as time_mod
 
         import llmcli.cli.proxy as proxy_mod
         from llmcli.cli.proxy import _install_signal_handlers
@@ -191,9 +202,7 @@ class TestSignalForwarding:
         assert child.poll.call_count >= 1
         assert child.kill.called is False
 
-    def test_drain_timeout_exceeded_kills_child(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_drain_timeout_exceeded_kills_child(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Handler calls kill when child does not exit within drain_timeout."""
         import signal
         import subprocess
@@ -259,7 +268,7 @@ class TestSignalForwarding:
         # To isolate the reentrant path, call handler once to set drain_state
         # active, then call again.
         handler(signal.SIGINT, None)  # first — sets active, drain exhausts, kills
-        child.kill.reset_mock()       # reset so we can assert the reentrant kill
+        child.kill.reset_mock()  # reset so we can assert the reentrant kill
 
         with pytest.raises(SystemExit) as exc_info:
             handler(signal.SIGINT, None)  # second — reentrant path
@@ -418,7 +427,9 @@ class TestExitCodePropagation:
             result = runner.invoke(typer_app, ["proxy"])
 
         # Assert
-        assert result.exit_code == 0, f"Expected 0; got {result.exit_code}; output: {result.output!r}"
+        assert result.exit_code == 0, (
+            f"Expected 0; got {result.exit_code}; output: {result.output!r}"
+        )
 
     def test_exit_forty_two_propagates(
         self,
@@ -452,7 +463,9 @@ class TestExitCodePropagation:
             result = runner.invoke(typer_app, ["proxy"])
 
         # Assert
-        assert result.exit_code == 42, f"Expected 42; got {result.exit_code}; output: {result.output!r}"
+        assert result.exit_code == 42, (
+            f"Expected 42; got {result.exit_code}; output: {result.output!r}"
+        )
 
     def test_negative_nine_maps_to_137(
         self,
@@ -488,4 +501,6 @@ class TestExitCodePropagation:
             result = runner.invoke(typer_app, ["proxy"])
 
         # Assert
-        assert result.exit_code == 137, f"Expected 137 (128+9); got {result.exit_code}; output: {result.output!r}"
+        assert result.exit_code == 137, (
+            f"Expected 137 (128+9); got {result.exit_code}; output: {result.output!r}"
+        )


### PR DESCRIPTION
## Summary

- New `llmcli proxy` Typer command owns the LiteLLM proxy lifecycle (config generation + subprocess) on `:18091`, replacing the lyra-supervisor-coupled `:4000` instance.
- Refactors `litellm_config.build_block` to wrap a new dict-returning `build_full_config`, eliminating ~60 lines of duplicated model_list construction while preserving the `model_list: null` empty-list invariant for `register-proxy` back-compat.
- `--config-out PATH` dry-run, pre-spawn provider-key validation, poll-loop SIGTERM/SIGINT drain (reentrant double-Ctrl-C → SIGKILL + exit 130), POSIX exit-code propagation (OOM/-9 → 137).

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Intent | #40: feat(proxy) — `llmcli proxy` catalog-driven LiteLLM portal | open |
| Frame | [40-llmcli-proxy-portal-frame.mdx](artifacts/frames/40-llmcli-proxy-portal-frame.mdx) | approved |
| Spec | [40-llmcli-proxy-portal-spec.mdx](artifacts/specs/40-llmcli-proxy-portal-spec.mdx) | approved |
| Plan | [40-llmcli-proxy-portal-plan.mdx](artifacts/plans/40-llmcli-proxy-portal-plan.mdx) | approved |
| Implementation | 16 commits on `feat/40-llmcli-proxy-portal` | complete |
| Verification | ruff ✓ · ruff format ✓ · lint-imports 3/3 ✓ · pytest 331/331 (57 new) | passed |

## Slices

| Slice | Tasks | Files | Tests |
|---|---|---|---|
| V1 — refactor | T1, T2, T3, T4, T5 | `litellm_config.py` | 5 (4 build_full_config + 1 empty-list invariant) |
| V2 — `--config-out` dry-run | T6, T7, T8, T9, T10, T11 | `cli/proxy.py` | 5 (3 validate_keys + 2 config-out) |
| V3 — full lifecycle | T12, T13, T14, T15, T16, T17, T18 | `cli/proxy.py` | 8 (2 spawn + 3 signals + 3 exit-code) |
| V4 — docs+lint | T19, T20 | `docs/guides/deployment.md` | — |

## Test Plan
- [ ] `uv run llmcli proxy --help` lists `--port`, `--host`, `--config-out` options
- [ ] `uv run llmcli proxy --config-out /tmp/out.yaml` writes valid YAML + exits 0 (dry-run)
- [ ] Missing `FIREWORKS_API_KEY` with fireworks model in catalog → exit 1 + actionable stderr message
- [ ] Real-binary smoke (after `uv add 'litellm[proxy]'`): `llmcli proxy` binds `:18091`; `curl -s -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/health` returns 200; Ctrl-C drains within 10s; `pgrep -fa litellm` shows no orphan
- [ ] Double Ctrl-C during drain → immediate SIGKILL + exit 130
- [ ] Quality gates: file-length 227/300 (`cli/proxy.py`), 189/300 (`litellm_config.py`), importlinter 3/3 contracts

## Out of Scope (follow-ups)
- `llmcli.container` Quadlet definition (Step 4 of central-portal plan)
- Migrate `deepseek-v4-pro` from hand-written `~/.litellm/config.yaml` into catalog (Step 5b)
- Replace running `:4000` lyra-supervisor instance (ops task after Quadlet ships)
- Migrate `cccc/cccfk/ccd` aliases `:4000` → `:18091`
- Catalog support for `pass_through_endpoints` (separate issue)
- Deprecate `llmcli register-proxy` (later cycle)

Closes #40

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`