### PR TITLE
fix(deploy): #34 worker quadlet — mount ~/.roxabi/llmcli/ for catalog access

### DIFF
--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -13,6 +13,7 @@ ContainerName=llmcli-nats-worker
 # host network — rootless podman cannot route tailnet 100.x without it
 Network=host
 Volume=%h/.cache/huggingface:/home/llmcli/.cache/huggingface
+Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z
 Environment=HF_HOME=/home/llmcli/.cache/huggingface
 Secret=llmcli-nats-worker,type=mount,target=/run/secrets/llmcli-nats-worker.seed,mode=0400,uid=1502,gid=1502
 Secret=llmcli-litellm-key,type=env,target=LLMCLI_LITELLM_API_KEY


### PR DESCRIPTION
## Summary

Restore the `~/.roxabi/llmcli/` bind mount to `llmcli-nats-worker.container` (lost in refactor commit `4820259`). Worker now reads its catalog like the proxy already does.

## Regression context

```
$ grep '^Volume=' deploy/quadlet/llmcli.container deploy/quadlet/llmcli-nats-worker.container
llmcli.container:Volume=%h/.cache/huggingface:/home/llmcli/.cache/huggingface
llmcli.container:Volume=%h/.roxabi/llmcli:/home/llmcli/.roxabi/llmcli:ro,Z     ← proxy has it
llmcli-nats-worker.container:Volume=%h/.cache/huggingface:/home/llmcli/.cache/huggingface
                                                                                ← worker missing it
```

## Failure mode

On boot the worker container exits 1 with:
```
FileNotFoundError: llmCLI catalog not found at /home/llmcli/.roxabi/llmcli/llmcli.toml.
If you're upgrading from ~/.config/llmcli/, run:
  mv ~/.config/llmcli ~/.roxabi/llmcli
Or set LLMCLI_CONFIG=<path> to point at a custom location.
```

The default `LLMCLI_CONFIG` resolves to `~/.roxabi/llmcli/llmcli.toml` (matches CLAUDE.md "Per-host catalog at `~/.roxabi/llmcli/llmcli.toml`"). Without the bind mount, the path doesn't exist inside the container.

## Discovery

2026-05-22 — M₁ (roxabituwer) post-NVIDIA driver recovery. CDI mount worked, NATS auth worked, then catalog load failed. Compared to the proxy `.container` (which works) → spotted the missing `Volume=` line. Hotfixed in-place via deployed `~/.config/containers/systemd/llmcli-nats-worker.container` so the worker could boot; this PR brings the source template back in line with the proxy.

## Change

One-line addition, identical format to the proxy (`:ro,Z` — read-only since worker only consumes `llmcli.toml` + `models/*.toml`; `Z` for per-container SELinux relabel, no-op on Ubuntu/Pop!_OS but symmetric).

## Test plan

- [x] Hotfix already validated on M₁ (worker active, no catalog error, generate.request subscription succeeds)
- [ ] Post-merge: M₁ `podman auto-update --force` picks up new image (no change here — Quadlet only); re-run `~/projects/deploy.sh --dry-run` on M₁ → no drift
- [ ] M₂ deploy: `systemctl --user daemon-reload && systemctl --user restart llmcli-nats-worker` reads new template
- [ ] No catalog FileNotFoundError in `journalctl --user -u llmcli-nats-worker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)