### PR TITLE
chore(quadlet): move proxy env file to ~/.roxabi/llmcli/env/proxy.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ HUB_SERVICES   := llm
 -include $(SUPERVISOR_HUB)/hub.mk
 
 QUADLET_DIR := $(HOME)/.config/containers/systemd
-QUADLET_ENV := $(QUADLET_DIR)/llmcli.env
+QUADLET_ENV_DIR := $(HOME)/.roxabi/llmcli/env
+QUADLET_ENV := $(QUADLET_ENV_DIR)/proxy.env
 
 .PHONY: register llm llm-swap install lint test install-quadlet
 
@@ -42,11 +43,12 @@ install:
 
 install-quadlet:
 	@mkdir -p $(QUADLET_DIR)
+	@mkdir -p $(QUADLET_ENV_DIR)
 	@mkdir -p $(HOME)/.cache/huggingface
 	@install -m 644 deploy/quadlet/llmcli.container $(QUADLET_DIR)/llmcli.container
 	@if [ ! -f "$(QUADLET_ENV)" ]; then \
 	  install -m 600 /dev/null "$(QUADLET_ENV)" ; \
-	  printf '# llmcli.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' >> "$(QUADLET_ENV)" ; \
+	  printf '# proxy.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' >> "$(QUADLET_ENV)" ; \
 	  echo "Created stub $(QUADLET_ENV) — edit before starting." ; \
 	else \
 	  echo "Preserving existing $(QUADLET_ENV)." ; \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Run `llmcli proxy` under user-systemd via a Podman Quadlet on `:18091`:
 
 ```bash
 make install-quadlet
-$EDITOR ~/.config/containers/systemd/llmcli.env
+$EDITOR ~/.roxabi/llmcli/env/proxy.env
 systemctl --user start llmcli
 ```
 

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -9,7 +9,7 @@ Label=io.containers.autoupdate=registry
 ContainerName=llmcli
 PublishPort=18091:18091
 Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
-EnvironmentFile=%h/.config/containers/systemd/llmcli.env
+EnvironmentFile=%h/.roxabi/llmcli/env/proxy.env
 Environment=LLMCLI_PROXY_PORT=18091
 Environment=LLMCLI_PROXY_HOST=0.0.0.0
 UserNS=keep-id:uid=1502,gid=1502

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -656,7 +656,7 @@ tag so the Quadlet picks it up without any unit-file change:
 # On the dev host (roxabitower) before the PR merges:
 podman build -t ghcr.io/roxabi/llmcli:staging -f Dockerfile.llm .
 make install-quadlet
-$EDITOR ~/.config/containers/systemd/llmcli.env   # fill in keys
+$EDITOR ~/.roxabi/llmcli/env/proxy.env   # fill in keys
 systemctl --user start llmcli
 ```
 
@@ -676,11 +676,11 @@ podman pull ghcr.io/roxabi/llmcli:staging && systemctl --user restart llmcli
 
 ### Env file template
 
-The env file lives at `~/.config/containers/systemd/llmcli.env` (chmod 600). `make install-quadlet`
+The env file lives at `~/.roxabi/llmcli/env/proxy.env` (chmod 600). `make install-quadlet`
 creates this stub idempotently — it **never** overwrites an existing file:
 
 ```bash
-# ~/.config/containers/systemd/llmcli.env — chmod 600
+# ~/.roxabi/llmcli/env/proxy.env — chmod 600
 LLMCLI_API_KEY=
 FIREWORKS_API_KEY=
 ANTHROPIC_API_KEY=
@@ -706,7 +706,7 @@ journalctl --user -u llmcli --since today  # today's log
 
 | Failure | Symptom | Recovery |
 |---|---|---|
-| `~/.config/containers/systemd/llmcli.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` recreates stub |
+| `~/.roxabi/llmcli/env/proxy.env` missing | `daemon-reload` warns; `start` fails with `EnvironmentFile not found` | `make install-quadlet` recreates stub |
 | `LLMCLI_API_KEY` or provider key empty | `llmcli proxy` exits 1; `RestartForceExitStatus=1` suppresses restart — unit enters `failed` immediately with no retry burn-up | populate env file, `systemctl --user reset-failed llmcli && systemctl --user start llmcli` |
 | `litellm` missing in image | `llmcli proxy` exits 127 ("litellm binary not found"); `RestartForceExitStatus=127` suppresses restart — unit `failed` immediately | rebuild image locally with this PR's `Dockerfile.llm` OR wait for CI rebuild |
 | Image not present + no network on M₁ | `podman` run fails (no pull source) | `podman pull ghcr.io/roxabi/llmcli:staging` on host first, OR local `podman build` from this repo |
@@ -788,7 +788,7 @@ If `proxy-base.yaml` is absent, `llmcli proxy` generates a minimal default confi
 4. Built-in default `18091`
 
 The Quadlet unit sets `Environment=LLMCLI_PROXY_HOST=0.0.0.0` so the container listens on
-all interfaces; override in `~/.config/containers/systemd/llmcli.env` to restrict.
+all interfaces; override in `~/.roxabi/llmcli/env/proxy.env` to restrict.
 
 ### Migration recipe (:4000 lyra-supervisor → :18091 Quadlet)
 


### PR DESCRIPTION
## Summary

- Move llmcli proxy `EnvironmentFile` from `~/.config/containers/systemd/llmcli.env` to `~/.roxabi/llmcli/env/proxy.env`, aligning with the per-tool data-dir pattern (lyra-clipool / lyra-hub use `~/.lyra/env/*.env`).
- Update Quadlet template, Makefile (new `QUADLET_ENV_DIR` + mkdir step + stub comment), README, and `docs/guides/deployment.md` (5 path references).

## Why

- Three coexisting patterns currently: `~/.lyra/env/` (grandfathered) · `~/.config/containers/systemd/` (llmcli only) · inline `Environment=` (voicecli, hermes). This consolidates llmcli onto the data-dir pattern so secrets path is predictable per tool.
- `~/.roxabi/<tool>/` is the canonical Roxabi data-dir convention; `~/.config/containers/systemd/` should stay focused on unit files.

## Trade-off (accepted)

The Quadlet `Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z` now also exposes `proxy.env` inside the container at `/home/llmcli/.roxabi/llmcli/env/proxy.env`. Net security delta is ~zero — the keys are already injected into the container as env vars (reachable via `/proc/1/environ`). Documented for future readers.

## Migration for existing M₁ deployment

Already applied to M₁ (roxabituwer) before this PR:

\`\`\`bash
mkdir -p ~/.roxabi/llmcli/env
mv ~/.config/containers/systemd/llmcli.env ~/.roxabi/llmcli/env/proxy.env
chmod 600 ~/.roxabi/llmcli/env/proxy.env
sed -i 's|%h/.config/containers/systemd/llmcli.env|%h/.roxabi/llmcli/env/proxy.env|' \\
    ~/.config/containers/systemd/llmcli.container
systemctl --user daemon-reload && systemctl --user restart llmcli.service
\`\`\`

Post-migration verified on M₁: container active, healthy, `/health/liveliness` returns 200, all three keys (LLMCLI_API_KEY, FIREWORKS_API_KEY, NVIDIA_API_KEY) present in container env. Backup of original Quadlet kept at `~/.config/containers/systemd/llmcli.container.bak-20260521`.

## Test plan

- [ ] Fresh \`make install-quadlet\` on M₂ (roxabitower) creates \`~/.roxabi/llmcli/env/proxy.env\` stub at mode 600 and the new \`~/.roxabi/llmcli/env/\` directory
- [ ] Existing env file is preserved (idempotent stub creation)
- [ ] \`systemctl --user start llmcli\` succeeds after stub edit
- [ ] Container reads keys correctly (verified internally: \`/v1/models\` returns 401 with key-required, not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)