### PR TITLE
fix(nats): adopt wait_ready=False worker opt-out

### DIFF
--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -65,6 +65,7 @@ class LlmNatsAdapter(GenerationMixin, NatsAdapterBase):
             heartbeat_interval=heartbeat_interval,
             drain_timeout=drain_timeout,
             inbox_prefix="_inbox.llmcli-llm",
+            wait_ready=False,  # worker semantics — see NatsAdapterBase docstring
         )
         self._model_name = model_name
         self._socket_path = socket_path or SOCKET_PATH

--- a/uv.lock
+++ b/uv.lock
@@ -2328,15 +2328,15 @@ wheels = [
 [[package]]
 name = "roxabi-contracts"
 version = "0.4.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#99f9bb25e45c3d26445f3a8bd0de097e6e5ed330" }
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
 dependencies = [
     { name = "pydantic" },
 ]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.3.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#99f9bb25e45c3d26445f3a8bd0de097e6e5ed330" }
+version = "0.4.1"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary

- Passes `wait_ready=False` to `NatsAdapterBase.__init__` in `LlmNatsAdapter` — worker (RPC responder) semantics; skips the JetStream KV readiness probe that requires `$JS.API.>` ACL grants workers don't hold
- Refreshes `uv.lock` to pick up `roxabi-nats v0.4.1` from lyra/staging (`7a21ce8e`)

Closes follow-up from Roxabi/lyra#1147. Upstream change landed in Roxabi/lyra#1285.

## Test plan

- [x] `uv run pytest` — 350/350 passed
- [x] `uv run ruff check .` — clean
- [x] `from roxabi_nats import NatsAdapterBase; assert 'wait_ready' in inspect.signature(...).parameters` — confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)