### PR TITLE
refactor(gpu,lifecycle): split gpu.py + extract swap helper (#77)

### DIFF
--- a/src/llmcli/gpu/__init__.py
+++ b/src/llmcli/gpu/__init__.py
@@ -1,0 +1,13 @@
+"""GPU utilities for llmCLI — VRAM probing and KV-cache overhead estimation."""
+
+from __future__ import annotations
+
+from llmcli.gpu.kv import kv_overhead_gib
+from llmcli.gpu.vram import VRAMMonitor, VRAMSampler, probe_free_vram_gib
+
+__all__ = [
+    "probe_free_vram_gib",
+    "VRAMSampler",
+    "VRAMMonitor",
+    "kv_overhead_gib",
+]

--- a/src/llmcli/gpu/kv.py
+++ b/src/llmcli/gpu/kv.py
@@ -1,0 +1,88 @@
+"""KV-cache VRAM overhead estimation for llmCLI."""
+
+from __future__ import annotations
+
+import re
+
+_QUANT_BITS: dict[str, float] = {
+    "q2_k": 2.0,
+    "q2_k_s": 2.0,
+    "iq3_xxs": 3.0,
+    "iq3_xs": 3.0,
+    "iq3_s": 3.0,
+    "iq3_m": 3.0,
+    "tq3_0": 3.0,
+    "q4_0": 4.0,
+    "q4_1": 4.0,
+    "q4_k": 4.0,
+    "q4_k_s": 4.0,
+    "q4_k_m": 4.0,
+    "iq4_nl": 4.0,
+    "iq4_xs": 4.0,
+    "q5_0": 5.0,
+    "q5_1": 5.0,
+    "q5_k": 5.0,
+    "q5_k_s": 5.0,
+    "q5_k_m": 5.0,
+    "q6_k": 6.0,
+    "q8_0": 8.0,
+    "f16": 16.0,
+    "bf16": 16.0,
+    "f32": 32.0,
+}
+_BASELINE_BITS = 4.0  # empirical baseline: q4_0
+
+
+def _quant_multiplier(flags: list[str]) -> float:
+    """Return a VRAM scaling factor relative to q4_0 from -ctk/-ctv flags.
+
+    Averages the key-cache and value-cache bit widths and normalises against
+    the q4_0 baseline. Falls back to 1.0 (no adjustment) when flags are absent.
+    """
+    key_bits: float | None = None
+    val_bits: float | None = None
+
+    i = 0
+    while i < len(flags) - 1:
+        flag = flags[i]
+        if flag == "-ctk":
+            key_bits = _QUANT_BITS.get(flags[i + 1].lower())
+        elif flag == "-ctv":
+            val_bits = _QUANT_BITS.get(flags[i + 1].lower())
+        i += 1
+
+    bits = [b for b in (key_bits, val_bits) if b is not None]
+    if not bits:
+        return 1.0
+    return sum(bits) / len(bits) / _BASELINE_BITS
+
+
+def kv_overhead_gib(flags: list[str]) -> float:
+    """Estimate KV-cache VRAM overhead in GiB from llama-server flags.
+
+    Heuristic: 0.5 GiB per 4096 tokens at q4_0, scaled by actual KV quant
+    type parsed from -ctk/-ctv flags (e.g. q8_0 = 2x overhead vs q4_0).
+
+    Returns 0.0 when -c / --ctx-size is absent.
+    """
+    ctx_tokens: int | None = None
+
+    i = 0
+    while i < len(flags):
+        token = flags[i]
+        if token in ("-c", "--ctx-size") and i + 1 < len(flags):
+            try:
+                ctx_tokens = int(flags[i + 1])
+            except ValueError:
+                pass
+            break
+        m = re.match(r"^(?:-c|--ctx-size)=(\d+)$", token)
+        if m:
+            ctx_tokens = int(m.group(1))
+            break
+        i += 1
+
+    if ctx_tokens is None:
+        return 0.0
+
+    return 0.5 * (ctx_tokens / 4096.0) * _quant_multiplier(flags)

--- a/src/llmcli/gpu/vram.py
+++ b/src/llmcli/gpu/vram.py
@@ -1,9 +1,8 @@
-"""GPU utilities for llmCLI — VRAM probing and KV-cache overhead estimation."""
+"""VRAM probing and monitoring utilities for llmCLI."""
 
 from __future__ import annotations
 
 import logging
-import re
 import subprocess
 import threading
 from typing import Self
@@ -225,87 +224,3 @@ class VRAMMonitor:
             return (mem.free / (1024**2), mem.used / (1024**2))
         except Exception:  # noqa: BLE001
             return (0.0, 0.0)
-
-
-_QUANT_BITS: dict[str, float] = {
-    "q2_k": 2.0,
-    "q2_k_s": 2.0,
-    "iq3_xxs": 3.0,
-    "iq3_xs": 3.0,
-    "iq3_s": 3.0,
-    "iq3_m": 3.0,
-    "tq3_0": 3.0,
-    "q4_0": 4.0,
-    "q4_1": 4.0,
-    "q4_k": 4.0,
-    "q4_k_s": 4.0,
-    "q4_k_m": 4.0,
-    "iq4_nl": 4.0,
-    "iq4_xs": 4.0,
-    "q5_0": 5.0,
-    "q5_1": 5.0,
-    "q5_k": 5.0,
-    "q5_k_s": 5.0,
-    "q5_k_m": 5.0,
-    "q6_k": 6.0,
-    "q8_0": 8.0,
-    "f16": 16.0,
-    "bf16": 16.0,
-    "f32": 32.0,
-}
-_BASELINE_BITS = 4.0  # empirical baseline: q4_0
-
-
-def _quant_multiplier(flags: list[str]) -> float:
-    """Return a VRAM scaling factor relative to q4_0 from -ctk/-ctv flags.
-
-    Averages the key-cache and value-cache bit widths and normalises against
-    the q4_0 baseline. Falls back to 1.0 (no adjustment) when flags are absent.
-    """
-    key_bits: float | None = None
-    val_bits: float | None = None
-
-    i = 0
-    while i < len(flags) - 1:
-        flag = flags[i]
-        if flag == "-ctk":
-            key_bits = _QUANT_BITS.get(flags[i + 1].lower())
-        elif flag == "-ctv":
-            val_bits = _QUANT_BITS.get(flags[i + 1].lower())
-        i += 1
-
-    bits = [b for b in (key_bits, val_bits) if b is not None]
-    if not bits:
-        return 1.0
-    return sum(bits) / len(bits) / _BASELINE_BITS
-
-
-def kv_overhead_gib(flags: list[str]) -> float:
-    """Estimate KV-cache VRAM overhead in GiB from llama-server flags.
-
-    Heuristic: 0.5 GiB per 4096 tokens at q4_0, scaled by actual KV quant
-    type parsed from -ctk/-ctv flags (e.g. q8_0 = 2× overhead vs q4_0).
-
-    Returns 0.0 when -c / --ctx-size is absent.
-    """
-    ctx_tokens: int | None = None
-
-    i = 0
-    while i < len(flags):
-        token = flags[i]
-        if token in ("-c", "--ctx-size") and i + 1 < len(flags):
-            try:
-                ctx_tokens = int(flags[i + 1])
-            except ValueError:
-                pass
-            break
-        m = re.match(r"^(?:-c|--ctx-size)=(\d+)$", token)
-        if m:
-            ctx_tokens = int(m.group(1))
-            break
-        i += 1
-
-    if ctx_tokens is None:
-        return 0.0
-
-    return 0.5 * (ctx_tokens / 4096.0) * _quant_multiplier(flags)

--- a/src/llmcli/nats/_lifecycle.py
+++ b/src/llmcli/nats/_lifecycle.py
@@ -189,78 +189,29 @@ class LifecycleMixin:
                 retryable=False,
             )
             return
-        instances: dict = self._instances  # type: ignore[attr-defined]
-        if model_name in instances:
-            inst = instances[model_name]
-            await self._reply_ok(
-                msg,
-                req,
-                data={
-                    "model": model_name,
-                    "port": inst.port,
-                    "vram_used_mb": 0,
-                },
-            )
-            log.info(
-                "lifecycle.swap: noop trace_id=%s model=%s (same model)",
-                req.trace_id,
-                model_name,
-            )
-            return
 
-        loop = asyncio.get_running_loop()
-        executor = getattr(self, "_executor", None)
+        await self._swap_drain_and_replace(msg, req, model_name, spec, _cap_engine)
 
-        # Drain pattern: set flag, wait for semaphore idle (with timeout), then
-        # stop-before-start. Sync engine ops run in executor so the event loop
-        # keeps spinning. The whole stop+start sequence shares one try/finally
-        # so _draining is always cleared even if engine.stop() raises.
-        self._draining.set()
-        new_inst = None
-        try:
-            try:
-                await asyncio.wait_for(
-                    self._wait_sem_idle(),
-                    timeout=self.drain_timeout,
-                )
-            except asyncio.TimeoutError:
-                log.warning("lifecycle.swap: drain timeout — hard-cutting in-flight")
+    async def _swap_drain_and_replace(
+        self,
+        msg,
+        req: LifecycleRequest,
+        model_name: str,
+        spec,
+        _cap_engine,
+    ) -> None:
+        """Drain active requests, stop old instances, start new one, and reply."""
+        from llmcli.nats._swap import _swap_drain_and_replace as _swap_impl
 
-            for old_name, old_inst in list(instances.items()):
-                old_engine = self._engine_for_spec(catalog.models[old_name])  # type: ignore[attr-defined]
-                await loop.run_in_executor(executor, old_engine.stop, old_inst)
-                del instances[old_name]
-
-            new_inst = await loop.run_in_executor(executor, _cap_engine.start, spec)
-        except Exception as exc:  # noqa: BLE001
-            wire_msg = _CRASH_MESSAGES.get(type(exc).__name__, _CRASH_FALLBACK)
-            await self._reply_err(msg, req, "worker.crash", wire_msg, retryable=True)
-            log.exception("worker.crash on swap to %s", model_name)
-            return
-        finally:
-            self._draining.clear()
-
-        instances[model_name] = new_inst
-        vram_used_mb = 0
-        vram_monitor = getattr(self, "_vram_monitor", None)
-        if vram_monitor is not None:
-            _, vram_used_mb = vram_monitor.sample()
-            vram_used_mb = int(vram_used_mb)
-        await self._reply_ok(
+        await _swap_impl(
+            self,
             msg,
             req,
-            data={
-                "model": model_name,
-                "port": new_inst.port,
-                "vram_used_mb": vram_used_mb,
-            },
-        )
-        log.info(
-            "lifecycle.swap: done trace_id=%s model=%s port=%s vram_used_mb=%d",
-            req.trace_id,
             model_name,
-            new_inst.port,
-            vram_used_mb,
+            spec,
+            _cap_engine,
+            crash_messages=_CRASH_MESSAGES,
+            crash_fallback=_CRASH_FALLBACK,
         )
 
     async def _do_status(self, msg, req: LifecycleRequest) -> None:

--- a/src/llmcli/nats/_swap.py
+++ b/src/llmcli/nats/_swap.py
@@ -1,0 +1,93 @@
+"""Swap execution helper for LifecycleMixin."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+log = logging.getLogger(__name__)
+
+
+async def _swap_drain_and_replace(
+    mixin,
+    msg,
+    req,
+    model_name: str,
+    spec,
+    _cap_engine,
+    *,
+    crash_messages: dict[str, str],
+    crash_fallback: str,
+) -> None:
+    """Drain active requests, stop old instances, start new one, and reply."""
+    instances: dict = mixin._instances  # type: ignore[attr-defined]
+    catalog = mixin._catalog  # type: ignore[attr-defined]
+
+    if model_name in instances:
+        inst = instances[model_name]
+        await mixin._reply_ok(
+            msg,
+            req,
+            data={
+                "model": model_name,
+                "port": inst.port,
+                "vram_used_mb": 0,
+            },
+        )
+        log.info(
+            "lifecycle.swap: noop trace_id=%s model=%s (same model)",
+            req.trace_id,
+            model_name,
+        )
+        return
+
+    loop = asyncio.get_running_loop()
+    executor = getattr(mixin, "_executor", None)
+
+    mixin._draining.set()
+    new_inst = None
+    try:
+        try:
+            await asyncio.wait_for(
+                mixin._wait_sem_idle(),
+                timeout=mixin.drain_timeout,
+            )
+        except asyncio.TimeoutError:
+            log.warning("lifecycle.swap: drain timeout — hard-cutting in-flight")
+
+        for old_name, old_inst in list(instances.items()):
+            old_engine = mixin._engine_for_spec(catalog.models[old_name])  # type: ignore[attr-defined]
+            await loop.run_in_executor(executor, old_engine.stop, old_inst)
+            del instances[old_name]
+
+        new_inst = await loop.run_in_executor(executor, _cap_engine.start, spec)
+    except Exception as exc:  # noqa: BLE001
+        wire_msg = crash_messages.get(type(exc).__name__, crash_fallback)
+        await mixin._reply_err(msg, req, "worker.crash", wire_msg, retryable=True)
+        log.exception("worker.crash on swap to %s", model_name)
+        return
+    finally:
+        mixin._draining.clear()
+
+    instances[model_name] = new_inst
+    vram_used_mb = 0
+    vram_monitor = getattr(mixin, "_vram_monitor", None)
+    if vram_monitor is not None:
+        _, vram_used_mb = vram_monitor.sample()
+        vram_used_mb = int(vram_used_mb)
+    await mixin._reply_ok(
+        msg,
+        req,
+        data={
+            "model": model_name,
+            "port": new_inst.port,
+            "vram_used_mb": vram_used_mb,
+        },
+    )
+    log.info(
+        "lifecycle.swap: done trace_id=%s model=%s port=%s vram_used_mb=%d",
+        req.trace_id,
+        model_name,
+        new_inst.port,
+        vram_used_mb,
+    )

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -232,7 +232,7 @@ class TestProbeVramFallback:
         with (
             patch.dict("sys.modules", {"pynvml": None}),
             patch(
-                "llmcli.gpu.subprocess.run",
+                "llmcli.gpu.vram.subprocess.run",
                 side_effect=FileNotFoundError("nvidia-smi not found"),
             ),
         ):
@@ -247,7 +247,7 @@ class TestProbeVramFallback:
 
         with (
             patch.dict("sys.modules", {"pynvml": None}),
-            patch("llmcli.gpu.subprocess.run", return_value=mock_result),
+            patch("llmcli.gpu.vram.subprocess.run", return_value=mock_result),
         ):
             result = probe_free_vram_gib()
         assert abs(result - 10.0) < 0.01, f"Expected ~10.0 GiB from nvidia-smi, got {result}"

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -1,5 +1,3 @@
 # File size exemptions (≤300 lines per file)
 # Each entry must have a tracking issue.
 # Format: <path>  # <lines> lines — <issue> <description>
-src/llmcli/nats/_lifecycle.py  # 328 lines — DEBT:file-exemptions — #77 LifecycleMixin landed in #34/ADR-004 Slice 6; _do_swap drain+stop+start extraction deferred
-src/llmcli/gpu.py  # 311 lines — DEBT:file-exemptions — #77 VRAMSampler/VRAMMonitor + kv_overhead split into gpu/vram.py + gpu/kv.py deferred


### PR DESCRIPTION
## Summary
- Split `gpu.py` (311 LOC) into `gpu/vram.py` (226 LOC) + `gpu/kv.py` (88 LOC) + `gpu/__init__.py` (13 LOC) with backward-compat re-exports
- Extract `_do_swap`'s drain+stop+start sequence into `nats/_swap.py::_swap_drain_and_replace` (93 LOC), reducing `_lifecycle.py` from 339 to 290 LOC
- Remove both files from `tools/file_exemptions.txt`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #77: refactor: split gpu.py + extract _lifecycle.py _do_swap helper (< 300 LOC) | OPEN |
| Analysis | — | Absent |
| Spec | — | Absent |
| Implementation | 1 commit on `feat/77-split-gpu-extract-lifecycle` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (0 new) | Passed |

## Test Plan
- [ ] Verify `llmcli list` and `llmcli status` still work (gpu imports unchanged)
- [ ] Verify NATS swap command still works (lifecycle mixin shape preserved)
- [ ] Confirm both `gpu/vram.py` and `nats/_lifecycle.py` are ≤ 300 LOC

Closes #77

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`