### PR TITLE
test(ci): #52 add litellm[proxy] runtime-import smoke

### DIFF
--- a/tests/test_proxy_runtime_imports.py
+++ b/tests/test_proxy_runtime_imports.py
@@ -1,0 +1,16 @@
+"""Regression guard for #49 — litellm[proxy] runtime deps must be importable.
+
+A breakage here means `llmcli proxy` would crash-loop at container start
+(as happened in T8 smoke of #44 before PR #50 fixed the missing [proxy] sub-extra).
+"""
+
+from __future__ import annotations
+
+
+def test_litellm_proxy_runtime_imports() -> None:
+    import apscheduler  # noqa: F401  # pyright: ignore[reportMissingImports]
+    import uvloop  # noqa: F401  # pyright: ignore[reportMissingImports]
+    import websockets  # noqa: F401  # pyright: ignore[reportMissingImports]
+    from litellm.proxy.proxy_server import app  # pyright: ignore[reportMissingImports]
+
+    assert app is not None


### PR DESCRIPTION
## Summary
- Add `tests/test_proxy_runtime_imports.py` — fast regression guard that imports `websockets`, `uvloop`, `apscheduler` and `litellm.proxy.proxy_server.app`.
- Fails CI if the `[proxy]` sub-extra on `litellm` is rolled back or any of its runtime deps break upstream — closing the gap that let PR #50's bug ship to T8 smoke of #44.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #52: test(ci): add litellm[proxy] runtime-import smoke | OPEN |
| Implementation | 1 commit on `feat/52-litellm-proxy-runtime-import-smoke` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new) | Passed |

## Test Plan
- [x] `uv run pytest tests/test_proxy_runtime_imports.py` exits 0
- [x] Test is collected by the default `uv run pytest -m "not nats"` CI invocation
- [ ] Manual sanity: roll `proxy = ["litellm>=1.0"]` (drop `[proxy]`) → test fails on `import websockets` / `uvloop` / `apscheduler`

## Out of Scope
- Spawning an actual litellm process (covered by deployment smoke T8/T9 + #44)
- Capping `litellm[proxy]<2.0` (rejected on PR #50 — placebo given uv.lock SHA pin)

Closes #52

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`