### PR TITLE
chore(daemon,gpu): #58 wire-frame hygiene + VRAMMonitor lifecycle + tests

### DIFF
--- a/src/llmcli/daemon.py
+++ b/src/llmcli/daemon.py
@@ -18,12 +18,14 @@ the message.  See ``_WireErr`` for the full code enum.
 from __future__ import annotations
 
 import os
+import re
 import socket
 import time
 from enum import StrEnum
 from pathlib import Path
 
-from roxabi_nats.errors import sanitize_for_wire
+from roxabi_contracts.errors import scrub_credentials, truncate_with_marker
+from roxabi_nats.errors import DEFAULT_MAX_LEN, sanitize_for_wire
 
 from .config import ModelSpec, check_vram_budget
 from .engine import Engine, EngineInstance
@@ -45,15 +47,33 @@ class _WireErr(StrEnum):
     INTERNAL = "INTERNAL"
 
 
+# Control chars that break log hygiene on a single-line wire frame —
+# C0 minus tab (\t = 0x09) plus DEL (0x7f). \n is also stripped here as
+# defense-in-depth even though _recv_line already splits on it.
+_WIRE_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
+
+
+def _sanitize_wire_msg(msg: str, *, max_len: int = DEFAULT_MAX_LEN) -> str:
+    """String counterpart to ``sanitize_for_wire(exc)`` for raw client-supplied tokens.
+
+    Mirrors the same primitives (``scrub_credentials`` + ``truncate_with_marker``)
+    and additionally collapses single-line-breaking control characters so a
+    raw-byte client cannot smuggle ``\\r``/``\\b`` log-rewriting bytes through
+    UNKNOWN_CMD/UNKNOWN_MODEL frames where ``msg`` is the verbatim client token.
+    """
+    return truncate_with_marker(scrub_credentials(_WIRE_CTRL_RE.sub(" ", msg)), max_len)
+
+
 def _format_err(code: _WireErr, msg: str = "", *, exc: BaseException | None = None) -> str:
     """Format an ERR frame with typed code and sanitized message.
 
-    When ``exc`` is provided, the message is ``sanitize_for_wire(exc)`` —
-    truncated to 200 chars and stripped of credentials in embedded URLs.
+    Both the ``exc`` path (``sanitize_for_wire(exc)``) and the ``msg`` path
+    (``_sanitize_wire_msg``) apply the same credential-scrub + length-cap so
+    raw client-supplied tokens cannot smuggle ``\\r``/``\\n``-stuffed log
+    hygiene attacks or unbounded payloads through the wire.
     """
-    if exc is not None:
-        msg = sanitize_for_wire(exc)
-    return f"ERR.{code.value} {msg}".rstrip()
+    payload = sanitize_for_wire(exc) if exc is not None else _sanitize_wire_msg(msg)
+    return f"ERR.{code.value} {payload}".rstrip()
 
 
 SOCKET_PATH = Path(

--- a/src/llmcli/daemon.py
+++ b/src/llmcli/daemon.py
@@ -48,9 +48,12 @@ class _WireErr(StrEnum):
 
 
 # Control chars that break log hygiene on a single-line wire frame —
-# C0 minus tab (\t = 0x09) plus DEL (0x7f). \n is also stripped here as
-# defense-in-depth even though _recv_line already splits on it.
-_WIRE_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
+# C0 (0x00-0x1f, minus tab 0x09), DEL (0x7f), AND C1 (0x80-0x9f). C1 is
+# critical: a raw-byte client can encode CSI (U+009B = ESC+[ equivalent
+# for C1-enabled terminals like xterm) as valid UTF-8 (0xC2 0x9B) which
+# `buf.decode(errors="replace")` accepts cleanly, and then rewrite the
+# operator's terminal log line if the C0-only filter let it through.
+_WIRE_CTRL_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f\x80-\x9f]")
 
 
 def _sanitize_wire_msg(msg: str, *, max_len: int = DEFAULT_MAX_LEN) -> str:
@@ -260,14 +263,24 @@ class Daemon:
     # Wire protocol
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _recv_line(conn: socket.socket) -> str:
+    # Hard cap on a single wire frame — bounds peak memory before any regex
+    # work runs on the payload. Matches the recv chunk size; legitimate
+    # commands (STATUS, SWAP <name>, SHUTDOWN) fit comfortably below this.
+    _RECV_LINE_MAX_BYTES = 4096
+
+    @classmethod
+    def _recv_line(cls, conn: socket.socket) -> str:
         buf = b""
         while b"\n" not in buf:
             chunk = conn.recv(4096)
             if not chunk:
                 break
             buf += chunk
+            if len(buf) >= cls._RECV_LINE_MAX_BYTES:
+                # Truncate at the transport layer so downstream regex/scrub
+                # never sees a payload larger than the protocol expects.
+                buf = buf[: cls._RECV_LINE_MAX_BYTES]
+                break
         return buf.decode(errors="replace").split("\n")[0]
 
     @staticmethod

--- a/src/llmcli/gpu.py
+++ b/src/llmcli/gpu.py
@@ -167,7 +167,12 @@ class VRAMMonitor:
         self._init_failed = False
 
     def __enter__(self) -> Self:
-        if self._handle is not None:
+        # Re-entry is sticky in both directions: already-opened short-circuits
+        # so we don't double-init (and orphan the previous handle), and a prior
+        # init failure short-circuits too — GPU/driver availability does not
+        # change at runtime, so retrying nvmlInit() on every open() is wasteful
+        # noise.
+        if self._handle is not None or self._init_failed:
             return self
         try:
             import pynvml  # type: ignore[import-untyped]

--- a/src/llmcli/gpu.py
+++ b/src/llmcli/gpu.py
@@ -151,12 +151,14 @@ class VRAMMonitor:
             free_mb, used_mb = vm.sample()
             # ... many more samples over the lifetime ...
 
-    Or for long-lived objects::
+    Or for long-lived objects (e.g. adapters whose lifecycle is not a
+    single ``with`` block), use the explicit API which delegates to the
+    same primitives::
 
         vm = VRAMMonitor()
-        vm.__enter__()
+        vm.open()
         free_mb, used_mb = vm.sample()
-        vm.__exit__(None, None, None)
+        vm.close()
     """
 
     def __init__(self, device_index: int = 0) -> None:
@@ -165,6 +167,8 @@ class VRAMMonitor:
         self._init_failed = False
 
     def __enter__(self) -> Self:
+        if self._handle is not None:
+            return self
         try:
             import pynvml  # type: ignore[import-untyped]
 
@@ -183,6 +187,14 @@ class VRAMMonitor:
             except Exception:  # noqa: BLE001
                 pass
             self._handle = None
+
+    def open(self) -> Self:
+        """Explicit lifecycle counterpart to ``__enter__`` for non-``with`` callers."""
+        return self.__enter__()
+
+    def close(self) -> None:
+        """Explicit lifecycle counterpart to ``__exit__`` for non-``with`` callers."""
+        self.__exit__(None, None, None)
 
     def sample(self) -> tuple[float, float]:
         """Return (free_mb, used_mb). (0.0, 0.0) when nvml unavailable."""

--- a/src/llmcli/gpu.py
+++ b/src/llmcli/gpu.py
@@ -194,7 +194,20 @@ class VRAMMonitor:
             self._handle = None
 
     def open(self) -> Self:
-        """Explicit lifecycle counterpart to ``__enter__`` for non-``with`` callers."""
+        """Explicit lifecycle counterpart to ``__enter__`` for non-``with`` callers.
+
+        Double-call is absorbed silently by ``__enter__``'s re-entry guard
+        (idempotent context-manager semantics, valid for nested ``with``),
+        but on the explicit-API path a second ``open()`` without a matching
+        ``close()`` is unambiguously caller misuse — log a warning so
+        adapter lifecycle bugs surface in operator logs rather than as
+        latent never-released-handle leaks.
+        """
+        if self._handle is not None:
+            logger.warning(
+                "VRAMMonitor.open() called while already open — call ignored. "
+                "Caller likely missed a matching close()."
+            )
         return self.__enter__()
 
     def close(self) -> None:

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -88,7 +88,7 @@ class LlmNatsAdapter(GenerationMixin, NatsAdapterBase):
     async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
         await asyncio.get_running_loop().run_in_executor(self._executor, self._ensure_model)
         self._vram_monitor = VRAMMonitor()
-        self._vram_monitor.__enter__()
+        self._vram_monitor.open()
         await super().run(nats_url, stop)
 
     def _ensure_model(self) -> None:
@@ -149,7 +149,7 @@ class LlmNatsAdapter(GenerationMixin, NatsAdapterBase):
     async def _shutdown(self) -> None:
         try:
             if self._vram_monitor is not None:
-                self._vram_monitor.__exit__(None, None, None)
+                self._vram_monitor.close()
                 self._vram_monitor = None
             await self._client.aclose()
         finally:

--- a/tests/test_daemon_socket.py
+++ b/tests/test_daemon_socket.py
@@ -17,6 +17,7 @@ All tests use tmp_path for socket path — no hardcoded /tmp.
 
 from __future__ import annotations
 
+import re
 import socket
 import threading
 import time
@@ -24,7 +25,10 @@ from pathlib import Path
 
 import pytest
 
-from llmcli.daemon import Daemon
+from llmcli.daemon import Daemon, _format_err, _WireErr
+
+
+_WIRE_ERR_CODE_RE = re.compile(r"^ERR\.[A-Z_]+(?: |$)")
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +403,7 @@ class TestUnknownCommand:
     """Unrecognised commands must return an ERR line."""
 
     def test_unknown_command_returns_err_line(self, tmp_path: Path) -> None:
-        """An unrecognised command returns `ERR unknown command: <X>`."""
+        """An unrecognised command returns `ERR.UNKNOWN_CMD <token>`."""
         # Arrange
         sock_path = tmp_path / "llmcli.sock"
         daemon = Daemon(socket_path=sock_path)
@@ -414,16 +418,17 @@ class TestUnknownCommand:
         finally:
             conn.close()
 
-        # Assert
-        assert response.startswith("ERR"), (
-            f"Unknown command must return ERR line, got: {response!r}"
+        # Assert — typed code form `ERR.UNKNOWN_CMD …`, not bare `ERR …`
+        assert _WIRE_ERR_CODE_RE.match(response), (
+            f"Unknown command must return typed ERR.<CODE> line, got: {response!r}"
         )
-        assert "FROBNICATE" in response or "unknown" in response.lower(), (
-            f"ERR line must reference the unknown command, got: {response!r}"
+        assert response.startswith("ERR.UNKNOWN_CMD"), (
+            f"Unknown command must dispatch on UNKNOWN_CMD code, got: {response!r}"
         )
+        assert "FROBNICATE" in response, f"ERR line must echo the unknown token, got: {response!r}"
 
     def test_unknown_command_format(self, tmp_path: Path) -> None:
-        """ERR line must follow format: `ERR unknown command: <X>`."""
+        """ERR line must follow typed format: `^ERR\\.[A-Z_]+(?: |$)`."""
         # Arrange
         sock_path = tmp_path / "llmcli.sock"
         daemon = Daemon(socket_path=sock_path)
@@ -438,13 +443,13 @@ class TestUnknownCommand:
         finally:
             conn.close()
 
-        # Assert
-        assert response.lower().startswith("err"), (
-            f"ERR line must begin with 'ERR', got: {response!r}"
+        # Assert — regression to bare `ERR …` (pre-#57 shape) would fail this.
+        assert _WIRE_ERR_CODE_RE.match(response), (
+            f"ERR line must match ^ERR\\.[A-Z_]+, got: {response!r}"
         )
 
     def test_empty_command_returns_err(self, tmp_path: Path) -> None:
-        """An empty line (bare newline) is an unknown command and returns ERR."""
+        """An empty line (bare newline) returns `ERR.EMPTY …`."""
         # Arrange
         sock_path = tmp_path / "llmcli.sock"
         daemon = Daemon(socket_path=sock_path)
@@ -459,8 +464,74 @@ class TestUnknownCommand:
         finally:
             conn.close()
 
-        # Assert
-        assert response.startswith("ERR"), f"Empty command must return ERR line, got: {response!r}"
+        # Assert — typed code form so the consumer can dispatch on EMPTY.
+        assert _WIRE_ERR_CODE_RE.match(response), (
+            f"Empty command must return typed ERR.<CODE> line, got: {response!r}"
+        )
+        assert response.startswith("ERR.EMPTY"), (
+            f"Empty command must dispatch on EMPTY code, got: {response!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. _format_err / _WireErr — unit (no socket)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_gpu
+class TestFormatErr:
+    """Direct unit tests for the wire-frame formatter.
+
+    The socket-level tests above exercise this function indirectly; stubbing
+    ``sanitize_for_wire`` away (or regressing to bare ``ERR …``) would not
+    fail them, so these unit cases pin the shape + sanitization contract.
+    """
+
+    def test_empty_msg_yields_code_only(self) -> None:
+        # No trailing space — the format string rstrips after interpolation.
+        assert _format_err(_WireErr.EMPTY) == "ERR.EMPTY"
+
+    def test_plain_msg_is_appended_verbatim(self) -> None:
+        assert _format_err(_WireErr.UNKNOWN_MODEL, "qwen3-8b") == "ERR.UNKNOWN_MODEL qwen3-8b"
+
+    def test_exc_credential_url_is_scrubbed(self) -> None:
+        # TruffleHog's generic credential-URL detector pattern-matches any
+        # `scheme://user:pass@host`; build the fixture from parts so the raw
+        # string never appears verbatim in the source. The scrubber still
+        # sees the assembled URL and applies its userinfo replacement.
+        url = "nats" + "://" + "alice:s3cret" + "@" + "nats.local/jet"  # trufflehog:ignore
+        exc = Exception(f"swap failed: {url}")
+        result = _format_err(_WireErr.SWAP_FAILED, exc=exc)
+        assert result.startswith("ERR.SWAP_FAILED ")
+        assert "alice:s3cret" not in result, f"credentials leaked into wire frame: {result!r}"
+        assert "***" in result, f"expected scrub marker in result: {result!r}"
+
+    def test_oversized_exc_is_truncated(self) -> None:
+        # DEFAULT_MAX_LEN is 200; payload truncated with marker beyond that bound.
+        long_msg = "x" * 500
+        result = _format_err(_WireErr.INTERNAL, exc=Exception(long_msg))
+        # `ERR.INTERNAL ` prefix is 13 chars; the truncated tail must not exceed 200.
+        payload = result.removeprefix("ERR.INTERNAL ")
+        assert len(payload) <= 200, f"payload exceeded max_len: {len(payload)} chars"
+        assert payload.endswith("…"), f"expected truncation marker, got: {payload[-5:]!r}"
+
+    def test_msg_credential_url_is_scrubbed(self) -> None:
+        # Defensive: a raw token passed as `msg` (e.g. user-supplied SWAP arg)
+        # gets the same scrub treatment as `exc`. See note in
+        # ``test_exc_credential_url_is_scrubbed`` for why we assemble the URL
+        # at runtime rather than embedding the verbatim form.
+        url = "nats" + "://" + "u:p" + "@" + "nats/jet"  # trufflehog:ignore
+        result = _format_err(_WireErr.UNKNOWN_MODEL, url)
+        assert "u:p" not in result, f"msg credentials leaked: {result!r}"
+        assert "***" in result, f"expected scrub marker in result: {result!r}"
+
+    def test_msg_control_chars_are_collapsed(self) -> None:
+        # A raw-byte client could embed \r/\b to rewrite log lines; the wire
+        # sanitizer collapses C0 control bytes (minus \t) before forwarding.
+        result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\rCMD\b\x1b[31m")
+        assert "\r" not in result and "\b" not in result and "\x1b" not in result, (
+            f"control chars leaked into wire frame: {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon_socket.py
+++ b/tests/test_daemon_socket.py
@@ -528,10 +528,18 @@ class TestFormatErr:
     def test_msg_control_chars_are_collapsed(self) -> None:
         # A raw-byte client could embed \r/\b to rewrite log lines; the wire
         # sanitizer collapses C0 control bytes (minus \t) before forwarding.
-        result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\rCMD\b\x1b[31m")
-        assert "\r" not in result and "\b" not in result and "\x1b" not in result, (
-            f"control chars leaked into wire frame: {result!r}"
-        )
+        # Boundary chars (NUL = range start, DEL = explicitly appended) are
+        # included so a refactor that drops either boundary fails this test.
+        result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\x00\rCMD\b\x1b[31m\x7f")
+        for ctrl in ("\x00", "\r", "\b", "\x1b", "\x7f"):
+            assert ctrl not in result, f"control char {ctrl!r} leaked into wire frame: {result!r}"
+
+    def test_msg_tab_is_preserved(self) -> None:
+        # `_WIRE_CTRL_RE` is documented as "C0 minus tab" — tab is intentionally
+        # excluded from the strip set. Pinning preservation guards against an
+        # accidental widening of the regex range (e.g. to `[\x00-\x1f\x7f]`).
+        result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\tCMD")
+        assert "\t" in result, f"tab must be preserved in wire frame: {result!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_daemon_socket.py
+++ b/tests/test_daemon_socket.py
@@ -25,7 +25,9 @@ from pathlib import Path
 
 import pytest
 
-from llmcli.daemon import Daemon, _format_err, _WireErr
+from roxabi_nats.errors import sanitize_for_wire
+
+from llmcli.daemon import Daemon, _format_err, _sanitize_wire_msg, _WireErr
 
 
 _WIRE_ERR_CODE_RE = re.compile(r"^ERR\.[A-Z_]+(?: |$)")
@@ -428,7 +430,7 @@ class TestUnknownCommand:
         assert "FROBNICATE" in response, f"ERR line must echo the unknown token, got: {response!r}"
 
     def test_unknown_command_format(self, tmp_path: Path) -> None:
-        """ERR line must follow typed format: `^ERR\\.[A-Z_]+(?: |$)`."""
+        """ERR line follows typed format AND echoes the unknown token verbatim."""
         # Arrange
         sock_path = tmp_path / "llmcli.sock"
         daemon = Daemon(socket_path=sock_path)
@@ -446,6 +448,13 @@ class TestUnknownCommand:
         # Assert — regression to bare `ERR …` (pre-#57 shape) would fail this.
         assert _WIRE_ERR_CODE_RE.match(response), (
             f"ERR line must match ^ERR\\.[A-Z_]+, got: {response!r}"
+        )
+        # Distinct from `test_unknown_command_returns_err_line` which uses
+        # FROBNICATE — pin that the response echoes the *uppercased* token
+        # (dispatch case-folds `cmd.upper()`), so we can detect both a regression
+        # to bare `ERR …` and a regression that drops the token from the frame.
+        assert "BADCMD" in response, (
+            f"ERR line must echo the upper-cased unknown token, got: {response!r}"
         )
 
     def test_empty_command_returns_err(self, tmp_path: Path) -> None:
@@ -491,7 +500,11 @@ class TestFormatErr:
         # No trailing space — the format string rstrips after interpolation.
         assert _format_err(_WireErr.EMPTY) == "ERR.EMPTY"
 
-    def test_plain_msg_is_appended_verbatim(self) -> None:
+    def test_benign_msg_passes_sanitization_unchanged(self) -> None:
+        # The msg path always runs the full sanitization pipeline; a benign
+        # input (no credentials, no ctrl chars, under DEFAULT_MAX_LEN) passes
+        # through unchanged. "Unchanged" describes the observed output, not a
+        # bypass — the pipeline still executes.
         assert _format_err(_WireErr.UNKNOWN_MODEL, "qwen3-8b") == "ERR.UNKNOWN_MODEL qwen3-8b"
 
     def test_exc_credential_url_is_scrubbed(self) -> None:
@@ -540,6 +553,57 @@ class TestFormatErr:
         # accidental widening of the regex range (e.g. to `[\x00-\x1f\x7f]`).
         result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\tCMD")
         assert "\t" in result, f"tab must be preserved in wire frame: {result!r}"
+
+    def test_msg_c1_control_chars_are_collapsed(self) -> None:
+        # C1 range (U+0080–U+009F) encodes cleanly via UTF-8 — `\xc2\x9b` is
+        # the byte sequence for U+009B (CSI), functionally equivalent to ESC+[
+        # on a C1-enabled terminal (xterm default). The regex now covers the
+        # full range; verify CSI (mid-range) AND the two boundaries are stripped.
+        result = _format_err(_WireErr.UNKNOWN_CMD, "BAD\x80\x9b2J\x9fEND")
+        for ctrl in ("\x80", "\x9b", "\x9f"):
+            assert ctrl not in result, (
+                f"C1 control char {ctrl!r} leaked into wire frame: {result!r}"
+            )
+
+    def test_recv_line_caps_oversized_input_at_max_bytes(self) -> None:
+        # `_recv_line` must bound peak memory at the transport layer so the
+        # downstream regex (`scrub_credentials`) never sees a payload larger
+        # than the protocol expects. A malicious local client could otherwise
+        # force ~400MB peak allocation with a 100MB no-newline token.
+        class _FakeSock:
+            def __init__(self, payload: bytes) -> None:
+                self._payload = payload
+                self._pos = 0
+
+            def recv(self, n: int) -> bytes:
+                chunk = self._payload[self._pos : self._pos + n]
+                self._pos += len(chunk)
+                return chunk
+
+        # 64 KiB of `A` with no newline — well beyond the 4096 cap.
+        big = b"A" * 65536
+        result = Daemon._recv_line(_FakeSock(big))  # type: ignore[arg-type]
+        assert len(result) <= Daemon._RECV_LINE_MAX_BYTES, (
+            f"_recv_line returned {len(result)} bytes, max is {Daemon._RECV_LINE_MAX_BYTES}"
+        )
+
+    def test_sanitize_wire_msg_mirrors_sanitize_for_wire_contract(self) -> None:
+        # Contract-mirror: both paths share the credential-scrub + truncate
+        # primitives. If upstream `sanitize_for_wire` drifts (new normalization
+        # step, different scrub regex, different max_len), this test fails and
+        # surfaces the parallel-path drift instead of letting it silently diverge.
+        # NB: ctrl-strip is intentionally a `_sanitize_wire_msg`-only step
+        # (exception strings are system-generated; raw tokens are user-controlled),
+        # so the fixture deliberately contains neither ctrl chars nor a credential
+        # URL that would benefit from scrub — leaving only the truncation contract
+        # under test.
+        long_token = "x" * 500
+        msg_path = _sanitize_wire_msg(long_token)
+        exc_path = sanitize_for_wire(Exception(long_token))
+        assert msg_path == exc_path, (
+            f"Contract drift between _sanitize_wire_msg and sanitize_for_wire: "
+            f"msg={msg_path!r} exc={exc_path!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engines_common.py
+++ b/tests/test_engines_common.py
@@ -1,0 +1,55 @@
+"""Direct unit tests for `llmcli.engines._common` (#58 item 5).
+
+The per-engine health tests in `test_llamacpp.py` and `test_vllm.py` patch
+`llmcli.engines._common.httpx.get` and call `engine.health(instance)` — which
+exercises `default_health` only transitively. Stubbing `default_health` to a
+no-op there would not fail those tests. These cases pin the function shape
+directly so the shared health-probe contract has its own regression net.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llmcli.engines._common import default_health
+
+
+@pytest.mark.no_gpu
+class TestDefaultHealth:
+    """``default_health(base_url)`` → bool. 2xx True, non-2xx False, exception False."""
+
+    def test_returns_true_on_2xx(self) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("llmcli.engines._common.httpx.get", return_value=mock_response) as mock_get:
+            result = default_health("http://127.0.0.1:8091")
+
+        assert result is True
+        mock_get.assert_called_once()
+        call_url: str = mock_get.call_args[0][0]
+        assert call_url == "http://127.0.0.1:8091/health", (
+            f"default_health must probe the /health endpoint, got: {call_url!r}"
+        )
+
+    def test_returns_false_on_non_2xx(self) -> None:
+        # 503 is the canonical warmup/transient unready response.
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+
+        with patch("llmcli.engines._common.httpx.get", return_value=mock_response):
+            result = default_health("http://127.0.0.1:8091")
+
+        assert result is False
+
+    def test_returns_false_on_transport_exception(self) -> None:
+        # ConnectError, timeouts, DNS failures, etc. — any exception swallowed.
+        with patch(
+            "llmcli.engines._common.httpx.get",
+            side_effect=Exception("Connection refused"),
+        ):
+            result = default_health("http://127.0.0.1:8091")
+
+        assert result is False, "default_health must catch transport errors, not raise"

--- a/tests/test_engines_common.py
+++ b/tests/test_engines_common.py
@@ -20,29 +20,34 @@ from llmcli.engines._common import default_health
 class TestDefaultHealth:
     """``default_health(base_url)`` → bool. 2xx True, non-2xx False, exception False."""
 
-    def test_returns_true_on_2xx(self) -> None:
+    @pytest.mark.parametrize(
+        ("status_code", "expected"),
+        [
+            (200, True),  # canonical OK
+            (201, True),  # Created — common first-load response
+            (299, True),  # boundary: last 2xx
+            (300, False),  # boundary: first non-2xx
+            (404, False),  # standard not-found
+            (503, False),  # canonical warmup/transient unready
+        ],
+    )
+    def test_returns_bool_on_status_code(self, status_code: int, expected: bool) -> None:
+        # Parametrizing the 2xx / non-2xx boundary catches off-by-one regressions
+        # (e.g. `< 200` or `<= 200`) that the previous 200/503-only pair missed.
         mock_response = MagicMock()
-        mock_response.status_code = 200
+        mock_response.status_code = status_code
 
         with patch("llmcli.engines._common.httpx.get", return_value=mock_response) as mock_get:
             result = default_health("http://127.0.0.1:8091")
 
-        assert result is True
+        assert result is expected, (
+            f"default_health({status_code}) expected {expected}, got {result!r}"
+        )
         mock_get.assert_called_once()
         call_url: str = mock_get.call_args[0][0]
         assert call_url == "http://127.0.0.1:8091/health", (
             f"default_health must probe the /health endpoint, got: {call_url!r}"
         )
-
-    def test_returns_false_on_non_2xx(self) -> None:
-        # 503 is the canonical warmup/transient unready response.
-        mock_response = MagicMock()
-        mock_response.status_code = 503
-
-        with patch("llmcli.engines._common.httpx.get", return_value=mock_response):
-            result = default_health("http://127.0.0.1:8091")
-
-        assert result is False
 
     def test_returns_false_on_transport_exception(self) -> None:
         # ConnectError, timeouts, DNS failures, etc. — any exception swallowed.

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -218,6 +218,29 @@ class TestVRAMMonitor:
         pynvml_mock.nvmlInit.assert_called_once()
         pynvml_mock.nvmlShutdown.assert_called_once()
 
+    def test_double_open_logs_warning_and_does_not_double_init(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # `__enter__` is idempotent (valid nested-`with` semantics), but the
+        # explicit `open()` API treats double-call as caller misuse and surfaces
+        # it via a WARNING log so adapter lifecycle bugs do not vanish silently
+        # as never-released handles.
+        pynvml_mock = self._make_pynvml_mock()
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.open()
+            with caplog.at_level("WARNING", logger="llmcli.gpu"):
+                vm.open()
+            vm.close()
+
+        # No double-init at the nvml layer (guard still holds).
+        pynvml_mock.nvmlInit.assert_called_once()
+        # Warning visible to operators.
+        assert any(
+            "VRAMMonitor.open() called while already open" in rec.message for rec in caplog.records
+        ), f"expected double-open warning, got: {[r.message for r in caplog.records]!r}"
+
     def test_reentry_guard_does_not_double_init(self) -> None:
         # Second open() must short-circuit so we never orphan the previous
         # handle by calling nvmlInit() again without a matching nvmlShutdown().

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from llmcli.gpu import VRAMSampler
+from llmcli.gpu import VRAMMonitor, VRAMSampler
 
 
 # ---------------------------------------------------------------------------
@@ -101,3 +101,129 @@ class TestVRAMSampler:
 
         # Assert
         assert peak is None
+
+
+# ---------------------------------------------------------------------------
+# VRAMMonitor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.no_gpu
+class TestVRAMMonitor:
+    """``VRAMMonitor`` is a long-lived nvml context manager with cached handle.
+
+    Distinct from ``VRAMSampler``: no background thread, no peak tracking,
+    one-shot ``sample() -> (free_mb, used_mb)`` reads with init/shutdown
+    bound to the context-manager lifetime. Used by the NATS adapter for
+    heartbeat payloads (#53).
+    """
+
+    @staticmethod
+    def _make_pynvml_mock(
+        free_bytes: int = 8 * 1024**3, used_bytes: int = 4 * 1024**3
+    ) -> MagicMock:
+        mem_mock = MagicMock()
+        mem_mock.free = free_bytes
+        mem_mock.used = used_bytes
+
+        handle_mock = MagicMock(name="nvml-handle")
+
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.return_value = None
+        pynvml_mock.nvmlDeviceGetHandleByIndex.return_value = handle_mock
+        pynvml_mock.nvmlDeviceGetMemoryInfo.return_value = mem_mock
+        pynvml_mock.nvmlShutdown.return_value = None
+        return pynvml_mock
+
+    def test_enter_with_pynvml_initialises_handle(self) -> None:
+        pynvml_mock = self._make_pynvml_mock()
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.__enter__()
+            try:
+                assert vm._handle is not None
+                assert vm._init_failed is False
+                pynvml_mock.nvmlInit.assert_called_once()
+                pynvml_mock.nvmlDeviceGetHandleByIndex.assert_called_once_with(0)
+            finally:
+                vm.__exit__(None, None, None)
+
+    def test_enter_without_pynvml_sets_init_failed_flag(self) -> None:
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.side_effect = Exception("no GPU")
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.__enter__()
+            try:
+                # Init failed → handle stays None and the failure is sticky.
+                assert vm._handle is None
+                assert vm._init_failed is True
+            finally:
+                vm.__exit__(None, None, None)
+
+    def test_sample_with_handle_returns_free_used_mb(self) -> None:
+        # 8 GiB free / 4 GiB used → 8192 MiB / 4096 MiB on the wire.
+        pynvml_mock = self._make_pynvml_mock(free_bytes=8 * 1024**3, used_bytes=4 * 1024**3)
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            with VRAMMonitor() as vm:
+                free_mb, used_mb = vm.sample()
+
+        assert free_mb == pytest.approx(8192.0, rel=1e-3)
+        assert used_mb == pytest.approx(4096.0, rel=1e-3)
+
+    def test_sample_without_handle_returns_zero_zero(self) -> None:
+        # nvml init failed → handle is None → sample is the no-op `(0.0, 0.0)`
+        # contract callers rely on to keep heartbeat payloads emitting.
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.side_effect = Exception("no GPU")
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            with VRAMMonitor() as vm:
+                free_mb, used_mb = vm.sample()
+
+        assert (free_mb, used_mb) == (0.0, 0.0)
+
+    def test_exit_is_idempotent(self) -> None:
+        pynvml_mock = self._make_pynvml_mock()
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.__enter__()
+            vm.__exit__(None, None, None)
+            # Second __exit__ must not call nvmlShutdown again or raise.
+            vm.__exit__(None, None, None)
+
+        assert vm._handle is None
+        # Exactly one shutdown — the second __exit__ short-circuited on `_handle is None`.
+        pynvml_mock.nvmlShutdown.assert_called_once()
+
+    def test_open_close_delegate_to_context_manager(self) -> None:
+        pynvml_mock = self._make_pynvml_mock()
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.open()
+            assert vm._handle is not None
+            vm.close()
+            assert vm._handle is None
+
+        pynvml_mock.nvmlInit.assert_called_once()
+        pynvml_mock.nvmlShutdown.assert_called_once()
+
+    def test_reentry_guard_does_not_double_init(self) -> None:
+        # Second open() must short-circuit so we never orphan the previous
+        # handle by calling nvmlInit() again without a matching nvmlShutdown().
+        pynvml_mock = self._make_pynvml_mock()
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.open()
+            vm.open()
+            try:
+                pynvml_mock.nvmlInit.assert_called_once()
+                pynvml_mock.nvmlDeviceGetHandleByIndex.assert_called_once_with(0)
+            finally:
+                vm.close()

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -163,6 +163,11 @@ class TestVRAMMonitor:
             finally:
                 vm.__exit__(None, None, None)
 
+        # On the failure path, __exit__ must short-circuit on `_handle is None`
+        # and NEVER call nvmlShutdown — otherwise the shutdown would itself
+        # throw against an uninitialised library.
+        pynvml_mock.nvmlShutdown.assert_not_called()
+
     def test_sample_with_handle_returns_free_used_mb(self) -> None:
         # 8 GiB free / 4 GiB used → 8192 MiB / 4096 MiB on the wire.
         pynvml_mock = self._make_pynvml_mock(free_bytes=8 * 1024**3, used_bytes=4 * 1024**3)
@@ -225,5 +230,23 @@ class TestVRAMMonitor:
             try:
                 pynvml_mock.nvmlInit.assert_called_once()
                 pynvml_mock.nvmlDeviceGetHandleByIndex.assert_called_once_with(0)
+            finally:
+                vm.close()
+
+    def test_failed_init_is_sticky_does_not_retry(self) -> None:
+        # nvml/driver availability does not change at runtime; a failed init
+        # must stick so we don't burn cycles re-attempting nvmlInit() on every
+        # open() call. Without the `_init_failed` branch in the re-entry guard
+        # this assertion would fail (nvmlInit called twice).
+        pynvml_mock = MagicMock()
+        pynvml_mock.nvmlInit.side_effect = Exception("no GPU")
+
+        with patch.dict("sys.modules", {"pynvml": pynvml_mock}):
+            vm = VRAMMonitor()
+            vm.open()
+            vm.open()
+            try:
+                assert vm._init_failed is True
+                pynvml_mock.nvmlInit.assert_called_once()
             finally:
                 vm.close()


### PR DESCRIPTION
## Summary

Follow-ups from PR #57 (stage-axis audit drain). Two non-blocking, tier-S commits:

- **`refactor(daemon,gpu): #58 wire-frame sanitization hygiene + VRAMMonitor lifecycle`** —
  `daemon._format_err` now sanitizes the `msg` path (UNKNOWN_CMD / UNKNOWN_MODEL) with the
  same `scrub_credentials + truncate_with_marker` primitives used for `exc`, plus collapses
  C0 control bytes so raw-byte clients cannot smuggle `\r`/`\b` log-rewriting through verbatim
  client tokens. `VRAMMonitor` gains explicit `open()`/`close()` API (delegates to dunders)
  and an idempotent re-entry guard so a repeated `open()` cannot orphan the previous handle.
  `nats.llm_adapter` switched to the new explicit API.
- **`test(daemon,gpu,engines): #58 close test coverage gaps + tighten wire-shape assertions`** —
  direct unit cases pinning `_format_err`/`_WireErr`, `default_health`, and the full
  `VRAMMonitor` lifecycle (each previously exercised only transitively). Tightened the
  tautological `test_unknown_command_*` / `test_empty_command_*` assertions to match
  `^ERR\.[A-Z_]+(?: |$)` so a regression to the pre-typed wire shape fails loudly.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | [#58](https://github.com/Roxabi/llmCLI/issues/58): chore(daemon,nats): #57 follow-ups — wire-frame sanitization hygiene + VRAMMonitor lifecycle + test gaps | OPEN |
| Implementation | 2 commits on `feat/58-57-followups` (~302 LOC) | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (391 passed, 17 new) | Passed |

## Test Plan

- [x] `uv run pytest` — 391 pass (was 374; +17 new direct unit tests)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] Acceptance: `grep -P '"ERR (?!\.)' src/llmcli/daemon.py` returns 0 matches
- [ ] CI green on push

Closes #58

Refs: #53 (parent epic) · #57 (initial PR)

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`