### PR TITLE
feat(deploy): package llmcli proxy as Podman Quadlet (#44)

### DIFF
--- a/Dockerfile.llm
+++ b/Dockerfile.llm
@@ -41,14 +41,14 @@ RUN UV_SKIP="--no-install-package torch \
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-install-project \
         $(cat /uv-skip-flags) \
-        --extra nats
+        --extra nats --extra proxy
 
 COPY src/ ./src/
 RUN uv sync --frozen --no-dev \
         $(cat /uv-skip-flags) \
-        --extra nats
+        --extra nats --extra proxy
 
-COPY deploy/entrypoint-nats.sh /entrypoint.sh
+COPY deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # ── runtime stage ─────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ install:
 install-quadlet:
 	@mkdir -p $(QUADLET_DIR)
 	@install -m 644 deploy/quadlet/llmcli.container $(QUADLET_DIR)/llmcli.container
-	@if [ ! -f $(QUADLET_ENV) ]; then \
-	  printf '# llmcli.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' > $(QUADLET_ENV) ; \
-	  chmod 600 $(QUADLET_ENV) ; \
+	@if [ ! -f "$(QUADLET_ENV)" ]; then \
+	  install -m 600 /dev/null "$(QUADLET_ENV)" ; \
+	  printf '# llmcli.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' >> "$(QUADLET_ENV)" ; \
 	  echo "Created stub $(QUADLET_ENV) — edit before starting." ; \
 	else \
 	  echo "Preserving existing $(QUADLET_ENV)." ; \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@ SUPERVISOR_HUB ?= $(HOME)/projects
 HUB_SERVICES   := llm
 -include $(SUPERVISOR_HUB)/hub.mk
 
-.PHONY: register llm llm-swap install lint test
+QUADLET_DIR := $(HOME)/.config/containers/systemd
+QUADLET_ENV := $(QUADLET_DIR)/llmcli.env
+
+.PHONY: register llm llm-swap install lint test install-quadlet
 
 register:
 	@echo "Registering llmCLI with supervisor hub..."
@@ -36,6 +39,19 @@ llm-swap:
 
 install:
 	uv sync
+
+install-quadlet:
+	@mkdir -p $(QUADLET_DIR)
+	@install -m 644 deploy/quadlet/llmcli.container $(QUADLET_DIR)/llmcli.container
+	@if [ ! -f $(QUADLET_ENV) ]; then \
+	  printf '# llmcli.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' > $(QUADLET_ENV) ; \
+	  chmod 600 $(QUADLET_ENV) ; \
+	  echo "Created stub $(QUADLET_ENV) — edit before starting." ; \
+	else \
+	  echo "Preserving existing $(QUADLET_ENV)." ; \
+	fi
+	@systemctl --user daemon-reload
+	@echo "Installed. Next: systemctl --user start llmcli"
 
 lint:
 	uv run ruff check .

--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ llama-server :PORT  ◄── llmcli_serve (supervisor, catalog-driven hot-swap)
 ## Supervisor
 
 Single program `llmcli_serve` registered into the lyra hub supervisor via `make register`. Local: `autostart=false`. Prod: `autostart=true`.
+
+## Quadlet (production HTTP proxy)
+
+Run `llmcli proxy` under user-systemd via a Podman Quadlet on `:18091`:
+
+```bash
+make install-quadlet
+$EDITOR ~/.config/containers/systemd/llmcli.env
+systemctl --user start llmcli
+```
+
+See `docs/guides/deployment.md` → "Running `llmcli proxy` as a Quadlet" for the full flow.

--- a/artifacts/frames/44-llmcli-quadlet-frame.mdx
+++ b/artifacts/frames/44-llmcli-quadlet-frame.mdx
@@ -1,0 +1,64 @@
+---
+title: feat(deploy) — package `llmcli proxy` as Podman Quadlet on M₁ + M₂
+issue: 44
+status: approved
+tier: F-lite
+date: 2026-05-20
+---
+
+## Problem
+
+Step 3 of the central-portal plan (#40) shipped `llmcli proxy` as a foreground binary that owns both config generation and process lifecycle. Step 4 now packages that binary as a Podman Quadlet so user-systemd supervises it directly on both M₁ (prod) and M₂ (dev) — finally allowing the `:4000` lyra-supervisor instance to be retired (Step 6).
+
+Trigger: Step 3 is merged; consumers (lyra, hermes, claude-code) need a stable, restart-survivable `:18091` endpoint that survives reboots without manual `make llm`.
+
+Observable today: `llmcli proxy` must be started manually on both hosts (`make llm` or shell). Crash on M₁ requires manual intervention. M₂ has no clean lifecycle (`make llm` blocks the shell).
+
+## Who
+
+- **Primary:** Mickael (ops) — needs `systemctl --user start/restart/status llmcli` to manage the portal on both hosts with the same grammar
+- **Secondary:**
+  - lyra, hermes, claude-code consumers — gain a stable, restart-survivable `:18091`
+  - M₁ (roxabituwer) — finally drops lyra-supervisor as a hard dep for proxy hosting
+  - Future Quadlet adopters (voiceCLI, imageCLI) — `llmcli.container` becomes the reference pattern
+
+## Constraints
+
+- Quadlet `.container` unit only — no Compose, no Kubernetes (lyra/voiceCLI pattern)
+- M₁ (roxabituwer, prod): autostart via user-linger; restart on crash
+- M₂ (roxabitower, dev): manual `systemctl --user start`, no auto-restart on crash
+- Mount: `~/.roxabi/llmcli/` (catalog, RW) + `~/.local/state/llmcli/` (state, RW) + `~/.cache/huggingface/` (model cache, RW)
+- Env: `LLMCLI_API_KEY`, `LLMCLI_PROXY_PORT=18091`, `LLMCLI_PROXY_HOST=0.0.0.0`
+- Image: reuse llmcli's published image OR build local from `pyproject.toml` if none exists (decide in spec)
+- `enable` is a no-op for Quadlet-generated user units — persistence is auto-wired by the generator (per project memory: `feedback_quadlet_enable_is_noop.md`)
+- Python 3.12, `uv` + `hatchling` (existing stack — no new build runtime)
+
+## Out of Scope
+
+- Retiring the `:4000` lyra-supervisor instance — Step 6 (separate ops task, blocked-by this)
+- Migrating `cccc/cccfk/ccd` aliases from `:4000` → `:18091` — Step 7
+- Resuming Hermes (2 Telegram bots) — Step 8
+- Migrating `deepseek-v4-pro` from hand-written `~/.litellm/config.yaml` to catalog — Step 5b
+- Building / pushing a container image to a registry — if a local image must be built, scope minimally (single `Containerfile`, local `podman build`)
+- Multi-host orchestration tooling (Ansible, Nomad, etc.) — out of band
+
+## Premise Validity
+
+**Success in 6 months:** `systemctl --user status llmcli` is green on M₁ and M₂; the unit survives M₁ reboots (validated via at least one observed reboot); consumers (lyra, hermes, claude-code) transit `:18091`; the `:4000` lyra-supervisor proxy is retired and the `litellm.conf` removed from `~/projects/lyra/deploy/supervisor/conf.d/`.
+
+**Failure in 6 months:** ≥1 prod incident per month on M₁ where the Quadlet fails to start or restart and requires manual `podman` intervention, OR M₂ never adopts the Quadlet (still using `make llm` 6 months in). Either condition is a falsifiable rollback signal — observable via `journalctl --user -u llmcli` (start/restart failures) and via the absence of `llmcli.service` in `systemctl --user list-units` on M₂.
+
+**Simplest alternative:** Raw systemd `.service` unit (no Quadlet) wrapping `podman run …` manually — declares the same restart policy, mounts, env, and port via standard `[Service]` directives.
+**Why not simplest:** Re-invents what Quadlet's generator already does — image refresh hooks (`AutoUpdate=registry`), volume + network plumbing, dependency wiring (`Requires=`/`After=`). Bare-`.service` units drift between M₁ and M₂ because each host's `podman run` flags get edited independently. Quadlet's declarative `.container` format keeps both hosts on the same source-of-truth; the rest of Roxabi (lyra, voiceCLI) is already on this pattern, so reusing it pays a one-time learning cost across the fleet.
+
+## Complexity
+
+**Tier: F-lite** — single new Quadlet unit + Makefile/docs touch + 1 ops smoke; reuses an established pattern (lyra/voiceCLI); no new arch, no new code path in `src/`, single domain (devops).
+
+Signals observed:
+- 1–3 new files: `deploy/quadlet/llmcli.container` + optional `deploy/quadlet/Containerfile` + docs section
+- 0 new dependencies (Podman + systemd already on both hosts)
+- Risk concentration: getting volume mode (`:Z`/`:U`) and user-linger semantics right on M₁ vs M₂; image source (published vs local-build) decision
+- Test surface bounded: smoke (`systemctl --user start llmcli` + `curl :18091/health/liveliness`) on both hosts
+- Multi-host but single domain — no FE / BE / cross-stack coupling
+- Issue label: `enhancement` (no size label assigned; F-lite confirmed by scope review)

--- a/artifacts/plans/44-llmcli-quadlet-plan.mdx
+++ b/artifacts/plans/44-llmcli-quadlet-plan.mdx
@@ -1,0 +1,605 @@
+---
+title: "Plan: feat(deploy) — package `llmcli proxy` as Podman Quadlet (M₁ + M₂)"
+issue: 44
+spec: artifacts/specs/44-llmcli-quadlet-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-05-20
+---
+
+## Summary
+
+Add `[proxy]` extra to `pyproject.toml` so the existing fleet image gains `litellm`, rename the worker entrypoint script and teach it a `proxy` MODE branch, ship `deploy/quadlet/llmcli.container` + `make install-quadlet`, and document the dual-host lifecycle. Single-domain F-lite — devops owns 5 code touches, doc-writer owns 2 doc touches, ops verification (M₂ + M₁) closes the SC ledger.
+
+## Architecture
+
+### Build → deploy → runtime pipeline
+
+```mermaid
+flowchart TD
+    subgraph repo[Repo source]
+      PYP[pyproject.toml<br/>+ proxy extra]
+      LOCK[uv.lock<br/>refreshed]
+      DOCK[Dockerfile.llm<br/>--extra proxy]
+      ENT[deploy/entrypoint.sh<br/>llm | proxy dispatch]
+      QUAD[deploy/quadlet/llmcli.container]
+      MAKE[Makefile<br/>install-quadlet]
+      DEPLOY[docs/guides/deployment.md]
+      README[README.md]
+    end
+    subgraph ci[GitHub Actions]
+      PUB[publish.yml]
+    end
+    subgraph ghcr[GHCR]
+      IMG[ghcr.io/roxabi/llmcli:staging<br/>now contains litellm]
+    end
+    subgraph host[Host: M₁ or M₂]
+      ENVFILE[~/.config/containers/systemd/llmcli.env<br/>chmod 600]
+      QUNIT[~/.config/containers/systemd/llmcli.container]
+      CAT[~/.roxabi/llmcli/]
+    end
+    subgraph systemd[user-systemd + podman]
+      GEN[Quadlet generator]
+      SVC[llmcli.service]
+      CONT[llmcli container :18091]
+    end
+
+    PYP --> LOCK
+    PYP --> DOCK
+    LOCK --> DOCK
+    ENT --> DOCK
+    DOCK --> PUB
+    PUB --> IMG
+    QUAD --> MAKE
+    MAKE --> QUNIT
+    MAKE --> ENVFILE
+    QUNIT --> GEN
+    GEN --> SVC
+    SVC --> CONT
+    IMG -.->|pull / autoupdate| CONT
+    ENVFILE -.->|EnvironmentFile=| CONT
+    CAT -.->|ro mount| CONT
+    DEPLOY -.->|operator docs| host
+    README -.->|repo index| repo
+
+    style PYP fill:#ffe5e5
+    style DOCK fill:#ffe5e5
+    style ENT fill:#ffe5e5
+    style QUAD fill:#ffe5e5
+    style CONT fill:#e5f5ff
+```
+
+### File × function map
+
+```mermaid
+flowchart LR
+    subgraph py[pyproject.toml]
+      OPT[optional-dependencies.proxy<br/>= litellm>=1.0]
+    end
+    subgraph lock[uv.lock]
+      RESOLVED[resolved litellm + deps]
+    end
+    subgraph dock[Dockerfile.llm]
+      SYNC1[uv sync --no-install-project<br/>--extra nats --extra proxy]
+      SYNC2[uv sync --extra nats --extra proxy]
+      COPY[COPY deploy/entrypoint.sh<br/>/entrypoint.sh]
+    end
+    subgraph ent[deploy/entrypoint.sh]
+      CASE_LLM[case llm) → exec llmcli nats-serve llm]
+      CASE_PROXY[case proxy) → exec llmcli proxy]
+      CASE_DEFAULT[default → echo Unknown ; exit 1]
+    end
+    subgraph quad[deploy/quadlet/llmcli.container]
+      UNITSEC[[Unit]<br/>StartLimitIntervalSec=60<br/>StartLimitBurst=5]
+      CONTSEC[[Container]<br/>Image + Volume + Env + Exec=proxy + Health]
+      SVCSEC[[Service]<br/>Restart=on-failure<br/>RestartForceExitStatus=1 127<br/>TimeoutStopSec=20s]
+      INSTSEC[[Install]<br/>WantedBy=default.target]
+    end
+    subgraph mk[Makefile]
+      TARGET[install-quadlet:<br/>cp .container + stub env + daemon-reload]
+    end
+    subgraph docs[docs/guides/deployment.md]
+      SECTION[## Running llmcli proxy as a Quadlet]
+    end
+    subgraph rd[README.md]
+      ROW[repo table row]
+    end
+
+    OPT --> RESOLVED
+    RESOLVED --> SYNC1
+    RESOLVED --> SYNC2
+    CASE_PROXY -.via Exec=proxy.-> CONTSEC
+    CASE_LLM -.unchanged.-> WORKER[llmcli-nats-worker.container<br/>Exec=llm --model qwen3-8b]
+    COPY --> CASE_LLM
+    COPY --> CASE_PROXY
+    COPY --> CASE_DEFAULT
+    TARGET --> CONTSEC
+    SECTION -.references.-> TARGET
+    SECTION -.references.-> CONTSEC
+    ROW -.references.-> TARGET
+
+    style CASE_PROXY fill:#e5f5ff
+    style WORKER fill:#f5f5e5
+```
+
+## Agents
+
+| Agent instance | Task count | Files |
+|---|---|---|
+| `devops-A` | 5 code + 1 smoke | `pyproject.toml`, `uv.lock`, `Dockerfile.llm`, `deploy/entrypoint.sh` (renamed), `deploy/quadlet/llmcli.container`, `Makefile` |
+| `doc-writer-A` | 2 docs | `docs/guides/deployment.md`, `README.md` |
+| `operator` | 1 ops smoke | M₁ remote install + verify (no file edit) |
+
+Skipped agents:
+- `tester` — no Python unit tests added; smokes are bash `curl`/`systemctl` commands embedded in deployment doc + SC verifies
+- `architect` — spec pinned all directives; no new module/pattern
+- `security-auditor` — env-file/UserNS/DropCapability pattern already in fleet (worker Quadlet)
+
+## Wave Structure
+
+4 waves, max 2 ∥ agents. Elapsed estimate ~25–35 min (sequential ~40–55 min).
+
+| Wave | Trigger | Agents | Tasks |
+|---|---|---|---|
+| 1 | start | 1 | devops-A: T1 (pyproject + uv lock — blocks rest) |
+| 2 | T1 done | 1 | devops-A: T2→T3→T4→T5 (chained same session) |
+| 3 | T2–T5 done | 2 ∥ | doc-writer-A: T6→T7 · devops-A: T8 (M₂ local build + smoke) |
+| 4 | merge + CI rebuild | 1 | operator: T9 (M₁ install + smoke) |
+
+### Budget
+
+| Task | Items | Class | Est. ops | Split? |
+|---|---|---|---|---|
+| T1 pyproject + uv lock | 1 | bounded | 3 | — |
+| T2 Dockerfile.llm edits | 1 | trivial | 2 | — |
+| T3 Entrypoint rename + dispatch | 1 | bounded | 2 | — |
+| T4 llmcli.container | 1 | judgmental | 4 | — |
+| T5 Makefile target | 1 | bounded | 2 | — |
+| T6 deployment.md section | 1 | judgmental | 5 | — |
+| T7 README row | 1 | trivial | 1 | — |
+| T8 M₂ smoke (5 SCs) | 5 | bounded | 4 | — |
+| T9 M₁ smoke (3 SCs) | 3 | bounded | 5 | — |
+
+**Total estimated ops: ~28** — well under 50; no split required.
+
+## Consistency Report
+
+| SC | Trace | Task |
+|---|---|---|
+| SC-1 | `pyproject.toml` `[proxy]` extra + `uv.lock` refreshed | T1 |
+| SC-2 | `Dockerfile.llm` `--extra nats --extra proxy` (both sync lines) | T2 |
+| SC-3 | `deploy/entrypoint.sh` dispatch with `proxy` case + default `exit 1` | T3 |
+| SC-4 | `deploy/entrypoint-nats.sh` removed + Dockerfile COPY path updated | T2 + T3 |
+| SC-5 | `deploy/quadlet/llmcli.container` matches data-model multiset (incl. `RestartForceExitStatus=1 127`, `TimeoutStopSec=20s`) | T4 |
+| SC-6 | `make install-quadlet` idempotent + `daemon-reload` | T5 |
+| SC-7 | Local build + `litellm --version` | T8 |
+| SC-8 | `is-active llmcli` within 30s on M₂ | T8 |
+| SC-9 | `curl :18091/health/liveliness` → 200 | T8 |
+| SC-10 | Authenticated `/v1/models` round-trip + 401 negative | T8 |
+| SC-11 | Catalog mount readable from inside container | T8 |
+| SC-12 | Deployment doc section (build flow + env template + failure modes + reset-failed) | T6 |
+| SC-13 | README repo-table mention | T7 |
+| SC-14 | M₁ image present + linger + active | T9 |
+| SC-15 | Reboot-equivalent autostart (real reboot OR `user@.service` simulation) | T9 |
+| SC-16 | Induced crash → automatic restart | T9 |
+
+**Coverage:** 16/16 SCs traced. 0 untraced tasks. 0 uncovered SCs.
+
+## Micro-Tasks
+
+### Slice V1 — Build pipeline + Quadlet + dev host (M₂) + docs
+
+#### T1 — Add `[proxy]` optional-dependency + refresh `uv.lock`
+
+- **Files:** `pyproject.toml`, `uv.lock`
+- **Agent:** devops-A
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Parallel-safe:** N (blocks T2)
+- **Spec trace:** SC-1
+
+**Skeleton:**
+
+```toml
+# pyproject.toml — under [project.optional-dependencies]
+proxy = ["litellm>=1.0"]
+```
+
+Then refresh lock:
+
+```bash
+uv lock
+```
+
+**Verify:**
+
+```bash
+grep -A1 '\[project.optional-dependencies\]' pyproject.toml | grep -q 'proxy =' && \
+  grep -q '^name = "litellm"' uv.lock && echo OK
+```
+
+**Expected:** `OK`.
+
+---
+
+#### T2 — Add `--extra proxy` to `Dockerfile.llm` + update entrypoint COPY path
+
+- **Files:** `Dockerfile.llm`
+- **Agent:** devops-A
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Parallel-safe:** N (depends T1; T3 must precede COPY change)
+- **Spec trace:** SC-2, SC-4 (Dockerfile half)
+
+**Skeleton:**
+
+```dockerfile
+RUN uv sync --frozen --no-dev --no-install-project --extra nats --extra proxy
+# ... later ...
+RUN uv sync --frozen --no-dev --extra nats --extra proxy
+# ... later ...
+COPY deploy/entrypoint.sh /entrypoint.sh
+```
+
+**Verify:**
+
+```bash
+grep -c -- '--extra nats --extra proxy' Dockerfile.llm    # expect: 2
+grep -q 'COPY deploy/entrypoint.sh /entrypoint.sh' Dockerfile.llm && echo OK
+```
+
+**Expected:** `2` then `OK`.
+
+---
+
+#### T3 — Rename `entrypoint-nats.sh` → `entrypoint.sh` + add `proxy` MODE branch
+
+- **Files:** `deploy/entrypoint.sh` (new), `deploy/entrypoint-nats.sh` (deleted)
+- **Agent:** devops-A
+- **Phase:** GREEN
+- **Difficulty:** 2
+- **Parallel-safe:** N (depends T1; T2 must reference new path)
+- **Spec trace:** SC-3, SC-4 (rename half)
+
+**Skeleton (`deploy/entrypoint.sh`):**
+
+```bash
+#!/bin/bash
+set -e
+MODE="${1:-llm}"
+shift || true
+case "$MODE" in
+    llm)
+        exec llmcli nats-serve llm "$@"
+        ;;
+    proxy)
+        exec llmcli proxy "$@"
+        ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        exit 1
+        ;;
+esac
+```
+
+Use `git mv deploy/entrypoint-nats.sh deploy/entrypoint.sh` to preserve history, then edit.
+
+**Verify:**
+
+```bash
+test -f deploy/entrypoint.sh && test ! -f deploy/entrypoint-nats.sh && \
+  grep -q 'exec llmcli proxy' deploy/entrypoint.sh && \
+  grep -q 'exec llmcli nats-serve llm' deploy/entrypoint.sh && \
+  grep -q 'Unknown mode' deploy/entrypoint.sh && \
+  test -x deploy/entrypoint.sh && echo OK
+```
+
+**Expected:** `OK`.
+
+---
+
+#### T4 — Write `deploy/quadlet/llmcli.container`
+
+- **Files:** `deploy/quadlet/llmcli.container` (new)
+- **Agent:** devops-A
+- **Phase:** GREEN
+- **Difficulty:** 3
+- **Parallel-safe:** Y (independent of T2/T3 once T1 ready)
+- **Spec trace:** SC-5
+- **Ref pattern:** `deploy/quadlet/llmcli-nats-worker.container`
+
+**Skeleton:**
+
+```ini
+[Unit]
+Description=llmCLI LiteLLM proxy (:18091)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
+ContainerName=llmcli
+PublishPort=18091:18091
+Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
+EnvironmentFile=%h/.config/containers/systemd/llmcli.env
+Environment=LLMCLI_PROXY_PORT=18091
+Environment=LLMCLI_PROXY_HOST=0.0.0.0
+UserNS=keep-id:uid=1502,gid=1502
+Exec=proxy
+HealthCmd=pgrep -f litellm
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+
+[Service]
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=20s
+RestartForceExitStatus=1 127
+
+[Install]
+WantedBy=default.target
+```
+
+**Verify:**
+
+```bash
+diff -u <(grep -E '^(Image|Label|ContainerName|PublishPort|Volume|EnvironmentFile|Environment|UserNS|Exec|HealthCmd|HealthInterval|HealthStartPeriod|NoNewPrivileges|DropCapability|Restart|RestartSec|TimeoutStopSec|RestartForceExitStatus|StartLimitIntervalSec|StartLimitBurst|Description|WantedBy)=' deploy/quadlet/llmcli.container | sort) <(cat <<'EOF' | sort
+Description=llmCLI LiteLLM proxy (:18091)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
+ContainerName=llmcli
+PublishPort=18091:18091
+Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
+EnvironmentFile=%h/.config/containers/systemd/llmcli.env
+Environment=LLMCLI_PROXY_PORT=18091
+Environment=LLMCLI_PROXY_HOST=0.0.0.0
+UserNS=keep-id:uid=1502,gid=1502
+Exec=proxy
+HealthCmd=pgrep -f litellm
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=20s
+RestartForceExitStatus=1 127
+WantedBy=default.target
+EOF
+) && echo OK
+```
+
+**Expected:** `OK` (empty diff).
+
+---
+
+#### T5 — Add `install-quadlet` Makefile target (idempotent)
+
+- **Files:** `Makefile`
+- **Agent:** devops-A
+- **Phase:** GREEN
+- **Difficulty:** 2
+- **Parallel-safe:** Y (depends T4 only)
+- **Spec trace:** SC-6
+
+**Skeleton:**
+
+```makefile
+QUADLET_DIR := $(HOME)/.config/containers/systemd
+QUADLET_ENV := $(QUADLET_DIR)/llmcli.env
+
+.PHONY: install-quadlet
+install-quadlet:
+	@mkdir -p $(QUADLET_DIR)
+	@install -m 644 deploy/quadlet/llmcli.container $(QUADLET_DIR)/llmcli.container
+	@if [ ! -f $(QUADLET_ENV) ]; then \
+	  printf '# llmcli.env — chmod 600. Populate with provider keys.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' > $(QUADLET_ENV) ; \
+	  chmod 600 $(QUADLET_ENV) ; \
+	  echo "Created stub $(QUADLET_ENV) — edit before starting." ; \
+	else \
+	  echo "Preserving existing $(QUADLET_ENV)." ; \
+	fi
+	@systemctl --user daemon-reload
+	@echo "Installed. Next: systemctl --user start llmcli"
+```
+
+**Verify:**
+
+```bash
+echo "LLMCLI_API_KEY=SENTINEL_$$" > /tmp/sentinel-env
+cp /tmp/sentinel-env "$HOME/.config/containers/systemd/llmcli.env" 2>/dev/null || true
+make install-quadlet > /tmp/installq.log 2>&1
+grep -q SENTINEL "$HOME/.config/containers/systemd/llmcli.env" && \
+  test -f "$HOME/.config/containers/systemd/llmcli.container" && \
+  echo OK
+```
+
+**Expected:** `OK`.
+
+---
+
+#### T6 — Add "Running `llmcli proxy` as a Quadlet" section to `docs/guides/deployment.md`
+
+- **Files:** `docs/guides/deployment.md`
+- **Agent:** doc-writer-A
+- **Phase:** GREEN
+- **Difficulty:** 3
+- **Parallel-safe:** Y (with T7 and T8)
+- **Spec trace:** SC-12
+
+**Sections to include:**
+1. Pre-merge local-build flow (`podman build` override of `:staging` tag)
+2. Post-merge registry-pull behavior (`Label=io.containers.autoupdate=registry`)
+3. Env-file template (full list: `LLMCLI_API_KEY`, `FIREWORKS_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `NVIDIA_API_KEY`)
+4. `systemctl --user` lifecycle commands (`start`, `restart`, `stop`, `status`, `journalctl --user -u llmcli`)
+5. Failure-mode table mirroring the spec's Expected Behavior section
+6. `reset-failed` note for `StartLimitBurst` exhaustion
+
+**Verify:**
+
+```bash
+grep -q "Running .llmcli proxy. as a Quadlet" docs/guides/deployment.md && \
+  grep -q "FIREWORKS_API_KEY" docs/guides/deployment.md && \
+  grep -q "systemctl --user reset-failed" docs/guides/deployment.md && \
+  grep -q "podman build -t ghcr.io/roxabi/llmcli:staging" docs/guides/deployment.md && \
+  echo OK
+```
+
+**Expected:** `OK`.
+
+---
+
+#### T7 — Add Quadlet row to `README.md` repo table
+
+- **Files:** `README.md`
+- **Agent:** doc-writer-A
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Parallel-safe:** Y (with T6, T8)
+- **Spec trace:** SC-13
+
+**Skeleton:** add a line to the existing supervisor/deployment table or top-level features list noting `llmcli.container` Quadlet + `make install-quadlet`.
+
+**Verify:**
+
+```bash
+grep -qi 'Quadlet' README.md && grep -q 'install-quadlet' README.md && echo OK
+```
+
+**Expected:** `OK`.
+
+---
+
+#### T8 — M₂ pre-merge smoke (local build + install + health + auth)
+
+- **Files:** none (ops verification)
+- **Agent:** devops-A (operator role on M₂)
+- **Phase:** VERIFY
+- **Difficulty:** 3
+- **Parallel-safe:** N (depends T1–T5)
+- **Spec trace:** SC-7, SC-8, SC-9, SC-10, SC-11
+
+**Steps (on `roxabitower` working tree):**
+
+```bash
+# SC-7
+podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .
+podman run --rm --entrypoint="" ghcr.io/roxabi/llmcli:staging /app/.venv/bin/litellm --version
+
+# Install + start
+make install-quadlet
+$EDITOR ~/.config/containers/systemd/llmcli.env   # populate keys
+systemctl --user start llmcli
+
+# SC-8
+timeout 30 bash -c 'until systemctl --user is-active llmcli; do sleep 1; done'
+
+# SC-9
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:18091/health/liveliness
+
+# SC-10
+KEY=$(grep ^LLMCLI_API_KEY ~/.config/containers/systemd/llmcli.env | cut -d= -f2)
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $KEY" http://localhost:18091/v1/models
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:18091/v1/models
+
+# SC-11
+podman exec llmcli test -r /home/llmcli/.roxabi/llmcli/llmcli.toml && echo OK
+```
+
+**Expected:** `litellm --version` prints non-empty; `is-active` returns `active`; SC-9 returns `200`; SC-10 first curl `200` (auth) then `401` (no header); SC-11 prints `OK`.
+
+---
+
+### Slice V2 — Prod host (M₁) + autostart + crash smoke
+
+#### T9 — M₁ install + linger check + autostart simulation + crash recovery
+
+- **Files:** none (ops verification on `roxabituwer`)
+- **Agent:** operator
+- **Phase:** VERIFY
+- **Difficulty:** 3
+- **Parallel-safe:** N (depends T8 + merge + CI image rebuild OR local build on M₁)
+- **Spec trace:** SC-14, SC-15, SC-16
+
+**Steps:**
+
+```bash
+# Either pull post-CI-rebuild or build locally on M₁
+podman pull ghcr.io/roxabi/llmcli:staging || \
+  (cd ~/projects/llmCLI && podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .)
+
+cd ~/projects/llmCLI && make install-quadlet
+$EDITOR ~/.config/containers/systemd/llmcli.env
+systemctl --user start llmcli
+
+# SC-14
+loginctl show-user mickael | grep Linger=yes
+systemctl --user is-active llmcli
+
+# SC-15 — path (b) simulation (preferred for SC-binary closure without waiting for reboot)
+sudo systemctl stop user@$(id -u mickael).service
+sleep 5
+sudo systemctl start user@$(id -u mickael).service
+timeout 30 bash -c 'until systemctl --user is-active llmcli; do sleep 1; done'
+
+# SC-16
+podman kill llmcli
+sleep 12
+systemctl --user is-active llmcli   # expect active
+systemctl --user status llmcli      # expect restart count incremented
+```
+
+**Expected:** linger `yes`; `is-active` returns `active` after both interventions; restart count > 0.
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs). -->
+
+### Wave 1 — no deps, 1 agent
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T1 | devops-A | — | Add `[proxy]` extra to pyproject + refresh uv.lock |
+
+### Wave 2 — after T1, 1 agent (chained same session)
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T2 | devops-A | T1, T3 | Dockerfile.llm: `--extra nats --extra proxy` + COPY new entrypoint path |
+| T3 | devops-A | T1 | Rename `entrypoint-nats.sh` → `entrypoint.sh` + add `proxy` MODE branch |
+| T4 | devops-A | T1 | Write `deploy/quadlet/llmcli.container` per data-model multiset |
+| T5 | devops-A | T4 | Add `install-quadlet` Makefile target (idempotent + daemon-reload) |
+
+### Wave 3 — after T2–T5, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T6 | doc-writer-A | T4, T5 | Add Quadlet section to `docs/guides/deployment.md` |
+| T7 | doc-writer-A | T6 | Add Quadlet row to `README.md` repo table |
+| T8 | devops-A | T2, T3, T4, T5 | M₂ pre-merge smoke (SC-7..SC-11) |
+
+### Wave 4 — after T8 + CI image rebuild (post-merge)
+
+| Task | Agent instance | blockedBy | Subject |
+|---|---|---|---|
+| T9 | operator | T8 | M₁ install + linger + autostart simulation + crash recovery |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 65 — Add `[proxy]` extra to pyproject.toml + refresh uv.lock
+- T2: 66 — Dockerfile.llm — `--extra nats --extra proxy` + COPY new entrypoint path
+- T3: 67 — Rename `entrypoint-nats.sh` → `entrypoint.sh` + add `proxy` MODE branch
+- T4: 68 — Write `deploy/quadlet/llmcli.container`
+- T5: 69 — Makefile — `install-quadlet` target (idempotent, daemon-reload)
+- T6: 70 — Add "Running `llmcli proxy` as a Quadlet" section to deployment.md
+- T7: 71 — README.md — add Quadlet row to repo table
+- T8: 72 — M₂ pre-merge smoke (local build + install + health + auth + catalog)
+- T9: 73 — M₁ install + linger + autostart simulation + crash recovery

--- a/artifacts/specs/44-llmcli-quadlet-spec.mdx
+++ b/artifacts/specs/44-llmcli-quadlet-spec.mdx
@@ -229,7 +229,7 @@ Dashed = consumer wiring lands in Steps 6 / 7 / 8 (separate issues).
 |---|---|---|---|---|
 | U1 | `make install-quadlet` | operator runs | `install -m 644 deploy/quadlet/llmcli.container ~/.config/containers/systemd/` → stub-env-file (chmod 600) if absent → `systemctl --user daemon-reload` | idempotent; preserves existing env file |
 | U2 | `systemctl --user start llmcli` | operator runs (after U1 daemon-reload) | user-systemd → Quadlet generator → `podman run …` (pulls image if not cached) | exit 0 within ~5s; ~10-30s on first pull from GHCR |
-| U3 | `systemctl --user restart llmcli` | operator runs after edit | systemd sends SIGTERM → `llmcli proxy` (#40) drains up to 10s → SIGKILL after `TimeoutStopSec=15s` → re-spawn | drains via N1 internals |
+| U3 | `systemctl --user restart llmcli` | operator runs after edit | systemd sends SIGTERM → `llmcli proxy` (#40) drains up to 10s → SIGKILL after `TimeoutStopSec=20s` → re-spawn | drains via N1 internals |
 | U4 | `systemctl --user status llmcli` | operator runs | reports unit state + last 10 log lines; journal via `journalctl --user -u llmcli` | — |
 | U5 | `curl http://localhost:18091/health/liveliness` | operator runs | LiteLLM HTTP — returns `{"status": "ok"}` | sub-second when healthy |
 | U6 | `curl -H "Authorization: Bearer $K" http://localhost:18091/v1/models` | operator runs | proxy returns 200 with model list; without `Authorization` returns 401 | validates env-file → proxy → litellm wiring |
@@ -261,7 +261,7 @@ S1 .container declares Exec=proxy → loads image → entrypoint → S2 dispatch
 
 U1 install-quadlet → S1 + S5 + daemon-reload → N3 generator → llmcli.service + symlink
 U2 start → N3 service → podman run (reads S5 env, mounts S1's catalog ro, publishes :18091)
-U3 restart → SIGTERM in → 10s drain (#40) → TimeoutStopSec=15s → SIGKILL → re-spawn
+U3 restart → SIGTERM in → 10s drain (#40) → TimeoutStopSec=20s → SIGKILL → re-spawn
 U5 health → LiteLLM HTTP responds; HealthCmd uses pgrep on litellm process (curl absent from image)
 U7 M₁ reboot → user-linger → default.target → Quadlet unit auto-starts (WantedBy symlink from N3)
 N1 crash → Restart=on-failure → RestartSec=5s → re-spawn (StartLimitBurst=5 per 60s window)

--- a/artifacts/specs/44-llmcli-quadlet-spec.mdx
+++ b/artifacts/specs/44-llmcli-quadlet-spec.mdx
@@ -1,0 +1,281 @@
+---
+title: "feat(deploy): package `llmcli proxy` as Podman Quadlet (M₁ + M₂)"
+issue: 44
+status: approved
+tier: F-lite
+date: 2026-05-20
+last_revised: 2026-05-20
+source: artifacts/frames/44-llmcli-quadlet-frame.mdx
+---
+
+## Context
+
+Promoted from [`44-llmcli-quadlet-frame.mdx`](../frames/44-llmcli-quadlet-frame.mdx).
+
+Step 4 of the **llmcli central-portal** plan. Step 3 (#40) shipped `llmcli proxy` as a foreground binary owning both config generation and process lifecycle. This spec packages it as a Podman Quadlet — `llmcli.container` — so user-systemd supervises it directly on both hosts, with the same `systemctl --user …` grammar lyra and voiceCLI already use.
+
+Today's state:
+- `llmcli proxy` runs as a foreground binary — started by `make llm` on M₂ or supervised by the lyra-supervisor `litellm` conf on `:4000` on M₁.
+- M₁ would prefer to drop the lyra-supervisor dependency entirely (`:4000` retirement is Step 6, blocked by this).
+- M₂ has no clean restart story — `make llm` blocks the shell.
+
+After this spec ships:
+- One `llmcli.container` Quadlet unit lives in the repo at `deploy/quadlet/llmcli.container`.
+- One `Containerfile` (deferred decision D-1) lives at `deploy/quadlet/Containerfile`.
+- Both hosts run `llmcli proxy` via `systemctl --user start llmcli`. M₁ adds reboot-survival via user-linger (no `enable` needed — `WantedBy=default.target` is auto-symlinked by the Quadlet generator on `daemon-reload`; running `systemctl --user enable` on a Quadlet-generated unit is a no-op per project memory `feedback_quadlet_enable_is_noop.md`).
+- The container mounts `~/.roxabi/llmcli/` (catalog, **RO** — proxy only reads), `~/.local/state/llmcli/` (state, RW), `~/.cache/huggingface/` (model cache, RW), reads `LLMCLI_API_KEY` from an env file, and publishes `:18091`.
+
+## Goal
+
+A single Quadlet `.container` unit, committed to the repo at `deploy/quadlet/llmcli.container`, installed to `~/.config/containers/systemd/llmcli.container` on each host by a `make install-quadlet` target, that supervises `llmcli proxy` on `:18091` under user-systemd with identical config across M₁ and M₂ — differing only via a per-host env file (`~/.config/containers/systemd/llmcli.env`) for the API key.
+
+## Users
+
+**Current beneficiary (this issue alone):**
+- **Mickael (ops)** — runs `systemctl --user start/restart/status llmcli` on both hosts; reads logs via `journalctl --user -u llmcli`; verifies `curl http://localhost:18091/health/liveliness` returns 200.
+
+**Deferred beneficiaries (require follow-up tasks):**
+- **lyra / hermes / claude-code consumers** — once both hosts have a stable `:18091`, Step 6 retires `:4000` and Step 7 retargets aliases
+- **Future Roxabi tools** — `llmcli.container` becomes the reference Quadlet pattern in the fleet (alongside lyra's and voiceCLI's existing units), which is why hardening directives (`NoNewPrivileges=true`, `DropCapability=all`) are required, not optional, in this spec
+
+Not in scope: registry image pipeline, virtual keys / multi-tenant, hot reload (catalog change → `systemctl --user restart llmcli`).
+
+## Expected Behavior
+
+### Happy path: M₂ (dev, on-demand)
+
+1. Operator runs `make build-quadlet-image` once (or after llmcli source change) on M₂. This builds `localhost/llmcli:dev` from `deploy/quadlet/Containerfile`.
+2. Operator runs `make install-quadlet` once. The target:
+   - copies `deploy/quadlet/llmcli.container` → `~/.config/containers/systemd/llmcli.container`,
+   - creates a chmod-600 `~/.config/containers/systemd/llmcli.env` stub (only if absent — never overwrites an existing env file),
+   - runs `systemctl --user daemon-reload` (this is what triggers the Quadlet generator to materialize `llmcli.service` and auto-symlink it into `default.target.wants/`).
+3. Operator edits `~/.config/containers/systemd/llmcli.env` to populate `LLMCLI_API_KEY=…` (only secret in the file; port + host stay as `Environment=` defaults in the unit).
+4. Operator runs `systemctl --user start llmcli`. Within ~3s the unit is `active (running)`. **Do not run `systemctl --user enable llmcli.service`** — for Quadlet-generated units this is a no-op at best and produces a misleading "Created symlink … → /dev/null" message; the generator already wired the unit via `WantedBy=default.target`.
+5. Smoke: `curl http://localhost:18091/health/liveliness` returns `{"status": "ok"}`.
+6. Operator runs `systemctl --user stop llmcli` to shut down — `TimeoutStopSec=15s` accommodates the in-container `llmcli proxy` 10s signal-drain (from #40) plus a 5s safety margin, then SIGKILL.
+
+### Happy path: M₁ (prod, autostart)
+
+1. One-time setup: `loginctl enable-linger mickael` (already done — lyra service depends on it).
+2. Operator runs the same M₂ V1 flow: `make build-quadlet-image && make install-quadlet`, edits env file, `systemctl --user start llmcli`. The single `.container` file produces identical behavior on both hosts; only the env file differs.
+3. M₁ reboots (planned or unplanned). After boot, `mickael`'s user-systemd starts under lingered session; `llmcli.service` (generated from `.container`) starts automatically because the unit declares `[Install] WantedBy=default.target` (Quadlet's default — already symlinked at step 2 by `daemon-reload`).
+4. If the container crashes, `Restart=on-failure` + `RestartSec=5s` brings it back within ~5s. `StartLimitIntervalSec=60s` + `StartLimitBurst=5` (fleet standard) means 5 consecutive crashes within 60s park the unit in `failed`. `journalctl --user -u llmcli` shows the restart cycle.
+
+### `--config-out` smoke (one-shot, container-internal)
+
+Existing `llmcli proxy --config-out /tmp/x.yaml` behavior is preserved. Operator can run `podman exec llmcli llmcli proxy --config-out /dev/stdout` to dump the rendered LiteLLM config — `llmcli` is the **fixed** container name set by `ContainerName=llmcli` in the unit (not deferred).
+
+### Failure modes
+
+| Failure | Symptom | Recovery |
+|---|---|---|
+| `~/.config/containers/systemd/llmcli.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` to create stub; populate |
+| `LLMCLI_API_KEY` empty in env file | container starts; `llmcli proxy` exits 1 (provider-key error from #40); `Restart=on-failure` retries within 60s/5-burst window then `failed` | populate env file, `systemctl --user reset-failed llmcli && start` |
+| Image not present locally (M₁ with no network) | `podman` run fails (no pull source) | `make build-quadlet-image` on host first (no registry round-trip needed — image is built locally per D-1) |
+| Port 18091 already bound | container fails to publish port; unit `failed` | identify conflict, free port, restart unit |
+| User-linger off on M₁ | service stops after logout | `loginctl enable-linger mickael` |
+| Operator runs `systemctl --user enable llmcli.service` | "Created symlink … → /dev/null" — Quadlet generator masks the unit name to prevent double-management | ignore the message; nothing is broken |
+| Bridge published port unreachable | `curl localhost:18091` connects but no response | confirm `LLMCLI_PROXY_HOST=0.0.0.0` inside the container (Environment= default in the unit) — bind to `127.0.0.1` inside the container silently breaks PublishPort forwarding |
+
+## Data Model & Consumers
+
+### Quadlet unit shape (resolved — no longer deferred)
+
+```mermaid
+classDiagram
+    class QuadletUnit {
+        +str Image = "localhost/llmcli:dev"
+        +str ContainerName = "llmcli"
+        +list~str~ PublishPort = ["18091:18091"]
+        +list~str~ Volume
+        +str EnvironmentFile = "%h/.config/containers/systemd/llmcli.env"
+        +dict Environment
+        +str UserNS = "keep-id:uid=1000,gid=1000"
+        +str Network = "bridge"
+        +bool NoNewPrivileges = true
+        +str DropCapability = "all"
+        +str HealthCmd = "curl -sf http://localhost:18091/health/liveliness"
+        +str HealthInterval = "30s"
+        +str HealthStartPeriod = "30s"
+    }
+    class ServiceSection {
+        +str Restart = "on-failure"
+        +int RestartSec = 5
+        +str TimeoutStopSec = "15s"
+        +str ExecStartPre = "/bin/mkdir -p %h/.local/state/llmcli"
+    }
+    class UnitSection {
+        +str Description
+        +int StartLimitIntervalSec = 60
+        +int StartLimitBurst = 5
+    }
+    class EnvFile {
+        <<chmod 0600>>
+        +str LLMCLI_API_KEY
+    }
+    class Containerfile {
+        +str FROM = "nvidia/cuda:12.5.1-runtime-ubuntu24.04"
+        +list~str~ stages = ["builder", "runtime"]
+        +str installer = "uv sync --frozen --no-dev"
+        +int RuntimeUID = 1502
+        +list~str~ ENTRYPOINT = ["llmcli", "proxy"]
+    }
+    class GeneratedService {
+        <<systemd unit>>
+        +str From = "llmcli.container"
+        +str ExecStart = "/usr/bin/podman run ..."
+        +WantedBy default.target
+    }
+    QuadletUnit --> EnvFile : reads at runtime
+    QuadletUnit --> ServiceSection : passthrough [Service]
+    QuadletUnit --> UnitSection : passthrough [Unit]
+    QuadletUnit --> Containerfile : built into Image
+    QuadletUnit --> GeneratedService : Quadlet generator emits
+```
+
+Volume bind-mounts (host path → container path, mode):
+
+| Host | Container (under `UserNS=keep-id:uid=1000`) | Mode |
+|---|---|---|
+| `%h/.roxabi/llmcli/` | `/home/mickael/.roxabi/llmcli/` | `ro` |
+| `%h/.local/state/llmcli/` | `/home/mickael/.local/state/llmcli/` | `rw` |
+| `%h/.cache/huggingface/` | `/home/mickael/.cache/huggingface/` | `rw` |
+
+With `UserNS=keep-id:uid=1000,gid=1000`, the container's effective UID maps to host UID 1000 (mickael); container `$HOME` is `/home/mickael`. **Not** `/root/`.
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    subgraph host[Host filesystem]
+      ENVFILE[~/.config/containers/systemd/llmcli.env]
+      CATALOG[~/.roxabi/llmcli/]
+      STATE[~/.local/state/llmcli/]
+      HFCACHE[~/.cache/huggingface/]
+      UNIT[~/.config/containers/systemd/llmcli.container]
+    end
+    subgraph systemd[user-systemd]
+      GEN[Quadlet generator]
+      SVC[llmcli.service]
+    end
+    subgraph podman[Podman]
+      CONT[llmcli container]
+    end
+    UNIT --> GEN
+    GEN --> SVC
+    SVC --> CONT
+    ENVFILE -.->|EnvironmentFile=| CONT
+    CATALOG -.->|/home/mickael/.roxabi/llmcli/ ro| CONT
+    STATE -.->|/home/mickael/.local/state/llmcli/ rw| CONT
+    HFCACHE -.->|/home/mickael/.cache/huggingface/ rw| CONT
+    CONT -.->|:18091| LYRA[lyra NATS satellite]
+    CONT -.->|:18091| HERMES[hermes bots]
+    CONT -.->|:18091| CCODE[claude-code aliases]
+```
+
+Dashed = consumer wiring lands in Steps 6 / 7 / 8 (separate issues).
+
+### Consumer summary
+
+| Consumer | Reads | When | This issue? |
+|---|---|---|---|
+| user-systemd | unit file | on `daemon-reload` + start | this issue |
+| Quadlet generator | `.container` + `Containerfile`-built image | on `daemon-reload` + on `podman build` | this issue |
+| Container runtime | env file, mounts, image | on container start | this issue |
+| lyra NATS satellite | `:18091` over HTTP | Step 6 retires `:4000` | future |
+| hermes bots | `:18091` over HTTP | Step 8 | future |
+| Claude Code aliases | `:18091` over HTTP | Step 7 | future |
+
+## Breadboard
+
+### Affordances
+
+| ID | Surface | Trigger | Handler | Notes |
+|---|---|---|---|---|
+| U1 | `make build-quadlet-image` | operator runs target | `podman build -t localhost/llmcli:dev -f deploy/quadlet/Containerfile .` | idempotent; reuses Podman layer cache |
+| U2 | `make install-quadlet` | operator runs target | `install -m 644 deploy/quadlet/llmcli.container ~/.config/containers/systemd/` → stub-env-file (chmod 600) if absent → `systemctl --user daemon-reload` | idempotent; preserves existing env file |
+| U3 | `systemctl --user start llmcli` | operator runs (after U2 daemon-reload) | user-systemd → Quadlet generator → `podman run …` | exit 0 within ~3s |
+| U4 | `systemctl --user restart llmcli` | operator runs after edit | systemd sends SIGTERM to container → `llmcli proxy` (#40) drains up to 10s → SIGKILL after `TimeoutStopSec=15s` → re-spawn | drains via N1 internals |
+| U5 | `systemctl --user status llmcli` | operator runs | reports unit state + last 10 log lines | full journal via `journalctl --user -u llmcli` |
+| U6 | `curl http://localhost:18091/health/liveliness` | operator runs | LiteLLM HTTP — returns `{"status": "ok"}` | sub-second when healthy; also wired as `HealthCmd=` |
+| U7 | M₁ host reboot | infra event | user-linger keeps session alive → Quadlet unit auto-starts via `WantedBy=default.target` | observable: `systemctl --user is-active llmcli` returns `active` post-boot |
+| N1 | Crash inside container | `llmcli proxy` exits non-zero | `Restart=on-failure` + `RestartSec=5s` re-spawns; `StartLimitIntervalSec=60`/`StartLimitBurst=5` parks at `failed` after 5 fast restarts | journal shows restart cycle |
+| N2 | Missing `LLMCLI_API_KEY` | env file empty/missing var | `llmcli proxy` exits 1 → retry → exhaust burst → unit `failed` | operator runs `systemctl --user reset-failed llmcli` after fix |
+| N3 | Quadlet generator | reads `.container` on `daemon-reload` | emits `llmcli.service` into `XDG_RUNTIME_DIR/systemd/generator.user/`; symlinks into `default.target.wants/` | not user-editable — drop-ins go via `~/.config/systemd/user/llmcli.service.d/*.conf` |
+| S1 | `deploy/quadlet/llmcli.container` | unit file in repo | committed source-of-truth | identical content on M₁ and M₂; only env file differs |
+| S2 | `deploy/quadlet/Containerfile` | image recipe in repo | committed source-of-truth | base `nvidia/cuda:12.5.1-runtime-ubuntu24.04`, two-stage builder, non-root UID 1502 |
+| S3 | `~/.config/containers/systemd/llmcli.env` | per-host secret | chmod 600; not in repo; created by U2 stub | sole host-specific input |
+
+### Wiring
+
+```
+U1 build → image localhost/llmcli:dev in podman storage
+U2 install-quadlet → S1 .container in user dir + S2 env-file stub + daemon-reload
+                   → N3 Quadlet generator emits llmcli.service + symlinks default.target.wants/
+U3 start → systemd starts service → podman run (reads S3, mounts host dirs ro/rw per table, publishes :18091)
+         → llmcli proxy bootstraps (#40 logic unchanged)
+U4 restart → SIGTERM in → 10s drain (per #40) → TimeoutStopSec=15s → SIGKILL → re-spawn
+U5 status → systemd unit state + journal tail
+U6 curl 18091/health/liveliness → in-container LiteLLM responds (also N3 health probe)
+U7 M₁ reboot → user-linger → default.target → Quadlet unit auto-starts (WantedBy symlink from N3)
+N1 crash → Restart=on-failure → RestartSec=5s wait → re-spawn (max StartLimitBurst=5 per 60s window)
+N2 missing key → exit 1 → N1 loop → unit goes failed → operator reset-failed
+```
+
+## Slices
+
+| # | Slice | Includes | Demo | Independently shippable? |
+|---|---|---|---|---|
+| V1 | **Unit + image + Makefile + dev host (M₂)** | `deploy/quadlet/llmcli.container` (with all hardening + healthcheck), `deploy/quadlet/Containerfile` (CUDA 12.5.1 base, two-stage builder, UID 1502 entrypoint), `make build-quadlet-image`, `make install-quadlet` (idempotent + daemon-reload), docs section in `docs/guides/deployment.md` | M₂ runs `make build-quadlet-image && make install-quadlet`, edits env file, `systemctl --user start llmcli`; smoke commands per Success Criteria | yes — M₁ keeps existing `make llm` + supervisor until V2 lands |
+| V2 | **Prod host (M₁) + autostart + crash smoke** | M₁ image build + install + start; observed reboot survival (real reboot OR documented next-planned-reboot acceptance); induced crash smoke | M₁ runs V1 commands; we record a journal-entry timestamp; on next planned reboot (or simulated kill-session) we verify the unit auto-restarts | yes — V1 already valuable on M₂ |
+| V3 | **Docs polish** | Update top-level `README.md` repo table to mention the Quadlet, add troubleshooting subsection to deployment guide (covers env-file missing, `enable` no-op message, port conflict, bridge `0.0.0.0` requirement, `reset-failed` after exhausted burst) | docs build green (no broken links) | yes — pure docs |
+
+## Success Criteria
+
+- [ ] **SC-1:** `deploy/quadlet/llmcli.container` and `deploy/quadlet/Containerfile` are committed to the repo (V1).
+- [ ] **SC-2:** The `.container` unit declares: `ContainerName=llmcli`, `Image=localhost/llmcli:dev`, `PublishPort=18091:18091`, `UserNS=keep-id:uid=1000,gid=1000`, `NoNewPrivileges=true`, `DropCapability=all`, `HealthCmd=curl -sf http://localhost:18091/health/liveliness`, `HealthInterval=30s`, `HealthStartPeriod=30s`, `EnvironmentFile=%h/.config/containers/systemd/llmcli.env`, `Environment=LLMCLI_PROXY_PORT=18091 LLMCLI_PROXY_HOST=0.0.0.0`, the 3 volume mounts at the modes given in the data-model table, and `[Service] Restart=on-failure RestartSec=5 TimeoutStopSec=15s ExecStartPre=/bin/mkdir -p %h/.local/state/llmcli`, and `[Unit] StartLimitIntervalSec=60 StartLimitBurst=5` (V1).
+- [ ] **SC-3:** `make build-quadlet-image` target exists and produces `localhost/llmcli:dev` from `deploy/quadlet/Containerfile`; the image runs `llmcli proxy` as UID 1502 by default (V1). Verify: `podman run --rm localhost/llmcli:dev id -u` returns `1502` (or, for tests that inject a fake entrypoint, `podman inspect localhost/llmcli:dev --format '{{.Config.User}}'` includes `1502`).
+- [ ] **SC-4:** `make install-quadlet` target is idempotent: re-running it does not overwrite an existing `llmcli.env`; on second run, `git status` (in repo) is clean and `~/.config/containers/systemd/llmcli.env` mtime is unchanged (V1).
+- [ ] **SC-5:** After `make build-quadlet-image && make install-quadlet`, populating env file, and `systemctl --user start llmcli`, `systemctl --user is-active llmcli` returns `active` within 10s on M₂ (V1).
+- [ ] **SC-6:** While the unit is active, `curl http://localhost:18091/health/liveliness` returns HTTP 200 with body `{"status": "ok"}` on M₂ (V1).
+- [ ] **SC-7:** Volume mounts function correctly on M₂ (V1). Verify:
+  - `podman exec llmcli test -r /home/mickael/.roxabi/llmcli/llmcli.toml` → exit 0 (RO catalog readable);
+  - `podman exec llmcli touch /home/mickael/.local/state/llmcli/probe-$(date +%s)` followed by host `ls ~/.local/state/llmcli/probe-*` shows the file (RW state works, ownership preserved by `keep-id`);
+  - `podman exec llmcli test -d /home/mickael/.cache/huggingface/hub` → exit 0 (HF cache visible).
+- [ ] **SC-8:** From outside the container on M₂, an authenticated request to a non-health endpoint succeeds: `curl -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/v1/models` returns HTTP 200 with a non-empty `data` array. Same call without the header returns HTTP 401. This validates `LLMCLI_API_KEY` from the env file reaches the in-container proxy and that auth is wired (V1).
+- [ ] **SC-9:** `docs/guides/deployment.md` has a "Running `llmcli proxy` as a Quadlet" section covering install, env file, smoke, troubleshooting (≥ the failure modes listed in Expected Behavior) (V1).
+- [ ] **SC-10:** On M₁, the V1 flow lands; `loginctl show-user mickael | grep Linger=yes` confirms user-linger; `systemctl --user is-active llmcli` returns `active` (V2).
+- [ ] **SC-11:** Reboot autostart is verified on M₁ by **either** (a) a real planned reboot followed by `systemctl --user is-active llmcli` returning `active` post-boot with a journal entry showing the unit started under PID 1 of the lingered user session, **or** (b) if no reboot is feasible during the implementation window, the unit is left running and the verification deferred — an explicit comment is added to the deployment guide noting "reboot autostart was last verified on $DATE" with the date filled in at the next observed reboot. Option (b) marks SC-11 partial; the criterion is fully closed only by option (a) (V2).
+- [ ] **SC-12:** Inducing a crash on M₁ via `podman kill llmcli` is followed by an automatic restart within ~10s per `Restart=on-failure + RestartSec=5s`; `systemctl --user status llmcli` shows the restart count incremented and current state `active` (V2).
+- [ ] **SC-13:** Top-level `README.md` repo table mentions the Quadlet unit (V3).
+
+## Open Questions
+
+All questions below are **defer-to-/plan** — implementer reads the recommendation, confirms or pushes back, then proceeds. None require user input before `/plan` starts.
+
+- **D-1 (image build details — base + extras + entrypoint):** Strategy is local build (no registry push) via `deploy/quadlet/Containerfile`. Recommended Containerfile constraints:
+  - **Base:** `nvidia/cuda:12.5.1-runtime-ubuntu24.04` (matches voiceCLI; supports both sm_86 / RTX 3080 on M₁ and sm_120 / RTX 5070 Ti on M₂ — runtime image, no driver inside container).
+  - **Two-stage:** builder stage installs `git` (needed for `roxabi-*` deps sourced from GitHub) + `uv`, copies lockfile, runs `uv sync --frozen --no-dev` (the proxy does **not** need the `nats` extra). Runtime stage copies the venv and source.
+  - **Non-root UID:** create container user `llmcli` with UID/GID **1502** (consistent with the existing `llmcli-nats-worker.container` UID convention).
+  - **Entrypoint:** `ENTRYPOINT ["llmcli", "proxy"]`. The proxy reads `LLMCLI_PROXY_HOST` / `LLMCLI_PROXY_PORT` from environment.
+  - **Cross-arch caveat:** The image is built per-host; both must produce a CUDA-12.x-compatible image without embedding sm-specific binaries (no `llama-server` build inside the image — the proxy is pure Python + LiteLLM).
+- **D-2 (network mode + host-side bind):** Recommended: `Network=bridge` (rootless default — `pasta` on Podman 4.9.3+) with `PublishPort=18091:18091`. Constraints: `LLMCLI_PROXY_HOST=0.0.0.0` must be set inside the container (binding `127.0.0.1` inside silently breaks PublishPort forwarding). Host-side bind decision: leave as `18091:18091` (all interfaces) so Tailnet-routed access from M₁→M₂ keeps working; do not restrict to `127.0.0.1:18091:18091` until Step 7 finalizes alias topology. `roxabi.network` membership decision: defer — current consumers are all on localhost or Tailnet; joining `roxabi.network` is only required if a future Quadlet on the same host needs container-to-container DNS (`http://llmcli:18091`). When that lands, add `Network=roxabi.network` line to this unit at that time.
+- **D-3 (UserNS form):** `UserNS=keep-id:uid=1000,gid=1000` (anchored form — explicit UID match host's `mickael`). Matches lyra-hub's `keep-id:uid=1500,gid=1500` pattern (just a different UID).
+- **D-4 (env file scope):** `~/.config/containers/systemd/llmcli.env` carries `LLMCLI_API_KEY` only. `LLMCLI_PROXY_PORT` and `LLMCLI_PROXY_HOST` stay as `Environment=` defaults in the unit. Rationale: env file is for secrets; tuning lives in the unit so changes are git-tracked.
+- **D-5 (hardening — resolved here, not deferred):** `NoNewPrivileges=true` and `DropCapability=all` are required in the unit file. `llmcli proxy` is a Python HTTP process needing no Linux capabilities. This sets the floor for future Roxabi Quadlets that copy this pattern. ReadOnly root filesystem is **not** required (Python + LiteLLM write to `/tmp` and `/home/mickael/.local/state/llmcli/`; locking the root FS down requires tmpfs overlay tuning that adds complexity for no proportional security gain in this trust boundary).
+- **D-6 (healthcheck — resolved here, not deferred):** `HealthCmd=curl -sf http://localhost:18091/health/liveliness`, `HealthInterval=30s`, `HealthStartPeriod=30s`. No `HealthOnFailure=` (avoid auto-kill loops; let `Restart=on-failure` handle process death; `podman healthcheck run llmcli` remains a manual debug primitive).
+- **D-7 (M₁/M₂ restart-on-crash delta — resolved here, not deferred):** Frame originally specified "no auto-restart on M₂". Spec relaxes this — `Restart=on-failure` applies on both hosts because (a) the single-unit-file goal demands it, and (b) auto-restart on M₂ is a feature not a bug for the dev experience (a manual crash during testing won't leave the shell holding a dead `make llm`). This delta is intentional; the frame's success/failure criteria do not depend on M₂ being restart-less. Documented in the deployment guide.
+
+## Edge cases
+
+| Edge case | Handling |
+|---|---|
+| First-time `daemon-reload` after dropping `.container` doesn't auto-start the unit | by design — `daemon-reload` only generates the unit file + symlink; first `start` is manual. Documented in deployment guide. |
+| `~/.cache/huggingface/` permission mismatch | `UserNS=keep-id:uid=1000,gid=1000` resolves this since host user owns the cache. If a specific host shows ownership-related EPERM, switch the bind to `:Z` (no-op on non-SELinux); flagged in troubleshooting. |
+| `~/.local/state/llmcli/` doesn't exist yet | `ExecStartPre=/bin/mkdir -p %h/.local/state/llmcli` in `[Service]` creates it unconditionally on every start. |
+| Operator forgets `daemon-reload` after manual edit | `make install-quadlet` always ends with `systemctl --user daemon-reload`, so the only path that misses it is a manual `cp` (documented to avoid). |
+| Operator runs `systemctl --user enable llmcli` | "Created symlink … → /dev/null" appears — Quadlet generator masks the user-facing unit name to prevent double-management; ignore it. Documented in troubleshooting. |
+| Concurrent edit of `llmcli.env` while unit is active | env file is re-read on next `restart`; not hot-reloaded. Operators run `systemctl --user restart llmcli` after edits. |
+| Container image stale after llmcli code change | `make build-quadlet-image && systemctl --user restart llmcli` — documented. The `Image=` line in the unit pins `localhost/llmcli:dev`; rebuild updates the same tag in place. |
+| `failed` state after exhausted `StartLimitBurst` | `systemctl --user reset-failed llmcli && systemctl --user start llmcli` — documented in troubleshooting (and in the deployment-guide failure-mode table). No automated notification in this issue (deferred to a separate monitoring story; the frame's "1 incident/month" budget is observable via `systemctl --user is-failed llmcli` from any cron / lyra watchdog later). |
+| Bridge mode + `LLMCLI_PROXY_HOST` accidentally set to `127.0.0.1` inside container | container starts, `:18091` answers nothing — `Environment=LLMCLI_PROXY_HOST=0.0.0.0` default in the unit prevents this unless explicitly overridden in the env file. Documented in troubleshooting. |

--- a/artifacts/specs/44-llmcli-quadlet-spec.mdx
+++ b/artifacts/specs/44-llmcli-quadlet-spec.mdx
@@ -14,95 +14,120 @@ Promoted from [`44-llmcli-quadlet-frame.mdx`](../frames/44-llmcli-quadlet-frame.
 
 Step 4 of the **llmcli central-portal** plan. Step 3 (#40) shipped `llmcli proxy` as a foreground binary owning both config generation and process lifecycle. This spec packages it as a Podman Quadlet — `llmcli.container` — so user-systemd supervises it directly on both hosts, with the same `systemctl --user …` grammar lyra and voiceCLI already use.
 
+**Image strategy (resolved this revision):** Single fleet image `ghcr.io/roxabi/llmcli:staging` (already built by `.github/workflows/publish.yml` via `Dockerfile.llm`) serves both the existing NATS worker (`llmcli-nats-worker.container`) and the new proxy (`llmcli.container`). The image's entrypoint script dispatches on first arg (`llm` → nats-serve, `proxy` → llmcli proxy). The PR therefore touches three concerns:
+1. **Image build** — `Dockerfile.llm` + `pyproject.toml` so the image contains `litellm`.
+2. **Entrypoint** — `deploy/entrypoint-nats.sh` is renamed to `deploy/entrypoint.sh` and learns a `proxy` mode (the existing `llm` mode is preserved — worker unit is untouched).
+3. **Quadlet unit** — `deploy/quadlet/llmcli.container` + Makefile install target + docs.
+
+These three concerns ship together because splitting them is not viable: the Quadlet needs `litellm` in the image, which only exists after the build-pipeline change merges and CI rebuilds. A "build PR first, Quadlet PR second" sequence would leave the build PR with no observable validation (the image gains a dep that nothing uses).
+
+The frame's "simplest alternative" (raw `.service` unit) remains rejected, and strategy A strengthens that rejection: there's no per-repo Containerfile diff to maintain (the fleet image is shared with the worker), `Label=io.containers.autoupdate=registry` handles image refresh declaratively, and the dispatched-entrypoint pattern is already in production (worker). A bare `.service` would re-invent all three.
+
 Today's state:
 - `llmcli proxy` runs as a foreground binary — started by `make llm` on M₂ or supervised by the lyra-supervisor `litellm` conf on `:4000` on M₁.
-- M₁ would prefer to drop the lyra-supervisor dependency entirely (`:4000` retirement is Step 6, blocked by this).
-- M₂ has no clean restart story — `make llm` blocks the shell.
+- The image at `ghcr.io/roxabi/llmcli:staging` (11.4 GB on disk; ml-base + CUDA inheritance from the worker case) currently does **not** include `litellm` — this PR adds it via a new `[proxy]` extra in `pyproject.toml`.
 
 After this spec ships:
-- One `llmcli.container` Quadlet unit lives in the repo at `deploy/quadlet/llmcli.container`.
-- One `Containerfile` (deferred decision D-1) lives at `deploy/quadlet/Containerfile`.
-- Both hosts run `llmcli proxy` via `systemctl --user start llmcli`. M₁ adds reboot-survival via user-linger (no `enable` needed — `WantedBy=default.target` is auto-symlinked by the Quadlet generator on `daemon-reload`; running `systemctl --user enable` on a Quadlet-generated unit is a no-op per project memory `feedback_quadlet_enable_is_noop.md`).
-- The container mounts `~/.roxabi/llmcli/` (catalog, **RO** — proxy only reads), `~/.local/state/llmcli/` (state, RW), `~/.cache/huggingface/` (model cache, RW), reads `LLMCLI_API_KEY` from an env file, and publishes `:18091`.
+- `Dockerfile.llm` builds with `--extra nats --extra proxy`, so the published image has both `nats-py` (worker) and `litellm` (proxy).
+- `deploy/entrypoint.sh` (renamed from `entrypoint-nats.sh`) dispatches `MODE=llm` → `exec llmcli nats-serve llm "$@"` (existing behavior) and `MODE=proxy` → `exec llmcli proxy "$@"` (new). Worker Quadlet continues to work without modification because its `Exec=llm --model qwen3-8b` line still routes through the `llm` branch.
+- `deploy/quadlet/llmcli.container` invokes the new branch via `Exec=proxy` and binds `:18091`.
+- Both hosts run `llmcli proxy` via `systemctl --user start llmcli`. M₁ adds reboot-survival via user-linger (no `enable` needed — `WantedBy=default.target` is auto-symlinked by the Quadlet generator on `daemon-reload`; per project memory `feedback_quadlet_enable_is_noop.md`).
+- The container mounts **only the catalog** `~/.roxabi/llmcli/` read-only at `/home/llmcli/.roxabi/llmcli/`. State (`proxy.config.yaml`) is written to the container's internal `/home/llmcli/.local/state/llmcli/` (ephemeral, regenerated each start). No HF cache mount — the proxy never touches GGUF files (those are served by `llmcli serve` running on the host outside any container).
 
 ## Goal
 
-A single Quadlet `.container` unit, committed to the repo at `deploy/quadlet/llmcli.container`, installed to `~/.config/containers/systemd/llmcli.container` on each host by a `make install-quadlet` target, that supervises `llmcli proxy` on `:18091` under user-systemd with identical config across M₁ and M₂ — differing only via a per-host env file (`~/.config/containers/systemd/llmcli.env`) for the API key.
+A single Quadlet `.container` unit pointing at the existing fleet image, installed via `make install-quadlet`, supervising `llmcli proxy` on `:18091` under user-systemd on both M₁ and M₂, with identical config across hosts — differing only via a per-host env file (`~/.config/containers/systemd/llmcli.env`) for the API key and provider keys.
 
 ## Users
 
 **Current beneficiary (this issue alone):**
-- **Mickael (ops)** — runs `systemctl --user start/restart/status llmcli` on both hosts; reads logs via `journalctl --user -u llmcli`; verifies `curl http://localhost:18091/health/liveliness` returns 200.
+- **Mickael (ops)** — runs `systemctl --user start/restart/status llmcli` on both hosts; reads logs via `journalctl --user -u llmcli`; verifies `curl http://localhost:18091/health/liveliness` returns 200 from outside the container.
 
 **Deferred beneficiaries (require follow-up tasks):**
 - **lyra / hermes / claude-code consumers** — once both hosts have a stable `:18091`, Step 6 retires `:4000` and Step 7 retargets aliases
-- **Future Roxabi tools** — `llmcli.container` becomes the reference Quadlet pattern in the fleet (alongside lyra's and voiceCLI's existing units), which is why hardening directives (`NoNewPrivileges=true`, `DropCapability=all`) are required, not optional, in this spec
+- **Future Roxabi tools** — `llmcli.container` becomes the reference Quadlet pattern for HTTP-only services in the fleet (registry-pulled image, no Containerfile in repo, dispatched entrypoint)
 
-Not in scope: registry image pipeline, virtual keys / multi-tenant, hot reload (catalog change → `systemctl --user restart llmcli`).
+Not in scope: registry image pipeline changes beyond adding `--extra proxy` to the existing build; virtual keys / multi-tenant; hot reload (catalog change → `systemctl --user restart llmcli`); retiring the `make llm` Makefile target on M₂ (kept as a fallback path during the transition — adoption signal is tracked via Step 6's `:4000` retirement, which depends on this issue but is its own follow-up).
 
 ## Expected Behavior
 
+### Pre-merge dev validation flow (M₂)
+
+The published image at `ghcr.io/roxabi/llmcli:staging` doesn't have `litellm` until this PR merges and CI rebuilds. For pre-merge validation on M₂, the dev builds the image locally with the same tag:
+
+```bash
+podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .
+make install-quadlet
+$EDITOR ~/.config/containers/systemd/llmcli.env   # populate LLMCLI_API_KEY + provider keys
+systemctl --user start llmcli
+curl http://localhost:18091/health/liveliness     # expect 200
+```
+
+After PR merges to staging and CI re-runs publish.yml, `podman` will auto-update on the `Label=io.containers.autoupdate=registry` cycle, picking up the canonical image.
+
 ### Happy path: M₂ (dev, on-demand)
 
-1. Operator runs `make build-quadlet-image` once (or after llmcli source change) on M₂. This builds `localhost/llmcli:dev` from `deploy/quadlet/Containerfile`.
-2. Operator runs `make install-quadlet` once. The target:
+1. Operator runs `make install-quadlet`. The target:
    - copies `deploy/quadlet/llmcli.container` → `~/.config/containers/systemd/llmcli.container`,
-   - creates a chmod-600 `~/.config/containers/systemd/llmcli.env` stub (only if absent — never overwrites an existing env file),
-   - runs `systemctl --user daemon-reload` (this is what triggers the Quadlet generator to materialize `llmcli.service` and auto-symlink it into `default.target.wants/`).
-3. Operator edits `~/.config/containers/systemd/llmcli.env` to populate `LLMCLI_API_KEY=…` (only secret in the file; port + host stay as `Environment=` defaults in the unit).
-4. Operator runs `systemctl --user start llmcli`. Within ~3s the unit is `active (running)`. **Do not run `systemctl --user enable llmcli.service`** — for Quadlet-generated units this is a no-op at best and produces a misleading "Created symlink … → /dev/null" message; the generator already wired the unit via `WantedBy=default.target`.
-5. Smoke: `curl http://localhost:18091/health/liveliness` returns `{"status": "ok"}`.
-6. Operator runs `systemctl --user stop llmcli` to shut down — `TimeoutStopSec=15s` accommodates the in-container `llmcli proxy` 10s signal-drain (from #40) plus a 5s safety margin, then SIGKILL.
+   - creates a chmod-600 `~/.config/containers/systemd/llmcli.env` stub (only if absent — never overwrites),
+   - runs `systemctl --user daemon-reload` (triggers the Quadlet generator to emit `llmcli.service` and auto-symlink it into `default.target.wants/`).
+2. Operator edits `~/.config/containers/systemd/llmcli.env` to populate `LLMCLI_API_KEY=…` and each provider key the catalog needs (`FIREWORKS_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `NVIDIA_API_KEY`, …). All secrets in one file, chmod 600.
+3. Operator runs `systemctl --user start llmcli`. Within ~5s the unit is `active (running)` (podman first pulls the image if not cached). **Do not run `systemctl --user enable llmcli.service`** — for Quadlet-generated units this is a no-op at best.
+4. Smoke: `curl http://localhost:18091/health/liveliness` returns `{"status": "ok"}`.
+5. Authenticated smoke: `curl -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/v1/models` returns 200 with non-empty `data` array; same request without the header returns 401.
+6. `systemctl --user stop llmcli` — `TimeoutStopSec=20s` accommodates the in-container `llmcli proxy` 10s signal-drain (from #40) plus a 10s safety margin for `podman`'s wrapper (`conmon`) to finish signalling the container before systemd SIGKILLs the wrapper itself, then SIGKILL.
 
 ### Happy path: M₁ (prod, autostart)
 
 1. One-time setup: `loginctl enable-linger mickael` (already done — lyra service depends on it).
-2. Operator runs the same M₂ V1 flow: `make build-quadlet-image && make install-quadlet`, edits env file, `systemctl --user start llmcli`. The single `.container` file produces identical behavior on both hosts; only the env file differs.
-3. M₁ reboots (planned or unplanned). After boot, `mickael`'s user-systemd starts under lingered session; `llmcli.service` (generated from `.container`) starts automatically because the unit declares `[Install] WantedBy=default.target` (Quadlet's default — already symlinked at step 2 by `daemon-reload`).
-4. If the container crashes, `Restart=on-failure` + `RestartSec=5s` brings it back within ~5s. `StartLimitIntervalSec=60s` + `StartLimitBurst=5` (fleet standard) means 5 consecutive crashes within 60s park the unit in `failed`. `journalctl --user -u llmcli` shows the restart cycle.
+2. Operator runs same M₂ V1 flow.
+3. M₁ reboots. After boot, `mickael`'s user-systemd starts under lingered session; `llmcli.service` auto-starts via `WantedBy=default.target`.
+4. If the container crashes, `Restart=on-failure` + `RestartSec=5s` brings it back. `StartLimitIntervalSec=60` + `StartLimitBurst=5` parks the unit in `failed` after 5 crashes within 60s.
 
 ### `--config-out` smoke (one-shot, container-internal)
 
-Existing `llmcli proxy --config-out /tmp/x.yaml` behavior is preserved. Operator can run `podman exec llmcli llmcli proxy --config-out /dev/stdout` to dump the rendered LiteLLM config — `llmcli` is the **fixed** container name set by `ContainerName=llmcli` in the unit (not deferred).
+`podman exec llmcli llmcli proxy --config-out /dev/stdout` dumps the rendered LiteLLM config from inside the running container (resolves `llmcli` via the image's `PATH=/app/.venv/bin:$PATH`). The container name `llmcli` is fixed by `ContainerName=llmcli`.
 
 ### Failure modes
 
 | Failure | Symptom | Recovery |
 |---|---|---|
-| `~/.config/containers/systemd/llmcli.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` to create stub; populate |
-| `LLMCLI_API_KEY` empty in env file | container starts; `llmcli proxy` exits 1 (provider-key error from #40); `Restart=on-failure` retries within 60s/5-burst window then `failed` | populate env file, `systemctl --user reset-failed llmcli && start` |
-| Image not present locally (M₁ with no network) | `podman` run fails (no pull source) | `make build-quadlet-image` on host first (no registry round-trip needed — image is built locally per D-1) |
-| Port 18091 already bound | container fails to publish port; unit `failed` | identify conflict, free port, restart unit |
+| `~/.config/containers/systemd/llmcli.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` recreates stub |
+| `LLMCLI_API_KEY` or provider key empty | `llmcli proxy` exits 1 (provider-key error from #40). `RestartForceExitStatus=1` suppresses restart — unit enters `failed` immediately with no retry burn-up | populate env file, `systemctl --user reset-failed llmcli && start` |
+| `litellm` missing in image | `llmcli proxy` exits 127 ("litellm binary not found"). `RestartForceExitStatus=127` suppresses restart — unit `failed` immediately | rebuild image locally with this PR's `Dockerfile.llm` OR wait for CI rebuild |
+| Image not present + no network on M₁ | `podman` run fails (no pull source) | `podman pull ghcr.io/roxabi/llmcli:staging` on host first, OR local `podman build` from this repo |
+| Port 18091 already bound | container fails to publish port; unit `failed` | identify conflict, free port, restart |
 | User-linger off on M₁ | service stops after logout | `loginctl enable-linger mickael` |
-| Operator runs `systemctl --user enable llmcli.service` | "Created symlink … → /dev/null" — Quadlet generator masks the unit name to prevent double-management | ignore the message; nothing is broken |
-| Bridge published port unreachable | `curl localhost:18091` connects but no response | confirm `LLMCLI_PROXY_HOST=0.0.0.0` inside the container (Environment= default in the unit) — bind to `127.0.0.1` inside the container silently breaks PublishPort forwarding |
+| Operator runs `systemctl --user enable llmcli.service` | "Created symlink … → /dev/null" — Quadlet generator masks the unit name | ignore; nothing is broken |
+| Container binds 127.0.0.1 inside (PROXY_HOST override accident) | `:18091` answers nothing externally | `Environment=LLMCLI_PROXY_HOST=0.0.0.0` default in unit prevents this unless explicitly overridden in env file |
 
 ## Data Model & Consumers
 
-### Quadlet unit shape (resolved — no longer deferred)
+### Quadlet unit shape (resolved — concrete directives)
 
 ```mermaid
 classDiagram
     class QuadletUnit {
-        +str Image = "localhost/llmcli:dev"
+        +str Image = "ghcr.io/roxabi/llmcli:staging"
+        +str Label = "io.containers.autoupdate=registry"
         +str ContainerName = "llmcli"
         +list~str~ PublishPort = ["18091:18091"]
-        +list~str~ Volume
+        +str Volume = "%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z"
         +str EnvironmentFile = "%h/.config/containers/systemd/llmcli.env"
         +dict Environment
-        +str UserNS = "keep-id:uid=1000,gid=1000"
-        +str Network = "bridge"
+        +str UserNS = "keep-id:uid=1502,gid=1502"
+        +str Exec = "proxy"
+        +str HealthCmd = "pgrep -f litellm"
+        +str HealthInterval = "30s"
+        +str HealthStartPeriod = "15s"
         +bool NoNewPrivileges = true
         +str DropCapability = "all"
-        +str HealthCmd = "curl -sf http://localhost:18091/health/liveliness"
-        +str HealthInterval = "30s"
-        +str HealthStartPeriod = "30s"
     }
     class ServiceSection {
         +str Restart = "on-failure"
         +int RestartSec = 5
-        +str TimeoutStopSec = "15s"
-        +str ExecStartPre = "/bin/mkdir -p %h/.local/state/llmcli"
+        +str TimeoutStopSec = "20s"
+        +str RestartForceExitStatus = "1 127"
     }
     class UnitSection {
         +str Description
@@ -112,36 +137,45 @@ classDiagram
     class EnvFile {
         <<chmod 0600>>
         +str LLMCLI_API_KEY
+        +str FIREWORKS_API_KEY
+        +str ANTHROPIC_API_KEY
+        +str OPENAI_API_KEY
+        +str NVIDIA_API_KEY
     }
-    class Containerfile {
-        +str FROM = "nvidia/cuda:12.5.1-runtime-ubuntu24.04"
-        +list~str~ stages = ["builder", "runtime"]
-        +str installer = "uv sync --frozen --no-dev"
-        +int RuntimeUID = 1502
-        +list~str~ ENTRYPOINT = ["llmcli", "proxy"]
+    class ImageBuild {
+        +str Dockerfile = "Dockerfile.llm"
+        +str CI_workflow = ".github/workflows/publish.yml"
+        +list~str~ uv_extras = ["nats", "proxy"]
+        +str entrypoint = "/entrypoint.sh"
+    }
+    class EntrypointScript {
+        +path "deploy/entrypoint.sh"
+        +str MODE_llm = "exec llmcli nats-serve llm"
+        +str MODE_proxy = "exec llmcli proxy"
     }
     class GeneratedService {
         <<systemd unit>>
         +str From = "llmcli.container"
-        +str ExecStart = "/usr/bin/podman run ..."
         +WantedBy default.target
     }
     QuadletUnit --> EnvFile : reads at runtime
     QuadletUnit --> ServiceSection : passthrough [Service]
     QuadletUnit --> UnitSection : passthrough [Unit]
-    QuadletUnit --> Containerfile : built into Image
+    QuadletUnit --> ImageBuild : pulls
+    ImageBuild --> EntrypointScript : copies
     QuadletUnit --> GeneratedService : Quadlet generator emits
+    QuadletUnit ..> EntrypointScript : "Exec=proxy" → MODE_proxy branch
 ```
 
-Volume bind-mounts (host path → container path, mode):
+### Mounts (final — 1 mount)
 
-| Host | Container (under `UserNS=keep-id:uid=1000`) | Mode |
-|---|---|---|
-| `%h/.roxabi/llmcli/` | `/home/mickael/.roxabi/llmcli/` | `ro` |
-| `%h/.local/state/llmcli/` | `/home/mickael/.local/state/llmcli/` | `rw` |
-| `%h/.cache/huggingface/` | `/home/mickael/.cache/huggingface/` | `rw` |
+| Host | Container path (under `UserNS=keep-id:uid=1502`) | Mode | Rationale |
+|---|---|---|---|
+| `%h/.roxabi/llmcli/` | `/home/llmcli/.roxabi/llmcli/` | `ro,Z` | catalog source-of-truth; proxy only reads. RO + cross-UID read works because host files have 644/755 perms. |
 
-With `UserNS=keep-id:uid=1000,gid=1000`, the container's effective UID maps to host UID 1000 (mickael); container `$HOME` is `/home/mickael`. **Not** `/root/`.
+Not mounted (intentional changes from earlier spec draft):
+- **State dir** (`~/.local/state/llmcli/`) — proxy writes `proxy.config.yaml` to its container-internal `/home/llmcli/.local/state/llmcli/` (writable by the container's UID 1502 because it owns its home). The file is regenerated from the catalog on every start; persistence buys nothing.
+- **HF cache** (`~/.cache/huggingface/`) — proxy never downloads or reads model files. GGUF files are served by `llama-server` running on the host (via `llmcli serve`), not by the proxy container.
 
 ### Consumer map
 
@@ -150,8 +184,6 @@ flowchart LR
     subgraph host[Host filesystem]
       ENVFILE[~/.config/containers/systemd/llmcli.env]
       CATALOG[~/.roxabi/llmcli/]
-      STATE[~/.local/state/llmcli/]
-      HFCACHE[~/.cache/huggingface/]
       UNIT[~/.config/containers/systemd/llmcli.container]
     end
     subgraph systemd[user-systemd]
@@ -161,13 +193,15 @@ flowchart LR
     subgraph podman[Podman]
       CONT[llmcli container]
     end
+    subgraph registry[GHCR]
+      IMG[ghcr.io/roxabi/llmcli:staging]
+    end
     UNIT --> GEN
     GEN --> SVC
     SVC --> CONT
+    IMG -.->|pull / autoupdate| CONT
     ENVFILE -.->|EnvironmentFile=| CONT
-    CATALOG -.->|/home/mickael/.roxabi/llmcli/ ro| CONT
-    STATE -.->|/home/mickael/.local/state/llmcli/ rw| CONT
-    HFCACHE -.->|/home/mickael/.cache/huggingface/ rw| CONT
+    CATALOG -.->|/home/llmcli/.roxabi/llmcli/ ro| CONT
     CONT -.->|:18091| LYRA[lyra NATS satellite]
     CONT -.->|:18091| HERMES[hermes bots]
     CONT -.->|:18091| CCODE[claude-code aliases]
@@ -180,8 +214,9 @@ Dashed = consumer wiring lands in Steps 6 / 7 / 8 (separate issues).
 | Consumer | Reads | When | This issue? |
 |---|---|---|---|
 | user-systemd | unit file | on `daemon-reload` + start | this issue |
-| Quadlet generator | `.container` + `Containerfile`-built image | on `daemon-reload` + on `podman build` | this issue |
-| Container runtime | env file, mounts, image | on container start | this issue |
+| Quadlet generator | `.container` | on `daemon-reload` | this issue |
+| GHCR | image | on `podman` pull (first start) + on `autoupdate=registry` cycle | this issue |
+| Container runtime | env file, catalog mount, image | on container start | this issue |
 | lyra NATS satellite | `:18091` over HTTP | Step 6 retires `:4000` | future |
 | hermes bots | `:18091` over HTTP | Step 8 | future |
 | Claude Code aliases | `:18091` over HTTP | Step 7 | future |
@@ -192,90 +227,95 @@ Dashed = consumer wiring lands in Steps 6 / 7 / 8 (separate issues).
 
 | ID | Surface | Trigger | Handler | Notes |
 |---|---|---|---|---|
-| U1 | `make build-quadlet-image` | operator runs target | `podman build -t localhost/llmcli:dev -f deploy/quadlet/Containerfile .` | idempotent; reuses Podman layer cache |
-| U2 | `make install-quadlet` | operator runs target | `install -m 644 deploy/quadlet/llmcli.container ~/.config/containers/systemd/` → stub-env-file (chmod 600) if absent → `systemctl --user daemon-reload` | idempotent; preserves existing env file |
-| U3 | `systemctl --user start llmcli` | operator runs (after U2 daemon-reload) | user-systemd → Quadlet generator → `podman run …` | exit 0 within ~3s |
-| U4 | `systemctl --user restart llmcli` | operator runs after edit | systemd sends SIGTERM to container → `llmcli proxy` (#40) drains up to 10s → SIGKILL after `TimeoutStopSec=15s` → re-spawn | drains via N1 internals |
-| U5 | `systemctl --user status llmcli` | operator runs | reports unit state + last 10 log lines | full journal via `journalctl --user -u llmcli` |
-| U6 | `curl http://localhost:18091/health/liveliness` | operator runs | LiteLLM HTTP — returns `{"status": "ok"}` | sub-second when healthy; also wired as `HealthCmd=` |
-| U7 | M₁ host reboot | infra event | user-linger keeps session alive → Quadlet unit auto-starts via `WantedBy=default.target` | observable: `systemctl --user is-active llmcli` returns `active` post-boot |
-| N1 | Crash inside container | `llmcli proxy` exits non-zero | `Restart=on-failure` + `RestartSec=5s` re-spawns; `StartLimitIntervalSec=60`/`StartLimitBurst=5` parks at `failed` after 5 fast restarts | journal shows restart cycle |
-| N2 | Missing `LLMCLI_API_KEY` | env file empty/missing var | `llmcli proxy` exits 1 → retry → exhaust burst → unit `failed` | operator runs `systemctl --user reset-failed llmcli` after fix |
-| N3 | Quadlet generator | reads `.container` on `daemon-reload` | emits `llmcli.service` into `XDG_RUNTIME_DIR/systemd/generator.user/`; symlinks into `default.target.wants/` | not user-editable — drop-ins go via `~/.config/systemd/user/llmcli.service.d/*.conf` |
-| S1 | `deploy/quadlet/llmcli.container` | unit file in repo | committed source-of-truth | identical content on M₁ and M₂; only env file differs |
-| S2 | `deploy/quadlet/Containerfile` | image recipe in repo | committed source-of-truth | base `nvidia/cuda:12.5.1-runtime-ubuntu24.04`, two-stage builder, non-root UID 1502 |
-| S3 | `~/.config/containers/systemd/llmcli.env` | per-host secret | chmod 600; not in repo; created by U2 stub | sole host-specific input |
+| U1 | `make install-quadlet` | operator runs | `install -m 644 deploy/quadlet/llmcli.container ~/.config/containers/systemd/` → stub-env-file (chmod 600) if absent → `systemctl --user daemon-reload` | idempotent; preserves existing env file |
+| U2 | `systemctl --user start llmcli` | operator runs (after U1 daemon-reload) | user-systemd → Quadlet generator → `podman run …` (pulls image if not cached) | exit 0 within ~5s; ~10-30s on first pull from GHCR |
+| U3 | `systemctl --user restart llmcli` | operator runs after edit | systemd sends SIGTERM → `llmcli proxy` (#40) drains up to 10s → SIGKILL after `TimeoutStopSec=15s` → re-spawn | drains via N1 internals |
+| U4 | `systemctl --user status llmcli` | operator runs | reports unit state + last 10 log lines; journal via `journalctl --user -u llmcli` | — |
+| U5 | `curl http://localhost:18091/health/liveliness` | operator runs | LiteLLM HTTP — returns `{"status": "ok"}` | sub-second when healthy |
+| U6 | `curl -H "Authorization: Bearer $K" http://localhost:18091/v1/models` | operator runs | proxy returns 200 with model list; without `Authorization` returns 401 | validates env-file → proxy → litellm wiring |
+| U7 | M₁ host reboot | infra event | user-linger keeps session → Quadlet unit auto-starts via `WantedBy=default.target` | observable: `systemctl --user is-active llmcli` post-boot |
+| U8 | Pre-merge dev validation | dev runs locally before merging | `podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .` overrides the registry image locally → V1 smoke works pre-merge | documented; not committed to Makefile |
+| N1 | Crash inside container | `llmcli proxy` (or `litellm` subprocess) exits non-zero | `Restart=on-failure` + `RestartSec=5s` re-spawn; `StartLimitIntervalSec=60`/`StartLimitBurst=5` parks at `failed` after 5 fast restarts | journal shows restart cycle |
+| N2 | Missing `LLMCLI_API_KEY` or provider key | env file empty/missing var | `llmcli proxy` exits 1 (provider-key error from #40) → retry → exhaust burst → unit `failed` | `systemctl --user reset-failed llmcli` after fix |
+| N3 | Quadlet generator | reads `.container` on `daemon-reload` | emits `llmcli.service` into `XDG_RUNTIME_DIR/systemd/generator.user/`; symlinks into `default.target.wants/` | not user-editable — drop-ins via `~/.config/systemd/user/llmcli.service.d/*.conf` |
+| N4 | Entrypoint dispatch | `Exec=proxy` reaches `/entrypoint.sh proxy` inside container | script's `case MODE` matches `proxy` branch → `exec llmcli proxy "$@"` | preserves `llm` branch for worker Quadlet (no worker change) |
+| S1 | `deploy/quadlet/llmcli.container` | unit file in repo | committed source-of-truth | identical on M₁ and M₂; only env file differs |
+| S2 | `deploy/entrypoint.sh` (renamed from `entrypoint-nats.sh`) | dispatch script in image | bash case on first arg → `llm` (legacy nats worker) ∨ `proxy` (new) | rename is transparent to worker Quadlet (worker uses `Exec=llm …`, unchanged) |
+| S3 | `Dockerfile.llm` | image build recipe | `uv sync --extra nats --extra proxy` ensures both deps in venv | one-line addition (`--extra proxy`) plus copy of renamed entrypoint |
+| S4 | `pyproject.toml` `[proxy]` extra | declares `litellm>=1.0` dependency | `uv sync --extra proxy` resolves | new optional-dependency group |
+| S5 | `~/.config/containers/systemd/llmcli.env` | per-host secrets | chmod 600; not in repo; created by U1 stub | sole host-specific input |
 
 ### Wiring
 
 ```
-U1 build → image localhost/llmcli:dev in podman storage
-U2 install-quadlet → S1 .container in user dir + S2 env-file stub + daemon-reload
-                   → N3 Quadlet generator emits llmcli.service + symlinks default.target.wants/
-U3 start → systemd starts service → podman run (reads S3, mounts host dirs ro/rw per table, publishes :18091)
-         → llmcli proxy bootstraps (#40 logic unchanged)
-U4 restart → SIGTERM in → 10s drain (per #40) → TimeoutStopSec=15s → SIGKILL → re-spawn
-U5 status → systemd unit state + journal tail
-U6 curl 18091/health/liveliness → in-container LiteLLM responds (also N3 health probe)
+S3 Dockerfile.llm + S4 pyproject [proxy] → CI publish.yml → image ghcr.io/roxabi/llmcli:staging
+                                                                  ↓
+                                                              S2 /entrypoint.sh baked in
+S1 .container declares Exec=proxy → loads image → entrypoint → S2 dispatch → llmcli proxy
+                                                                                ↓
+                                                                          reads CATALOG (ro mount)
+                                                                                ↓
+                                                                          generates /home/llmcli/.local/state/llmcli/proxy.config.yaml
+                                                                                ↓
+                                                                          spawn litellm subprocess → :18091
+
+U1 install-quadlet → S1 + S5 + daemon-reload → N3 generator → llmcli.service + symlink
+U2 start → N3 service → podman run (reads S5 env, mounts S1's catalog ro, publishes :18091)
+U3 restart → SIGTERM in → 10s drain (#40) → TimeoutStopSec=15s → SIGKILL → re-spawn
+U5 health → LiteLLM HTTP responds; HealthCmd uses pgrep on litellm process (curl absent from image)
 U7 M₁ reboot → user-linger → default.target → Quadlet unit auto-starts (WantedBy symlink from N3)
-N1 crash → Restart=on-failure → RestartSec=5s wait → re-spawn (max StartLimitBurst=5 per 60s window)
-N2 missing key → exit 1 → N1 loop → unit goes failed → operator reset-failed
+N1 crash → Restart=on-failure → RestartSec=5s → re-spawn (StartLimitBurst=5 per 60s window)
+N2 missing key → exit 1 → N1 loop → failed → operator reset-failed
 ```
 
 ## Slices
 
 | # | Slice | Includes | Demo | Independently shippable? |
 |---|---|---|---|---|
-| V1 | **Unit + image + Makefile + dev host (M₂)** | `deploy/quadlet/llmcli.container` (with all hardening + healthcheck), `deploy/quadlet/Containerfile` (CUDA 12.5.1 base, two-stage builder, UID 1502 entrypoint), `make build-quadlet-image`, `make install-quadlet` (idempotent + daemon-reload), docs section in `docs/guides/deployment.md` | M₂ runs `make build-quadlet-image && make install-quadlet`, edits env file, `systemctl --user start llmcli`; smoke commands per Success Criteria | yes — M₁ keeps existing `make llm` + supervisor until V2 lands |
-| V2 | **Prod host (M₁) + autostart + crash smoke** | M₁ image build + install + start; observed reboot survival (real reboot OR documented next-planned-reboot acceptance); induced crash smoke | M₁ runs V1 commands; we record a journal-entry timestamp; on next planned reboot (or simulated kill-session) we verify the unit auto-restarts | yes — V1 already valuable on M₂ |
-| V3 | **Docs polish** | Update top-level `README.md` repo table to mention the Quadlet, add troubleshooting subsection to deployment guide (covers env-file missing, `enable` no-op message, port conflict, bridge `0.0.0.0` requirement, `reset-failed` after exhausted burst) | docs build green (no broken links) | yes — pure docs |
+| V1 | **Build pipeline + Quadlet + dev host (M₂) + docs** | `pyproject.toml` (new `[proxy]` extra with litellm), `Dockerfile.llm` (add `--extra proxy` + copy renamed entrypoint), `deploy/entrypoint-nats.sh` → `deploy/entrypoint.sh` (rename + dispatch on MODE), `deploy/quadlet/llmcli.container` (final shape per data model), `Makefile` `install-quadlet` target, `docs/guides/deployment.md` Quadlet section (covers pre-merge local build + post-merge registry pull + failure modes), top-level `README.md` table mention | M₂ runs `podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm . && make install-quadlet && systemctl --user start llmcli` → health + authenticated smokes per Success Criteria | yes — M₁ keeps existing `make llm` + supervisor until V2 lands |
+| V2 | **Prod host (M₁) + autostart + crash smoke** | M₁ image pull (or local build) + install + start; observed reboot survival (real reboot OR documented next-planned-reboot acceptance per SC-9); induced crash smoke | M₁ runs V1 commands; we record `systemctl --user is-active` and a `journalctl --user -u llmcli --since today` snippet; on next planned reboot we verify auto-restart | yes — V1 already valuable on M₂ |
 
 ## Success Criteria
 
-- [ ] **SC-1:** `deploy/quadlet/llmcli.container` and `deploy/quadlet/Containerfile` are committed to the repo (V1).
-- [ ] **SC-2:** The `.container` unit declares: `ContainerName=llmcli`, `Image=localhost/llmcli:dev`, `PublishPort=18091:18091`, `UserNS=keep-id:uid=1000,gid=1000`, `NoNewPrivileges=true`, `DropCapability=all`, `HealthCmd=curl -sf http://localhost:18091/health/liveliness`, `HealthInterval=30s`, `HealthStartPeriod=30s`, `EnvironmentFile=%h/.config/containers/systemd/llmcli.env`, `Environment=LLMCLI_PROXY_PORT=18091 LLMCLI_PROXY_HOST=0.0.0.0`, the 3 volume mounts at the modes given in the data-model table, and `[Service] Restart=on-failure RestartSec=5 TimeoutStopSec=15s ExecStartPre=/bin/mkdir -p %h/.local/state/llmcli`, and `[Unit] StartLimitIntervalSec=60 StartLimitBurst=5` (V1).
-- [ ] **SC-3:** `make build-quadlet-image` target exists and produces `localhost/llmcli:dev` from `deploy/quadlet/Containerfile`; the image runs `llmcli proxy` as UID 1502 by default (V1). Verify: `podman run --rm localhost/llmcli:dev id -u` returns `1502` (or, for tests that inject a fake entrypoint, `podman inspect localhost/llmcli:dev --format '{{.Config.User}}'` includes `1502`).
-- [ ] **SC-4:** `make install-quadlet` target is idempotent: re-running it does not overwrite an existing `llmcli.env`; on second run, `git status` (in repo) is clean and `~/.config/containers/systemd/llmcli.env` mtime is unchanged (V1).
-- [ ] **SC-5:** After `make build-quadlet-image && make install-quadlet`, populating env file, and `systemctl --user start llmcli`, `systemctl --user is-active llmcli` returns `active` within 10s on M₂ (V1).
-- [ ] **SC-6:** While the unit is active, `curl http://localhost:18091/health/liveliness` returns HTTP 200 with body `{"status": "ok"}` on M₂ (V1).
-- [ ] **SC-7:** Volume mounts function correctly on M₂ (V1). Verify:
-  - `podman exec llmcli test -r /home/mickael/.roxabi/llmcli/llmcli.toml` → exit 0 (RO catalog readable);
-  - `podman exec llmcli touch /home/mickael/.local/state/llmcli/probe-$(date +%s)` followed by host `ls ~/.local/state/llmcli/probe-*` shows the file (RW state works, ownership preserved by `keep-id`);
-  - `podman exec llmcli test -d /home/mickael/.cache/huggingface/hub` → exit 0 (HF cache visible).
-- [ ] **SC-8:** From outside the container on M₂, an authenticated request to a non-health endpoint succeeds: `curl -H "Authorization: Bearer $LLMCLI_API_KEY" http://localhost:18091/v1/models` returns HTTP 200 with a non-empty `data` array. Same call without the header returns HTTP 401. This validates `LLMCLI_API_KEY` from the env file reaches the in-container proxy and that auth is wired (V1).
-- [ ] **SC-9:** `docs/guides/deployment.md` has a "Running `llmcli proxy` as a Quadlet" section covering install, env file, smoke, troubleshooting (≥ the failure modes listed in Expected Behavior) (V1).
-- [ ] **SC-10:** On M₁, the V1 flow lands; `loginctl show-user mickael | grep Linger=yes` confirms user-linger; `systemctl --user is-active llmcli` returns `active` (V2).
-- [ ] **SC-11:** Reboot autostart is verified on M₁ by **either** (a) a real planned reboot followed by `systemctl --user is-active llmcli` returning `active` post-boot with a journal entry showing the unit started under PID 1 of the lingered user session, **or** (b) if no reboot is feasible during the implementation window, the unit is left running and the verification deferred — an explicit comment is added to the deployment guide noting "reboot autostart was last verified on $DATE" with the date filled in at the next observed reboot. Option (b) marks SC-11 partial; the criterion is fully closed only by option (a) (V2).
-- [ ] **SC-12:** Inducing a crash on M₁ via `podman kill llmcli` is followed by an automatic restart within ~10s per `Restart=on-failure + RestartSec=5s`; `systemctl --user status llmcli` shows the restart count incremented and current state `active` (V2).
-- [ ] **SC-13:** Top-level `README.md` repo table mentions the Quadlet unit (V3).
+- [ ] **SC-1:** `pyproject.toml` declares an `[project.optional-dependencies] proxy = ["litellm>=1.0"]` block, AND `uv.lock` is refreshed (`uv lock` run as part of the PR) to include `litellm` and its transitive deps. `git diff` shows both files modified in the same commit (V1).
+- [ ] **SC-2:** `Dockerfile.llm` `uv sync` lines use `--extra nats --extra proxy` (V1).
+- [ ] **SC-3:** `deploy/entrypoint.sh` exists, dispatches on `$MODE` first arg with cases `llm` (`exec llmcli nats-serve llm "$@"`) and `proxy` (`exec llmcli proxy "$@"`); any other value writes `Unknown mode: <arg>` to stderr and exits `1` (V1).
+- [ ] **SC-4:** `deploy/entrypoint-nats.sh` is removed from the repo (renamed/replaced by `entrypoint.sh`) and `Dockerfile.llm` `COPY` of the entrypoint reflects the new path (V1).
+- [ ] **SC-5:** `deploy/quadlet/llmcli.container` contains all directives shown in the Data Model section's class diagram, including specifically `RestartForceExitStatus=1 127` (suppresses restart on the proxy's two known non-retryable exit codes — provider-key missing and litellm-binary missing) and `TimeoutStopSec=20s` (10s drain + 10s podman/conmon margin). Verification: `diff -u <(grep -E '^(Image|Label|ContainerName|PublishPort|Volume|EnvironmentFile|Environment|UserNS|Exec|HealthCmd|HealthInterval|HealthStartPeriod|NoNewPrivileges|DropCapability|Restart|RestartSec|TimeoutStopSec|RestartForceExitStatus|StartLimitIntervalSec|StartLimitBurst|Description|WantedBy)=' deploy/quadlet/llmcli.container | sort)` returns the same multiset of directives as the data-model table (V1).
+- [ ] **SC-6:** `make install-quadlet` is idempotent: re-running it does not overwrite an existing `llmcli.env` (verify by populating it with a sentinel value, re-running, then `grep SENTINEL ~/.config/containers/systemd/llmcli.env`); it also runs `systemctl --user daemon-reload` (V1).
+- [ ] **SC-7:** Local image build on M₂ succeeds: `podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .` returns exit 0, AND `podman run --rm --entrypoint="" ghcr.io/roxabi/llmcli:staging /app/.venv/bin/litellm --version` returns a non-empty version string (V1).
+- [ ] **SC-8:** After local build + install + populated env file + `systemctl --user start llmcli`, `systemctl --user is-active llmcli` returns `active` within 30s on M₂ (V1).
+- [ ] **SC-9:** From M₂ host: `curl -s -o /dev/null -w "%{http_code}" http://localhost:18091/health/liveliness` returns `200` (V1).
+- [ ] **SC-10:** Authenticated round-trip on M₂: `curl -s -H "Authorization: Bearer $(grep ^LLMCLI_API_KEY ~/.config/containers/systemd/llmcli.env | cut -d= -f2)" http://localhost:18091/v1/models` returns HTTP 200 with a JSON body containing a non-empty `data` array; same request without the `Authorization` header returns HTTP 401 (V1).
+- [ ] **SC-11:** Catalog mount works: `podman exec llmcli test -r /home/llmcli/.roxabi/llmcli/llmcli.toml` returns exit 0 (V1).
+- [ ] **SC-12:** `docs/guides/deployment.md` has a "Running `llmcli proxy` as a Quadlet" section covering: pre-merge local-build flow, post-merge registry-pull behavior, env-file template (with all expected provider key names), `systemctl --user` lifecycle commands, failure-mode table mirroring the Expected Behavior section, and a `reset-failed` note (V1).
+- [ ] **SC-13:** Top-level `README.md` repo table mentions the Quadlet unit (V1).
+- [ ] **SC-14:** On M₁: image present in podman storage (either pulled from registry or built locally), `loginctl show-user mickael | grep Linger=yes` confirms user-linger, `systemctl --user is-active llmcli` returns `active` (V2).
+- [ ] **SC-15:** Reboot-equivalent autostart on M₁ is verified by **either** (a) a real planned/unplanned reboot followed by `systemctl --user is-active llmcli` returning `active` post-boot, **or** (b) a root-side simulation that terminates and re-creates the lingered user session: `sudo systemctl stop user@$(id -u mickael).service` (kills mickael's user-systemd including `llmcli.service`) → wait 5s → `sudo systemctl start user@$(id -u mickael).service` (re-creates the lingered session under default.target) → `systemctl --user is-active llmcli` returns `active` within 30s. Path (b) exercises the same `WantedBy=default.target` + linger path as a real cold-boot. Either path satisfies the SC binary (active / not-active) — no doc-comment deferral (V2).
+- [ ] **SC-16:** Induced crash on M₁: `podman kill llmcli` followed by automatic restart within ~10s; `systemctl --user status llmcli` shows the restart count incremented and current state `active` (V2).
 
 ## Open Questions
 
-All questions below are **defer-to-/plan** — implementer reads the recommendation, confirms or pushes back, then proceeds. None require user input before `/plan` starts.
+All questions resolved or explicitly deferred. None block `/plan`.
 
-- **D-1 (image build details — base + extras + entrypoint):** Strategy is local build (no registry push) via `deploy/quadlet/Containerfile`. Recommended Containerfile constraints:
-  - **Base:** `nvidia/cuda:12.5.1-runtime-ubuntu24.04` (matches voiceCLI; supports both sm_86 / RTX 3080 on M₁ and sm_120 / RTX 5070 Ti on M₂ — runtime image, no driver inside container).
-  - **Two-stage:** builder stage installs `git` (needed for `roxabi-*` deps sourced from GitHub) + `uv`, copies lockfile, runs `uv sync --frozen --no-dev` (the proxy does **not** need the `nats` extra). Runtime stage copies the venv and source.
-  - **Non-root UID:** create container user `llmcli` with UID/GID **1502** (consistent with the existing `llmcli-nats-worker.container` UID convention).
-  - **Entrypoint:** `ENTRYPOINT ["llmcli", "proxy"]`. The proxy reads `LLMCLI_PROXY_HOST` / `LLMCLI_PROXY_PORT` from environment.
-  - **Cross-arch caveat:** The image is built per-host; both must produce a CUDA-12.x-compatible image without embedding sm-specific binaries (no `llama-server` build inside the image — the proxy is pure Python + LiteLLM).
-- **D-2 (network mode + host-side bind):** Recommended: `Network=bridge` (rootless default — `pasta` on Podman 4.9.3+) with `PublishPort=18091:18091`. Constraints: `LLMCLI_PROXY_HOST=0.0.0.0` must be set inside the container (binding `127.0.0.1` inside silently breaks PublishPort forwarding). Host-side bind decision: leave as `18091:18091` (all interfaces) so Tailnet-routed access from M₁→M₂ keeps working; do not restrict to `127.0.0.1:18091:18091` until Step 7 finalizes alias topology. `roxabi.network` membership decision: defer — current consumers are all on localhost or Tailnet; joining `roxabi.network` is only required if a future Quadlet on the same host needs container-to-container DNS (`http://llmcli:18091`). When that lands, add `Network=roxabi.network` line to this unit at that time.
-- **D-3 (UserNS form):** `UserNS=keep-id:uid=1000,gid=1000` (anchored form — explicit UID match host's `mickael`). Matches lyra-hub's `keep-id:uid=1500,gid=1500` pattern (just a different UID).
-- **D-4 (env file scope):** `~/.config/containers/systemd/llmcli.env` carries `LLMCLI_API_KEY` only. `LLMCLI_PROXY_PORT` and `LLMCLI_PROXY_HOST` stay as `Environment=` defaults in the unit. Rationale: env file is for secrets; tuning lives in the unit so changes are git-tracked.
-- **D-5 (hardening — resolved here, not deferred):** `NoNewPrivileges=true` and `DropCapability=all` are required in the unit file. `llmcli proxy` is a Python HTTP process needing no Linux capabilities. This sets the floor for future Roxabi Quadlets that copy this pattern. ReadOnly root filesystem is **not** required (Python + LiteLLM write to `/tmp` and `/home/mickael/.local/state/llmcli/`; locking the root FS down requires tmpfs overlay tuning that adds complexity for no proportional security gain in this trust boundary).
-- **D-6 (healthcheck — resolved here, not deferred):** `HealthCmd=curl -sf http://localhost:18091/health/liveliness`, `HealthInterval=30s`, `HealthStartPeriod=30s`. No `HealthOnFailure=` (avoid auto-kill loops; let `Restart=on-failure` handle process death; `podman healthcheck run llmcli` remains a manual debug primitive).
-- **D-7 (M₁/M₂ restart-on-crash delta — resolved here, not deferred):** Frame originally specified "no auto-restart on M₂". Spec relaxes this — `Restart=on-failure` applies on both hosts because (a) the single-unit-file goal demands it, and (b) auto-restart on M₂ is a feature not a bug for the dev experience (a manual crash during testing won't leave the shell holding a dead `make llm`). This delta is intentional; the frame's success/failure criteria do not depend on M₂ being restart-less. Documented in the deployment guide.
+- **D-1 (image source — RESOLVED):** Use the existing fleet image `ghcr.io/roxabi/llmcli:staging` built by `.github/workflows/publish.yml` from `Dockerfile.llm`. The PR adds `--extra proxy` so the image includes `litellm`. No `Containerfile` in `deploy/quadlet/`; no `make build-quadlet-image` target — the existing build pipeline is the source of truth.
+- **D-2 (network — RESOLVED):** Omit `Network=` line (rootless default = bridge via `pasta`). `PublishPort=18091:18091` exposes the port on all host interfaces (so Tailnet-routed access from cross-machine consumers works). `LLMCLI_PROXY_HOST=0.0.0.0` inside the container is required and set via `Environment=` in the unit. `roxabi.network` membership is **deferred** — none of the current/Step-6/7/8 consumers run as Podman containers on the same host; if a future Quadlet on the same host needs container-to-container DNS to llmcli, add `Network=roxabi.network` then.
+- **D-3 (UserNS — RESOLVED):** `keep-id:uid=1502,gid=1502` to match the image's internal `llmcli` user (UID 1502, set in `Dockerfile.llm`). Catalog bind-mount works because host-side perms are 644/755 (cross-UID read OK).
+- **D-4 (env file scope — RESOLVED):** `LLMCLI_API_KEY` + all provider keys (`FIREWORKS_API_KEY`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `NVIDIA_API_KEY`, …) in `~/.config/containers/systemd/llmcli.env` (chmod 600). One file, all secrets. `LLMCLI_PROXY_PORT` / `LLMCLI_PROXY_HOST` stay as `Environment=` defaults in the unit.
+- **D-5 (hardening — RESOLVED):** `NoNewPrivileges=true` + `DropCapability=all`. ReadOnly root FS not adopted (proxy writes `proxy.config.yaml` to `/home/llmcli/.local/state/llmcli/`).
+- **D-6 (healthcheck — RESOLVED):** `HealthCmd=pgrep -f litellm` + `HealthInterval=30s` + `HealthStartPeriod=15s`. Reason: `curl` is not in the image (verified). `pgrep` on the `litellm` subprocess name confirms the HTTP server process is alive — stronger than `pgrep -f "llmcli proxy"` (which would pass even if the wrapper hadn't successfully spawned litellm). **Accepted limitation:** `pgrep` passes if the process is alive even when the HTTP listener is hung or returning 5xx for all requests. SC-9 (`curl :18091/health/liveliness` from outside) catches this at smoke time, but the Quadlet's runtime health probe does not. Adding `curl` to the image (so a true HTTP healthcheck becomes possible) is a deliberate follow-up — not blocking this PR.
+- **D-7 (M₁/M₂ Restart delta — RESOLVED):** Single unit with `Restart=on-failure` applies to both hosts. The frame's "no auto-restart on M₂" is relaxed — auto-restart on M₂ is dev-friendly (no orphan crash leaving a dead shell). Documented.
+- **D-8 (entrypoint dispatch — RESOLVED):** Rename `deploy/entrypoint-nats.sh` → `deploy/entrypoint.sh`; extend with `proxy` MODE branch (preserve `llm` branch verbatim). Worker Quadlet's `Exec=llm --model qwen3-8b` continues to work without modification because the new script's `llm` case is the same as the old script's only case. The new proxy Quadlet uses `Exec=proxy`.
 
 ## Edge cases
 
 | Edge case | Handling |
 |---|---|
-| First-time `daemon-reload` after dropping `.container` doesn't auto-start the unit | by design — `daemon-reload` only generates the unit file + symlink; first `start` is manual. Documented in deployment guide. |
-| `~/.cache/huggingface/` permission mismatch | `UserNS=keep-id:uid=1000,gid=1000` resolves this since host user owns the cache. If a specific host shows ownership-related EPERM, switch the bind to `:Z` (no-op on non-SELinux); flagged in troubleshooting. |
-| `~/.local/state/llmcli/` doesn't exist yet | `ExecStartPre=/bin/mkdir -p %h/.local/state/llmcli` in `[Service]` creates it unconditionally on every start. |
-| Operator forgets `daemon-reload` after manual edit | `make install-quadlet` always ends with `systemctl --user daemon-reload`, so the only path that misses it is a manual `cp` (documented to avoid). |
-| Operator runs `systemctl --user enable llmcli` | "Created symlink … → /dev/null" appears — Quadlet generator masks the user-facing unit name to prevent double-management; ignore it. Documented in troubleshooting. |
-| Concurrent edit of `llmcli.env` while unit is active | env file is re-read on next `restart`; not hot-reloaded. Operators run `systemctl --user restart llmcli` after edits. |
-| Container image stale after llmcli code change | `make build-quadlet-image && systemctl --user restart llmcli` — documented. The `Image=` line in the unit pins `localhost/llmcli:dev`; rebuild updates the same tag in place. |
-| `failed` state after exhausted `StartLimitBurst` | `systemctl --user reset-failed llmcli && systemctl --user start llmcli` — documented in troubleshooting (and in the deployment-guide failure-mode table). No automated notification in this issue (deferred to a separate monitoring story; the frame's "1 incident/month" budget is observable via `systemctl --user is-failed llmcli` from any cron / lyra watchdog later). |
-| Bridge mode + `LLMCLI_PROXY_HOST` accidentally set to `127.0.0.1` inside container | container starts, `:18091` answers nothing — `Environment=LLMCLI_PROXY_HOST=0.0.0.0` default in the unit prevents this unless explicitly overridden in the env file. Documented in troubleshooting. |
+| First-time `daemon-reload` doesn't auto-start the unit | by design — `daemon-reload` only generates + symlinks; first `start` is manual. Documented. |
+| Catalog mount permission mismatch on a specific host | host catalog files must be world-readable (644/755). If `chmod` is tighter, `podman exec llmcli cat /home/llmcli/.roxabi/llmcli/llmcli.toml` reproduces the issue. Documented as `chmod a+r` fix. |
+| Proxy writes to `/home/llmcli/.local/state/` inside container | this is the container's UID-1502 home — always writable. No mount needed; file is regenerated each start. |
+| `LLMCLI_API_KEY` empty + restart loop | exits exhaust `StartLimitBurst=5`/`60s` → unit `failed` → `systemctl --user reset-failed llmcli` after fix. Documented. |
+| Operator runs `systemctl --user enable llmcli` | "Created symlink → /dev/null" message — ignore. Documented. |
+| Image stale (e.g., new llmcli code merged) | `podman pull ghcr.io/roxabi/llmcli:staging && systemctl --user restart llmcli`. `autoupdate=registry` label also drives `podman auto-update.timer` cycles when enabled at the system level. Documented. |
+| Worker Quadlet broken by entrypoint rename | impossible — the script is COPY'd into the image at `/entrypoint.sh` (target path unchanged); the source filename in the repo (`deploy/entrypoint.sh` vs `deploy/entrypoint-nats.sh`) only matters at build time. Worker Quadlet continues to work after image rebuild. |
+| Bridge default + `LLMCLI_PROXY_HOST` accidentally set to `127.0.0.1` in env file | container starts, `:18091` answers nothing externally. `Environment=LLMCLI_PROXY_HOST=0.0.0.0` default in unit prevents this unless explicitly overridden in env file. Documented. |

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -8,6 +8,9 @@ case "$MODE" in
     llm)
         exec llmcli nats-serve llm "$@"
         ;;
+    proxy)
+        exec llmcli proxy "$@"
+        ;;
     *)
         echo "Unknown mode: $MODE" >&2
         exit 1

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -30,6 +30,7 @@ Environment=LLMCLI_LITELLM_URL=http://localhost:4000/v1
 Exec=llm --model qwen3-8b
 HealthCmd=pgrep -f "llmcli nats-serve"
 HealthInterval=30s
+HealthStartPeriod=30s
 NoNewPrivileges=true
 DropCapability=all
 

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -1,0 +1,31 @@
+[Unit]
+Description=llmCLI LiteLLM proxy (:18091)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
+ContainerName=llmcli
+PublishPort=18091:18091
+Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
+EnvironmentFile=%h/.config/containers/systemd/llmcli.env
+Environment=LLMCLI_PROXY_PORT=18091
+Environment=LLMCLI_PROXY_HOST=0.0.0.0
+UserNS=keep-id:uid=1502,gid=1502
+Exec=proxy
+HealthCmd=pgrep -f litellm
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+
+[Service]
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=20s
+# RestartForceExitStatus: skip restart on provider-key (1) and litellm-missing (127) errors
+RestartForceExitStatus=1 127
+
+[Install]
+WantedBy=default.target

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -631,3 +631,134 @@ child:
 
 This ensures that `systemd`, `supervisord`, and interactive Ctrl-C all receive a clean
 shutdown while preventing the process from hanging indefinitely on an unresponsive child.
+
+---
+
+## Running `llmcli proxy` as a Quadlet
+
+### When to use this
+
+Use this path for production deployments on M₁ (roxabituwer) and for development on M₂
+(roxabitower) when you want `llmcli proxy` to start automatically and survive reboots.
+User-systemd owns the lifecycle: `systemctl --user start/restart/stop/status llmcli`.
+If you only need a quick one-off run or are troubleshooting the proxy interactively, use the
+foreground invocation described in the
+[Running `llmcli proxy` (managed LiteLLM portal)](#running-llmcli-proxy-managed-litellm-portal)
+section above.
+
+### Pre-merge local-build flow
+
+On the dev host (roxabitower), the published image at `ghcr.io/roxabi/llmcli:staging` does
+not yet contain `litellm` until this PR merges and CI rebuilds. Build locally with the same
+tag so the Quadlet picks it up without any unit-file change:
+
+```bash
+# On the dev host (roxabitower) before the PR merges:
+podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .
+make install-quadlet
+$EDITOR ~/.config/containers/systemd/llmcli.env   # fill in keys
+systemctl --user start llmcli
+```
+
+The local build overrides the registry image with the same tag, so the Quadlet picks it up
+without any change to the unit file.
+
+### Post-merge registry pull
+
+After the PR merges to staging, CI's `.github/workflows/publish.yml` rebuilds and pushes the
+updated image to `ghcr.io/roxabi/llmcli:staging`. The `Label=io.containers.autoupdate=registry`
+directive in the Quadlet hooks into the system-wide `podman auto-update.timer` — enable it
+if you want fully automatic image refresh (optional). Manual refresh:
+
+```bash
+podman pull ghcr.io/roxabi/llmcli:staging && systemctl --user restart llmcli
+```
+
+### Env file template
+
+The env file lives at `~/.config/containers/systemd/llmcli.env` (chmod 600). `make install-quadlet`
+creates this stub idempotently — it **never** overwrites an existing file:
+
+```bash
+# ~/.config/containers/systemd/llmcli.env — chmod 600
+LLMCLI_API_KEY=
+FIREWORKS_API_KEY=
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+NVIDIA_API_KEY=
+```
+
+To rotate a key, edit the file and `systemctl --user restart llmcli`.
+
+### systemctl --user lifecycle
+
+```bash
+systemctl --user start    llmcli           # start (idempotent)
+systemctl --user restart  llmcli           # restart after env or catalog change
+systemctl --user stop     llmcli           # graceful drain (TimeoutStopSec=20s)
+systemctl --user status   llmcli           # current state + last log lines
+systemctl --user is-active llmcli          # binary check, exit 0 if active
+journalctl --user -u llmcli -f             # live tail
+journalctl --user -u llmcli --since today  # today's log
+```
+
+### Failure modes
+
+| Failure | Symptom | Recovery |
+|---|---|---|
+| `~/.config/containers/systemd/llmcli.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` recreates stub |
+| `LLMCLI_API_KEY` or provider key empty | `llmcli proxy` exits 1; `RestartForceExitStatus=1` suppresses restart — unit enters `failed` immediately with no retry burn-up | populate env file, `systemctl --user reset-failed llmcli && systemctl --user start llmcli` |
+| `litellm` missing in image | `llmcli proxy` exits 127 ("litellm binary not found"); `RestartForceExitStatus=127` suppresses restart — unit `failed` immediately | rebuild image locally with this PR's `Dockerfile.llm` OR wait for CI rebuild |
+| Image not present + no network on M₁ | `podman` run fails (no pull source) | `podman pull ghcr.io/roxabi/llmcli:staging` on host first, OR local `podman build` from this repo |
+| Port 18091 already bound | container fails to publish port; unit `failed` | identify conflict, free port, restart |
+| User-linger off on M₁ | service stops after logout | `loginctl enable-linger mickael` |
+| Operator runs `systemctl --user enable llmcli.service` | "Created symlink … → /dev/null" — Quadlet generator masks the unit name | ignore; nothing is broken |
+| Container binds 127.0.0.1 inside (PROXY_HOST override accident) | `:18091` answers nothing externally | `Environment=LLMCLI_PROXY_HOST=0.0.0.0` default in unit prevents this unless explicitly overridden in env file |
+
+### `reset-failed` after StartLimitBurst exhaustion
+
+If the proxy crashes 5 times within 60s, systemd parks the unit in `failed` and stops
+retrying. After fixing the root cause (check `journalctl --user -u llmcli` for details):
+
+```bash
+systemctl --user reset-failed llmcli
+systemctl --user start llmcli
+```
+
+The proxy's two non-retryable exit codes — `1` (provider key missing) and `127` (litellm
+binary missing in image) — are declared in `RestartForceExitStatus=1 127`, so they enter
+`failed` immediately without burning the restart budget.
+
+### Inspecting config from inside the container
+
+The container name is fixed at `llmcli` (set by `ContainerName=llmcli` in the unit). While
+the container is running, dump the rendered LiteLLM config with:
+
+```bash
+# Dump the rendered LiteLLM config (proxy is a one-shot here)
+podman exec llmcli llmcli proxy --config-out /dev/stdout
+```
+
+Note that `curl` is intentionally absent from the image; for external HTTP probing use
+`curl -s http://localhost:18091/health/liveliness` from the host.
+
+### M₁ (prod) one-time linger setup
+
+Linger allows the user-systemd instance to start at boot even when no interactive session is
+open. On M₁ (roxabituwer) this is already configured because lyra requires it:
+
+```bash
+# Once per machine (prod). Already set on roxabituwer (lyra requires it).
+loginctl enable-linger mickael
+loginctl show-user mickael | grep Linger=yes
+```
+
+Without linger, the unit only runs while a user session is open. M₂ (roxabitower) typically
+has linger off, so the operator runs `systemctl --user start llmcli` after login.
+
+### Drop-ins
+
+The Quadlet generator emits an immutable `llmcli.service` at runtime — any direct edits to
+that file are overwritten on the next `daemon-reload`. Persistent overrides go in
+`~/.config/systemd/user/llmcli.service.d/*.conf`; drop-in files are merged on `daemon-reload`
+and survive Quadlet regeneration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ nats = [
     "roxabi-nats",
     "roxabi-contracts",
 ]
+proxy = [
+    "litellm>=1.0",
+]
 
 [tool.uv.sources]
 roxabi-nats      = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats",      branch = "staging" }

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,25 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -962,6 +981,29 @@ wheels = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.85.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/d5/3c9b560db2ffa9e498655d0dfd74f408bc5b32ede858b5731c2a5fa4c752/litellm-1.85.0.tar.gz", hash = "sha256:babdd569809af913d08a08a7eb55df1ed3e6a3960ee365c6cef4ad031c9bc72a", size = 15344387, upload-time = "2026-05-17T01:59:15.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/38/e6a4abb062e039d18d59538cc4e6fc370c2c10cd2bff4a2e546acb69dcb9/litellm-1.85.0-py3-none-any.whl", hash = "sha256:2bb449153610691faffd76f5b94a8c29e4b66fc5394156ebf54fd4fe92759b1a", size = 16978229, upload-time = "2026-05-17T01:59:11.902Z" },
+]
+
+[[package]]
 name = "llguidance"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -996,6 +1038,9 @@ nats = [
     { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
 ]
+proxy = [
+    { name = "litellm" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1015,6 +1060,7 @@ vllm = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=1.0" },
+    { name = "litellm", marker = "extra == 'proxy'", specifier = ">=1.0" },
     { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.6,<3" },
     { name = "nkeys", marker = "extra == 'nats'", specifier = ">=0.1" },
     { name = "nvidia-ml-py", specifier = ">=12.0" },
@@ -1027,7 +1073,7 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.12" },
 ]
-provides-extras = ["nats"]
+provides-extras = ["nats", "proxy"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Packages `llmcli proxy` as a Podman Quadlet (`deploy/quadlet/llmcli.container`) on `:18091`, supervised by user-systemd via the existing fleet image `ghcr.io/roxabi/llmcli:staging`. Identical config across both M₁ (prod, autostart via linger) and M₂ (dev, manual `systemctl --user start`); only the env file differs per host.
- Adds `[proxy]` optional-dependency to `pyproject.toml` (refreshes `uv.lock`) so the fleet image contains `litellm`. Renames `deploy/entrypoint-nats.sh` → `deploy/entrypoint.sh` with a new `proxy` MODE dispatch branch — the existing `llm` MODE is preserved verbatim, so the NATS worker Quadlet keeps working without any change.
- Adds `make install-quadlet` (idempotent — never overwrites the env file) + a 130-line deployment runbook section + README mention. Closes Step 4 of the central-portal plan.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#44](https://github.com/Roxabi/llmCLI/issues/44) | OPEN |
| Frame | [`artifacts/frames/44-llmcli-quadlet-frame.mdx`](artifacts/frames/44-llmcli-quadlet-frame.mdx) | approved |
| Spec | [`artifacts/specs/44-llmcli-quadlet-spec.mdx`](artifacts/specs/44-llmcli-quadlet-spec.mdx) | approved |
| Plan | [`artifacts/plans/44-llmcli-quadlet-plan.mdx`](artifacts/plans/44-llmcli-quadlet-plan.mdx) | 7/9 tasks complete; T8/T9 = post-implement ops smokes |
| Implementation | 7 commits on `feat/44-llmcli-quadlet` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (350 passed, all extras synced; 0 new Python tests — Quadlet/Docker config, smokes are bash in T8/T9) | Passed |

## Test Plan

**Pre-merge (M₂ = `roxabitower`):**
- [ ] **SC-7:** `podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .` succeeds → `podman run --rm --entrypoint=\"\" ghcr.io/roxabi/llmcli:staging /app/.venv/bin/litellm --version` non-empty
- [ ] **SC-8:** `make install-quadlet` → populate `~/.config/containers/systemd/llmcli.env` → `systemctl --user start llmcli` → `is-active llmcli` returns `active` within 30s
- [ ] **SC-9:** `curl -s -o /dev/null -w \"%{http_code}\" http://localhost:18091/health/liveliness` returns `200`
- [ ] **SC-10:** Authenticated `/v1/models` returns 200 with non-empty `data`; same without `Authorization` returns `401`
- [ ] **SC-11:** `podman exec llmcli test -r /home/llmcli/.roxabi/llmcli/llmcli.toml` exits 0

**Post-merge (M₁ = `roxabituwer`):**
- [ ] **SC-14:** image present + `Linger=yes` + `is-active`
- [ ] **SC-15 (path b):** `sudo systemctl stop user@…service` → sleep 5 → `start` → `is-active` within 30s (validates `WantedBy=default.target` + linger autostart path)
- [ ] **SC-16:** `podman kill llmcli` → restart count incremented within ~10s

## Out of Scope (deliberate Step-4 boundaries)
- Step 5b — `deepseek-v4-pro` catalog migration
- Step 6 — `:4000` lyra-supervisor retirement
- Step 7 — `cccc/cccfk/ccd` retarget to `:18091`
- Step 8 — Hermes (2 Telegram bots) resume

Closes #44

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`