### PR TITLE
chore(deploy): warn loudly that install.sh --force destroys env files

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,7 +7,12 @@
 # Flags:
 #   --dry-run       Print what would be done, make no changes
 #   --secrets-only  Only check/report on required secrets, skip unit install
-#   --force         Overwrite existing env stubs (default: preserve)
+#   --force         DESTRUCTIVE — overwrites existing env stubs (proxy.env,
+#                   worker.env) with empty templates. Provider keys
+#                   (FIREWORKS_API_KEY, NVIDIA_API_KEY, etc.) populated by the
+#                   operator will be lost. Only use on first install or when
+#                   you explicitly want to reset env files. To re-install only
+#                   the Quadlet units after a unit edit, omit --force.
 #
 # Prerequisites (no-ops if already present):
 #   - podman secret create llmcli-litellm-key  <value>
@@ -131,11 +136,19 @@ for unit in llmcli.container llmcli-nats-worker.container; do
 done
 
 # --- Env stubs ---
+# WARNING: --force overwrites existing env files with empty templates. Any
+# provider keys (FIREWORKS/NVIDIA/ANTHROPIC/OPENAI) populated by the operator
+# will be lost — they are not in podman secrets or any backup. Print a loud
+# warning before clobbering so the operator has a chance to abort.
 echo ""
 echo "--- Env stubs ---"
 
 PROXY_ENV="${ENV_DIR}/proxy.env"
 if [ ! -f "$PROXY_ENV" ] || "$FORCE"; then
+  if [ -f "$PROXY_ENV" ] && "$FORCE"; then
+    echo "  [WARNING] --force will OVERWRITE $PROXY_ENV with empty stub" >&2
+    echo "            (operator-populated provider keys will be lost)" >&2
+  fi
   run install -m 600 /dev/null "$PROXY_ENV"
   if ! "$DRY_RUN"; then
     printf '# proxy.env — chmod 600. Fill in keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' >> "$PROXY_ENV"
@@ -147,6 +160,10 @@ fi
 
 WORKER_ENV="${ENV_DIR}/worker.env"
 if [ ! -f "$WORKER_ENV" ] || "$FORCE"; then
+  if [ -f "$WORKER_ENV" ] && "$FORCE"; then
+    echo "  [WARNING] --force will OVERWRITE $WORKER_ENV with empty stub" >&2
+    echo "            (operator-populated LLMCLI_NATS_URL will be lost)" >&2
+  fi
   run install -m 600 /dev/null "$WORKER_ENV"
   if ! "$DRY_RUN"; then
     printf '# worker.env — chmod 600. Set LLMCLI_NATS_URL before starting.\n# LLMCLI_NATS_URL=nats://<hub-tailnet-ip>:4222\nLLMCLI_NATS_URL=\n' >> "$WORKER_ENV"

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -48,6 +48,14 @@ This:
 - Creates stub env files at `~/.roxabi/llmcli/env/{proxy,worker}.env`
 - Runs `systemctl --user daemon-reload`
 
+> ⚠ **`--force` is destructive.** Re-running with `--force` overwrites
+> existing env files (`proxy.env`, `worker.env`) with empty stubs — any
+> provider keys (FIREWORKS/NVIDIA/ANTHROPIC/OPENAI) populated by the
+> operator are **lost** (not in podman secrets, no backup). Use plain
+> `./deploy/install.sh` to re-sync Quadlet units after editing them; only
+> use `--force` on first install or when you explicitly want to reset env
+> files.
+
 ### 1.3 Populate env files
 
 ```bash


### PR DESCRIPTION
## Summary

`install.sh --force` silently rewrites `~/.roxabi/llmcli/env/{proxy,worker}.env` to empty stubs, losing operator-populated provider keys (FIREWORKS, NVIDIA, ANTHROPIC, OPENAI) that are NOT in podman secrets or any backup.

Discovered while deploying #60 — a routine `install.sh --force` to refresh the Quadlet unit silently wiped M₁'s proxy.env, brick-looping llmcli.

## Changes (no behavior change)

- `install.sh` header: spell out which keys are lost
- inline comment above env-stub section: same warning for code readers
- runtime `[WARNING]` to stderr before each overwrite (chance to ctrl-C)
- `QUADLET-DEPLOYMENT.md` § 1.2: callout pointing operators to plain `install.sh` for unit-only refreshes

## Follow-ups (out of scope)

- Split `--force-units` from `--force-env` so unit refresh doesn't touch env
- Snapshot env to `proxy.env.bak.<timestamp>` before clobber

## Test plan

- [ ] `./deploy/install.sh --force` on a populated proxy.env → emits `[WARNING]` lines to stderr
- [ ] `./deploy/install.sh` (no --force) on a populated proxy.env → still keeps env (`[keep]`)
- [ ] `./deploy/install.sh --dry-run --force` → no actual writes