### PR TITLE
feat(quadlet): #60 join roxabi.network for inter-container DNS routing

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -85,6 +85,33 @@ run mkdir -p "$ENV_DIR"
 run mkdir -p "${HOME}/.cache/huggingface"
 echo "  dirs ok"
 
+# --- Networks ---
+# llmcli.container requires roxabi.network (shared bridge with lyra-*, hermes-*)
+# for container-to-container DNS routing. The .network Quadlet file is owned by
+# lyra deploy (single source of truth across the fleet) — installed at
+# ~/.config/containers/systemd/roxabi.network. We only verify presence here.
+echo ""
+echo "--- Networks ---"
+if podman network exists systemd-roxabi 2>/dev/null; then
+  echo "  [ok]     systemd-roxabi (from roxabi.network Quadlet)"
+elif [ -f "${QUADLET_DIR}/roxabi.network" ]; then
+  echo "  [pending] roxabi.network Quadlet present but network not yet generated"
+  echo "            run: systemctl --user daemon-reload && podman network ls"
+else
+  echo "  [MISSING] roxabi.network Quadlet not found at ${QUADLET_DIR}/roxabi.network" >&2
+  echo "" >&2
+  echo "  llmcli.container references Network=roxabi.network (shared bridge)." >&2
+  echo "  On M₁: provided by lyra deploy." >&2
+  echo "  On other hosts: install via lyra/deploy/quadlet/roxabi.network or:" >&2
+  echo "    cat > ${QUADLET_DIR}/roxabi.network <<EOF" >&2
+  echo "    [Network]" >&2
+  echo "    Driver=bridge" >&2
+  echo "    Label=app=roxabi" >&2
+  echo "    EOF" >&2
+  echo "    systemctl --user daemon-reload" >&2
+  exit 1
+fi
+
 # --- Quadlet units ---
 echo ""
 echo "--- Quadlet units ---"

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -7,6 +7,11 @@ StartLimitBurst=5
 Image=ghcr.io/roxabi/llmcli:staging
 Label=io.containers.autoupdate=registry
 ContainerName=llmcli
+# Bridge membership enables container-to-container DNS routing (closes #60):
+# other services on roxabi.network reach this proxy as `http://llmcli:18091`
+# instead of hardcoded LAN IPs. PublishPort below keeps host-side clients
+# (Claude Code aliases, ssh/tailnet) reaching :18091 via loopback.
+Network=roxabi.network
 PublishPort=18091:18091
 Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
 EnvironmentFile=%h/.roxabi/llmcli/env/proxy.env


### PR DESCRIPTION
## Summary

- Adds `Network=roxabi.network` to `deploy/quadlet/llmcli.container` so bridge containers (lyra-*, hermes-*) reach the proxy via DNS `llmcli:18091` instead of brittle LAN IPs
- `PublishPort=18091` preserved → host-side clients (ccl/ccp aliases, ssh/tailnet) unchanged
- `install.sh`: verify `roxabi.network` Quadlet presence with clear remediation if absent (lyra deploy owns the .network file as single source of truth)

## Why

Observed during Hermes deploy on M₁ (2026-05-21):

| From bridge | Path tried | Result |
|---|---|---|
| Hermes → llmcli | `127.0.0.1:18091` | container itself |
| Hermes → llmcli | `host.containers.internal:18091` (pasta) | **timeout** |
| Hermes → llmcli | `192.168.1.16:18091` (LAN) | works but brittle |
| Hermes → llmcli | `http://llmcli:18091` (bridge DNS) | clean — needs this PR |

Mirrors lyra pattern (`nats://lyra-nats:4222`).

## Deploy plan

1. Merge to staging
2. M₁: `cd ~/projects/llmCLI && git pull && ./deploy/install.sh --force && systemctl --user restart llmcli`
3. M₁: edit `~/.hermes/bots/{default,personal}/{.env,config.yaml}` → `http://llmcli:18091/v1`
4. M₁: `systemctl --user start hermes-default hermes-personal`
5. M₂: skipped this round (no Hermes; pasta still works for current consumers — when needed, install `roxabi.network` Quadlet first)

## Test plan

- [ ] M₁ `podman network exists systemd-roxabi` → true
- [ ] M₁ `podman exec hermes-default getent hosts llmcli` → resolves
- [ ] M₁ `podman exec hermes-default curl -sf http://llmcli:18091/health` → 200
- [ ] M₁ Hermes bots up + answering on Telegram
- [ ] M₁ Claude Code aliases (ccl/ccp) still reach `:18091` via loopback

Closes #60