### PR TITLE
chore(dev-core): port Lyra worktree-setup.sh (.venv symlink for Pyright)

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -31,6 +31,7 @@ commands:
   format: uv run ruff format .
   typecheck: uv run ruff check --select=PYI .
   install: uv sync
+  worktree_setup: tools/worktree-setup.sh
 
 artifacts:
   analyses: artifacts/analyses

--- a/tools/worktree-setup.sh
+++ b/tools/worktree-setup.sh
@@ -5,6 +5,7 @@
 # if a branch bumps deps, `rm .venv && uv sync` inside the worktree.
 set -euo pipefail
 
+# git worktree list --porcelain always emits the main worktree first per git docs.
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
 
 if [ -z "${MAIN_REPO:-}" ] || [ ! -d "${MAIN_REPO}/.venv" ]; then
@@ -18,7 +19,9 @@ if [ "${PWD}" = "${MAIN_REPO}" ]; then
 fi
 
 if [ -L .venv ]; then
-  rm .venv
+  existing=$(readlink .venv 2>/dev/null)
+  [ "$existing" = "${MAIN_REPO}/.venv" ] && { echo "worktree-setup: already linked — OK"; exit 0; }
+  rm -f .venv || { echo "worktree-setup: cannot remove .venv symlink" >&2; exit 1; }
 elif [ -d .venv ]; then
   echo "worktree-setup: .venv already exists as a real directory — leaving it untouched" >&2
   exit 0

--- a/tools/worktree-setup.sh
+++ b/tools/worktree-setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Post-worktree-create hook invoked by dev-core /implement.
+# Symlinks the main repo's .venv into the new worktree so Pyright/uv resolve
+# third-party imports immediately. Branches share uv.lock, so this is safe;
+# if a branch bumps deps, `rm .venv && uv sync` inside the worktree.
+set -euo pipefail
+
+MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+
+if [ -z "${MAIN_REPO:-}" ] || [ ! -d "${MAIN_REPO}/.venv" ]; then
+  echo "worktree-setup: main repo .venv not found at ${MAIN_REPO:-?} — skipping" >&2
+  exit 0
+fi
+
+if [ "${PWD}" = "${MAIN_REPO}" ]; then
+  echo "worktree-setup: running inside main repo, refusing to symlink .venv onto itself" >&2
+  exit 0
+fi
+
+if [ -L .venv ]; then
+  rm .venv
+elif [ -d .venv ]; then
+  echo "worktree-setup: .venv already exists as a real directory — leaving it untouched" >&2
+  exit 0
+fi
+
+ln -s "${MAIN_REPO}/.venv" .venv
+echo "worktree-setup: linked .venv → ${MAIN_REPO}/.venv"


### PR DESCRIPTION
## Summary
- Ports `tools/worktree-setup.sh` from Lyra — symlinks the main repo's `.venv` into new worktrees so Pyright resolves third-party imports immediately without a first-run `uv sync`
- Wires the script via `commands.worktree_setup: tools/worktree-setup.sh` in `.claude/stack.yml`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #80: chore(dev-core): port Lyra worktree-setup.sh (.venv symlink for Pyright) | Open |
| Implementation | 1 commit on `feat/80-port-lyra-worktree-setup` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests N/A (shell script, no new Python) | Passed |

## Test Plan
- [ ] Create a fresh worktree via `/dev` on any new issue — confirm `.venv` symlink appears in worktree root
- [ ] Open a Python file in the worktree with Pyright active — confirm no "module not found" errors for llmcli or third-party imports
- [ ] Run `uv run llmcli --help` from inside the worktree — confirm it works without reinstalling

Closes #80

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`