### PR TITLE
fix(proxy): apply 3 deferred review suggestions from PR #42

### DIFF
--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -169,9 +169,12 @@ def proxy(
             raise typer.Exit(127)
 
     # 5. Write with 0o700 dir mode, 0o600 file mode
+    # Atomic create with restrictive perms (no write_text→chmod race window).
     target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    target.write_text(yaml_text)
-    target.chmod(0o600)
+    fd = os.open(target, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(yaml_text)
+    target.chmod(0o600)  # defense-in-depth: enforce exact mode regardless of process umask
 
     # 6. If --config-out, dry-run exit
     if config_out is not None:
@@ -256,8 +259,14 @@ def _spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen:
             "or `uv add 'litellm[proxy]'`"
         )
         raise typer.Exit(127)
+    # start_new_session=True: child runs in its own process group so terminal
+    # SIGINT/SIGTERM hits only the parent. The handler in _install_signal_handlers
+    # then forwards deterministically with a drain timeout — without isolation,
+    # the kernel would deliver the signal to both parent and child via the
+    # foreground group, racing the drain logic.
     return subprocess.Popen(  # noqa: S603
-        [binary, "--config", str(config_path), "--port", str(port), "--host", host]
+        [binary, "--config", str(config_path), "--port", str(port), "--host", host],
+        start_new_session=True,
     )
 
 

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -192,7 +192,8 @@ class TestSpawnLitellm:
                 "18091",
                 "--host",
                 "0.0.0.0",
-            ]
+            ],
+            start_new_session=True,
         )
 
     def test_missing_binary_exits_127(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -583,6 +584,50 @@ class TestExitCodePropagation:
         assert result.exit_code == 137, (
             f"Expected 137 (128+9); got {result.exit_code}; output: {result.output!r}"
         )
+
+    def test_port_flag_propagates_to_spawn(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """`--port 4001` reaches _spawn_litellm via Typer → covers the CLI wiring end-to-end."""
+        from typer.testing import CliRunner
+        from llmcli.cli._app import app as typer_app
+
+        monkeypatch.setenv("LLMCLI_API_KEY", "test-master-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+        fake_child = MagicMock()
+        fake_child.wait.return_value = 0
+        fake_spawn = MagicMock(return_value=fake_child)
+
+        catalog = self._make_remote_catalog()
+        runner = CliRunner()
+
+        with patch("llmcli.cli.config") as mock_config:
+            mock_config.load.return_value = catalog
+            import llmcli.cli.proxy as proxy_mod
+
+            monkeypatch.setattr(
+                proxy_mod.shutil,
+                "which",
+                lambda name: "/usr/local/bin/litellm" if name == "litellm" else None,
+            )
+            monkeypatch.setattr("llmcli.cli.proxy._spawn_litellm", fake_spawn)
+            monkeypatch.setattr(
+                "llmcli.cli.proxy._install_signal_handlers",
+                lambda *a, **k: None,
+            )
+            result = runner.invoke(typer_app, ["proxy", "--port", "4001"])
+
+        assert result.exit_code == 0, (
+            f"Expected 0; got {result.exit_code}; output: {result.output!r}"
+        )
+        fake_spawn.assert_called_once()
+        # Signature: _spawn_litellm(config_path, port, host) — port is positional[1].
+        called_port = fake_spawn.call_args.args[1]
+        assert called_port == 4001, f"Expected port 4001; got {called_port!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Apply 3 of the 4 deferred review findings from PR #42 (F15/F16/F17). F13 skipped — current dry-run path is already hermetic.
- No behavior change for happy path; tighter security + signal isolation + extra CLI coverage.

## Findings Applied

| ID | Domain | Change |
|---|---|---|
| **F13** | tester | **Skipped.** `proxy.py:163` already gates `shutil.which("litellm")` behind `if config_out is None:`. The `--config-out` (dry-run) path is hermetic by construction; the proposed `monkeypatch.setattr(proxy_mod.shutil, "which", lambda _: None)` is moot. |
| **F15** | tester | New `TestExitCodePropagation.test_port_flag_propagates_to_spawn` — invokes `proxy --port 4001` via `CliRunner`, asserts the mocked `_spawn_litellm` received `port=4001`. Covers end-to-end Typer wiring previously absent. |
| **F16** | security-auditor | Atomic file create: `os.open(target, O_CREAT\|O_WRONLY\|O_TRUNC, 0o600)` + `os.fdopen` replaces `write_text` + trailing `chmod(0o600)` (race window closed). Trailing `chmod` kept as defense-in-depth against process-umask edge cases (e.g. `umask 0o222` strips bits otherwise). |
| **F17** | backend-dev | `subprocess.Popen(..., start_new_session=True)` — child runs in its own process group so terminal SIGINT/SIGTERM hits only the parent; existing `_install_signal_handlers` then forwards deterministically with drain. Eliminates the race between kernel group-delivery and Python-side drain logic. |

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #43: follow-up(proxy): defer 4 review suggestions from PR #42 | OPEN (size:S) |
| Implementation | 1 commit on `feat/43-proxy-followups` | Complete |
| Verification | Lint ✅  Typecheck (ruff PYI) ✅  Tests ✅ 468/468 (1 new) | Passed |

## Test Plan
- [x] Full suite: `uv run pytest` → 468 passed
- [x] Lint: `uv run ruff check .` → clean
- [x] New F15 test: `pytest tests/test_proxy_cmd.py::TestExitCodePropagation::test_port_flag_propagates_to_spawn` → green
- [x] Updated `TestSpawnLitellm.test_happy_path_calls_popen_with_args` asserts `start_new_session=True` kwarg
- [ ] Manual smoke: `llmcli proxy --port 4001` → litellm binds 4001, `ctrl+C` shuts down within 10 s drain

Closes #43

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`