### PR TITLE
feat(cli): --fleet lifecycle ops + extract cli/_nats_client.py helper

### DIFF
--- a/src/llmcli/cli/_nats_client.py
+++ b/src/llmcli/cli/_nats_client.py
@@ -1,0 +1,149 @@
+"""Reusable NATS client helper for llmCLI lifecycle commands."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import typer
+
+from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse
+
+from llmcli.cli._app import err_console
+from llmcli.config import apply_nats_env_from_config
+
+
+@dataclass
+class FleetResult:
+    responses: list[LifecycleResponse] = field(default_factory=list)
+    errors: list[tuple[str, WorkerError]] = field(default_factory=list)
+    timeout_reached: bool = False
+    elapsed_ms: float = 0.0
+
+
+class NatsClient:
+    def __init__(self, *, allow_anonymous: bool = False) -> None:
+        self.allow_anonymous = allow_anonymous
+        self._nc = None
+
+    async def connect(self) -> None:
+        from nats.aio.client import Client as NATS
+
+        self._nc = NATS()
+        creds_path = Path("~/.roxabi/llmcli/nkeys/operator.creds").expanduser()
+        apply_nats_env_from_config()
+        nats_url = os.environ.get("LLMCLI_NATS_URL", "nats://localhost:4222")
+
+        if not creds_path.exists() and not self.allow_anonymous:
+            err_console.print(
+                f"[red]NATS operator credentials not found at {creds_path}. "
+                f"Run lyra-acl genkeys (Slice 0) or pass "
+                f"--allow-anonymous to connect without credentials (CI/dev only).[/red]"
+            )
+            raise typer.Exit(code=1)
+
+        await self._nc.connect(
+            nats_url,
+            nkeys_seed_str=creds_path.read_text().strip() if creds_path.exists() else None,
+            inbox_prefix="_inbox.llm-operator",
+        )
+
+    async def request(
+        self,
+        subject: str,
+        op: str,
+        host: str | None,
+        timeout: float,
+        *,
+        model_name: str | None = None,
+    ) -> LifecycleResponse:
+        if self._nc is None:
+            raise RuntimeError("NatsClient not connected. Call connect() first.")
+
+        req = LifecycleRequest(
+            contract_version="1",
+            trace_id=uuid4().hex,
+            issued_at=datetime.now(timezone.utc).isoformat(),
+            request_id=uuid4().hex,
+            host=host or socket.gethostname(),
+            op=op,
+            model_name=model_name,
+        )
+        msg = await self._nc.request(subject, req.model_dump_json().encode(), timeout=timeout)
+        return LifecycleResponse.model_validate_json(msg.data)
+
+    async def request_fleet(
+        self,
+        subject: str,
+        op: str,
+        timeout: float,
+        *,
+        model_name: str | None = None,
+    ) -> FleetResult:
+        if self._nc is None:
+            raise RuntimeError("NatsClient not connected. Call connect() first.")
+
+        req = LifecycleRequest(
+            contract_version="1",
+            trace_id=uuid4().hex,
+            issued_at=datetime.now(timezone.utc).isoformat(),
+            request_id=uuid4().hex,
+            host=None,
+            op=op,
+            model_name=model_name,
+        )
+        payload = req.model_dump_json().encode()
+
+        inbox = self._nc.new_inbox()
+        sub = await self._nc.subscribe(inbox)
+        try:
+            await self._nc.publish(subject, payload, reply=inbox)
+
+            result = FleetResult()
+            start = time.perf_counter()
+
+            while True:
+                elapsed = time.perf_counter() - start
+                remaining = timeout - elapsed
+                if remaining <= 0:
+                    result.timeout_reached = True
+                    break
+
+                try:
+                    msg = await asyncio.wait_for(sub.next_msg(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    result.timeout_reached = True
+                    break
+
+                try:
+                    resp = LifecycleResponse.model_validate_json(msg.data)
+                except Exception:
+                    continue
+
+                if resp.ok:
+                    result.responses.append(resp)
+                else:
+                    we = resp.worker_error
+                    if we is None:
+                        we = WorkerError(
+                            code="unknown",
+                            message=resp.error or "unknown error",
+                        )
+                    result.errors.append((resp.host or "unknown", we))
+
+            result.elapsed_ms = (time.perf_counter() - start) * 1000
+            return result
+        finally:
+            await sub.unsubscribe()
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            await self._nc.drain()
+            self._nc = None

--- a/src/llmcli/cli/lifecycle.py
+++ b/src/llmcli/cli/lifecycle.py
@@ -102,37 +102,80 @@ def status(
         help="Connect to NATS without operator credentials. CI/dev only — do not use in production.",
         hidden=True,
     ),
+    fleet: bool = typer.Option(
+        False,
+        "--fleet",
+        help="Query all workers in the fleet.",
+    ),
 ) -> None:
     """Show engine status, ports, VRAM, uptime."""
     from roxabi_contracts.llm.subjects import SUBJECTS
+    from llmcli.cli._nats_client import NatsClient
 
-    resp = asyncio.run(
-        lifecycle_nats_request(
-            SUBJECTS.lifecycle_status,
-            "status",
-            host or socket.gethostname(),
-            timeout,
-            allow_anonymous=allow_anonymous,
-        )
-    )
-    if not resp.ok:
-        we = resp.worker_error
-        if we:
-            err_console.print(f"[red]{we.code}: {we.message}[/red]")
-        else:
-            err_console.print(f"[red]status failed: {resp.error}[/red]")
-        raise typer.Exit(code=1)
-    data = resp.data or {}
-    if not data.get("model"):
-        console.print("No engines running.")
-        return
-    table = Table(title="Running engines")
-    table.add_column("model")
-    table.add_column("port")
-    table.add_column("vram_used_mb")
-    table.add_row(
-        str(data.get("model", "?")),
-        str(data.get("port", "?")),
-        str(data.get("vram_used_mb", 0)),
-    )
-    console.print(table)
+    async def _run() -> None:
+        client = NatsClient(allow_anonymous=allow_anonymous)
+        await client.connect()
+        try:
+            if fleet:
+                result = await client.request_fleet(
+                    SUBJECTS.lifecycle_status, "status", timeout
+                )
+                if result.responses:
+                    table = Table(title="Fleet status")
+                    table.add_column("host", style="cyan")
+                    table.add_column("model")
+                    table.add_column("port")
+                    table.add_column("vram_used_mb")
+                    for resp in result.responses:
+                        data = resp.data or {}
+                        table.add_row(
+                            resp.host or "?",
+                            str(data.get("model", "?")),
+                            str(data.get("port", "?")),
+                            str(data.get("vram_used_mb", 0)),
+                        )
+                    console.print(table)
+                if result.errors:
+                    for h, we in result.errors:
+                        err_console.print(f"[red]{h}: {we.code} - {we.message}[/red]")
+                if result.timeout_reached and not result.responses:
+                    err_console.print("[yellow]Fleet query timed out with no responses.[/yellow]")
+            else:
+                try:
+                    resp = await client.request(
+                        SUBJECTS.lifecycle_status,
+                        "status",
+                        host or socket.gethostname(),
+                        timeout,
+                    )
+                except Exception as exc:
+                    err_console.print(
+                        f"[yellow]No worker responded for host={host or socket.gethostname()!r}. "
+                        f"Check hostname or NATS connectivity: {exc}[/yellow]"
+                    )
+                    raise typer.Exit(code=1) from exc
+                if not resp.ok:
+                    we = resp.worker_error
+                    if we:
+                        err_console.print(f"[red]{we.code}: {we.message}[/red]")
+                    else:
+                        err_console.print(f"[red]status failed: {resp.error}[/red]")
+                    raise typer.Exit(code=1)
+                data = resp.data or {}
+                if not data.get("model"):
+                    console.print("No engines running.")
+                    return
+                table = Table(title="Running engines")
+                table.add_column("model")
+                table.add_column("port")
+                table.add_column("vram_used_mb")
+                table.add_row(
+                    str(data.get("model", "?")),
+                    str(data.get("port", "?")),
+                    str(data.get("vram_used_mb", 0)),
+                )
+                console.print(table)
+        finally:
+            await client.close()
+
+    asyncio.run(_run())

--- a/src/llmcli/cli/lifecycle_extra.py
+++ b/src/llmcli/cli/lifecycle_extra.py
@@ -37,42 +37,92 @@ def list_models(
         help="Connect to NATS without operator credentials. CI/dev only — do not use in production.",
         hidden=True,
     ),
+    fleet: bool = typer.Option(
+        False,
+        "--fleet",
+        help="Query all workers in the fleet.",
+    ),
 ) -> None:
     """Show catalog models + running state + VRAM."""
     from roxabi_contracts.llm.subjects import SUBJECTS
+    from llmcli.cli._nats_client import NatsClient
 
-    # PR-1: single-host list. Fleet broadcast + aggregate → v2 (Roxabi/llmCLI#61).
-    resp = asyncio.run(
-        lifecycle_nats_request(
-            SUBJECTS.lifecycle_list,
-            "list",
-            host or socket.gethostname(),
-            timeout,
-            allow_anonymous=allow_anonymous,
-        )
-    )
-    if not resp.ok:
-        we = resp.worker_error
-        if we:
-            err_console.print(f"[red]{we.code}: {we.message}[/red]")
-        else:
-            err_console.print(f"[red]list failed: {resp.error}[/red]")
-        raise typer.Exit(code=1)
-    data = resp.data or {}
-    models = data.get("models", [])
-    table = Table(title="llmCLI models")
-    table.add_column("name", style="cyan")
-    table.add_column("engine")
-    table.add_column("vram_gib")
-    table.add_column("running?")
-    for m in models:
-        table.add_row(
-            m.get("name", "?"),
-            m.get("engine", "?"),
-            str(m.get("vram_gib", "?")),
-            "yes" if m.get("running") else "no",
-        )
-    console.print(table)
+    async def _run() -> None:
+        client = NatsClient(allow_anonymous=allow_anonymous)
+        await client.connect()
+        try:
+            if fleet:
+                result = await client.request_fleet(
+                    SUBJECTS.lifecycle_list, "list", timeout
+                )
+                # Merge model lists from all hosts
+                models: dict[str, dict] = {}
+                for resp in result.responses:
+                    for m in (resp.data or {}).get("models", []):
+                        name = m.get("name", "?")
+                        if name not in models:
+                            models[name] = {
+                                "engine": m.get("engine", "?"),
+                                "vram_gib": m.get("vram_gib", "?"),
+                                "running_on": [],
+                            }
+                        if m.get("running"):
+                            models[name]["running_on"].append(resp.host or "?")
+                if models:
+                    table = Table(title="Fleet models")
+                    table.add_column("name", style="cyan")
+                    table.add_column("engine")
+                    table.add_column("vram_gib")
+                    table.add_column("running")
+                    for name, info in sorted(models.items()):
+                        running = ", ".join(info["running_on"]) if info["running_on"] else "no"
+                        table.add_row(name, info["engine"], str(info["vram_gib"]), running)
+                    console.print(table)
+                if result.errors:
+                    for h, we in result.errors:
+                        err_console.print(f"[red]{h}: {we.code} - {we.message}[/red]")
+                if result.timeout_reached and not result.responses:
+                    err_console.print("[yellow]Fleet query timed out with no responses.[/yellow]")
+            else:
+                try:
+                    resp = await client.request(
+                        SUBJECTS.lifecycle_list,
+                        "list",
+                        host or socket.gethostname(),
+                        timeout,
+                    )
+                except Exception as exc:
+                    err_console.print(
+                        f"[yellow]No worker responded for host={host or socket.gethostname()!r}. "
+                        f"Check hostname or NATS connectivity: {exc}[/yellow]"
+                    )
+                    raise typer.Exit(code=1) from exc
+                if not resp.ok:
+                    we = resp.worker_error
+                    if we:
+                        err_console.print(f"[red]{we.code}: {we.message}[/red]")
+                    else:
+                        err_console.print(f"[red]list failed: {resp.error}[/red]")
+                    raise typer.Exit(code=1)
+                data = resp.data or {}
+                models = data.get("models", [])
+                table = Table(title="llmCLI models")
+                table.add_column("name", style="cyan")
+                table.add_column("engine")
+                table.add_column("vram_gib")
+                table.add_column("running?")
+                for m in models:
+                    table.add_row(
+                        m.get("name", "?"),
+                        m.get("engine", "?"),
+                        str(m.get("vram_gib", "?")),
+                        "yes" if m.get("running") else "no",
+                    )
+                console.print(table)
+        finally:
+            await client.close()
+
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------

--- a/src/llmcli/cli/swap.py
+++ b/src/llmcli/cli/swap.py
@@ -1,90 +1,14 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import socket
-from datetime import datetime, timezone
-from pathlib import Path
 from typing import Optional
-from uuid import uuid4
 
 import typer
 
 from llmcli.cli._app import app, console, err_console
-
-
-# ---------------------------------------------------------------------------
-# NATS swap implementation (inline per DP2 consensus — no _nats_client.py)
-# ---------------------------------------------------------------------------
-
-
-async def _swap_via_nats(name: str, host: str, timeout: float, *, allow_anonymous: bool) -> None:
-    from nats.aio.client import Client as NATS  # type: ignore[import]
-    from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse
-    from roxabi_contracts.llm.subjects import SUBJECTS
-
-    nc = NATS()
-    creds_path = Path("~/.roxabi/llmcli/nkeys/operator.creds").expanduser()
-    from llmcli.config import apply_nats_env_from_config
-
-    apply_nats_env_from_config()
-    nats_url = os.environ.get("LLMCLI_NATS_URL", "nats://localhost:4222")
-    # Fail-closed: missing creds requires explicit --allow-anonymous flag to connect.
-    # Use --allow-anonymous for CI/dev only — do not use in production.
-    if not creds_path.exists() and not allow_anonymous:
-        err_console.print(
-            f"[red]NATS operator credentials not found at {creds_path}. "
-            f"Run lyra-acl genkeys (Slice 0) or pass "
-            f"--allow-anonymous to connect without credentials (CI/dev only).[/red]"
-        )
-        raise typer.Exit(code=1)
-    await nc.connect(
-        nats_url,
-        nkeys_seed_str=creds_path.read_text().strip() if creds_path.exists() else None,
-        inbox_prefix="_inbox.llm-operator",
-    )
-    try:
-        req = LifecycleRequest(
-            contract_version="1",
-            trace_id=uuid4().hex,
-            issued_at=datetime.now(timezone.utc).isoformat(),
-            request_id=uuid4().hex,
-            host=host,
-            op="swap",
-            model_name=name,
-        )
-        try:
-            msg = await nc.request(
-                SUBJECTS.lifecycle_swap,
-                req.model_dump_json().encode(),
-                timeout=timeout,
-            )
-        except Exception as exc:
-            err_console.print(f"[red]NATS unreachable or no worker responded: {exc}[/red]")
-            raise typer.Exit(code=1) from exc
-
-        resp = LifecycleResponse.model_validate_json(msg.data)
-        if not resp.ok:
-            we = resp.worker_error
-            if we:
-                err_console.print(f"[red]{we.code}: {we.message}[/red]")
-            else:
-                err_console.print(f"[red]swap failed: {resp.error}[/red]")
-            raise typer.Exit(code=1)
-
-        data = resp.data or {}
-        console.print(
-            f"OK swapped to {data.get('model', name)} "
-            f"(port={data.get('port', '?')}, "
-            f"vram={data.get('vram_used_mb', 0)}MB)"
-        )
-    finally:
-        await nc.drain()
-
-
-# ---------------------------------------------------------------------------
-# swap
-# ---------------------------------------------------------------------------
+from llmcli.cli._nats_client import NatsClient
+from roxabi_contracts.llm.subjects import SUBJECTS
 
 
 @app.command()
@@ -106,6 +30,11 @@ def swap(
         help="Connect to NATS without operator credentials. CI/dev only — do not use in production.",
         hidden=True,
     ),
+    fleet: bool = typer.Option(
+        False,
+        "--fleet",
+        help="Swap on all workers in the fleet.",
+    ),
 ) -> None:
     """Hot-swap the running model via NATS."""
     import llmcli.cli as _cli
@@ -117,11 +46,59 @@ def swap(
         err_console.print(f"[red]Unknown model '{name}'. Available: {available}[/red]")
         raise typer.Exit(code=1)
 
-    asyncio.run(
-        _swap_via_nats(
-            name,
-            host=host or socket.gethostname(),
-            timeout=timeout,
-            allow_anonymous=allow_anonymous,
-        )
-    )
+    async def _run() -> None:
+        client = NatsClient(allow_anonymous=allow_anonymous)
+        await client.connect()
+        try:
+            if fleet:
+                result = await client.request_fleet(
+                    SUBJECTS.lifecycle_swap, "swap", timeout, model_name=name
+                )
+                any_failed = False
+                for resp in result.responses:
+                    data = resp.data or {}
+                    console.print(
+                        f"OK {resp.host or '?'} swapped to {data.get('model', name)} "
+                        f"(port={data.get('port', '?')}, "
+                        f"vram={data.get('vram_used_mb', 0)}MB)"
+                    )
+                if result.errors:
+                    any_failed = True
+                    for h, we in result.errors:
+                        err_console.print(f"[red]{h}: {we.code} - {we.message}[/red]")
+                if result.timeout_reached and not result.responses:
+                    err_console.print("[yellow]Fleet swap timed out with no responses.[/yellow]")
+                    any_failed = True
+                if any_failed:
+                    raise typer.Exit(code=1)
+            else:
+                try:
+                    resp = await client.request(
+                        SUBJECTS.lifecycle_swap,
+                        "swap",
+                        host or socket.gethostname(),
+                        timeout,
+                        model_name=name,
+                    )
+                except Exception as exc:
+                    err_console.print(f"[red]NATS unreachable or no worker responded: {exc}[/red]")
+                    raise typer.Exit(code=1) from exc
+
+                if not resp.ok:
+                    we = resp.worker_error
+                    if we:
+                        err_console.print(f"[red]{we.code}: {we.message}[/red]")
+                    else:
+                        err_console.print(f"[red]swap failed: {resp.error}[/red]")
+                    raise typer.Exit(code=1)
+
+                data = resp.data or {}
+                console.print(
+                    f"OK swapped to {data.get('model', name)} "
+                    f"(port={data.get('port', '?')}, "
+                    f"vram={data.get('vram_used_mb', 0)}MB)"
+                )
+        finally:
+            await client.close()
+
+    asyncio.run(_run())

--- a/tests/cli/test_lifecycle_nats.py
+++ b/tests/cli/test_lifecycle_nats.py
@@ -11,6 +11,7 @@ Mirrors the patterns in tests/cli/test_swap_nats.py — monkeypatches
 
 from __future__ import annotations
 
+import asyncio
 import socket
 from datetime import datetime, timezone
 from pathlib import Path
@@ -46,20 +47,20 @@ flags    = []
 runner = CliRunner()
 
 
-def _make_ok(data: dict | None = None) -> bytes:
+def _make_ok(data: dict | None = None, host: str | None = None) -> bytes:
     resp = LifecycleResponse(
         contract_version="1",
         trace_id="trace-ok",
         issued_at=datetime.now(timezone.utc).isoformat(),
         request_id="req-ok",
         ok=True,
-        host=socket.gethostname(),
+        host=host or socket.gethostname(),
         data=data or {},
     )
     return resp.model_dump_json().encode()
 
 
-def _make_err(code: str, message: str) -> bytes:
+def _make_err(code: str, message: str, host: str | None = None) -> bytes:
     from roxabi_contracts.errors import WorkerError
 
     resp = LifecycleResponse(
@@ -68,7 +69,7 @@ def _make_err(code: str, message: str) -> bytes:
         issued_at=datetime.now(timezone.utc).isoformat(),
         request_id="req-err",
         ok=False,
-        host=socket.gethostname(),
+        host=host or socket.gethostname(),
         worker_error=WorkerError(code=code, message=message, retryable=False),
     )
     return resp.model_dump_json().encode()
@@ -92,6 +93,45 @@ class _FakeNATSClient:
 
 
 def _patch_nats(client: _FakeNATSClient):
+    return patch("nats.aio.client.Client", return_value=client)
+
+
+class _FakeNATSClientFleet:
+    """NATS client stub that yields pre-staged replies for request_fleet()."""
+
+    def __init__(self, replies: list[bytes]) -> None:
+        self._replies = replies
+        self._reply_idx = 0
+        self.published_subject: str | None = None
+        self.published_payload: bytes | None = None
+        self.connect = AsyncMock(return_value=None)
+        self.drain = AsyncMock(return_value=None)
+
+    def new_inbox(self):
+        return "_inbox.test.1"
+
+    async def subscribe(self, inbox):
+        client = self
+
+        class _Sub:
+            async def next_msg(self, timeout=10):
+                if client._reply_idx < len(client._replies):
+                    r = client._replies[client._reply_idx]
+                    client._reply_idx += 1
+                    return SimpleNamespace(data=r)
+                raise asyncio.TimeoutError
+
+            async def unsubscribe(self):
+                pass
+
+        return _Sub()
+
+    async def publish(self, subject, payload, reply=None):
+        self.published_subject = subject
+        self.published_payload = payload
+
+
+def _patch_nats_fleet(client: _FakeNATSClientFleet):
     return patch("nats.aio.client.Client", return_value=client)
 
 
@@ -183,6 +223,42 @@ class TestStatusCLI:
 # ---------------------------------------------------------------------------
 
 
+class TestStatusFleetCLI:
+    def test_status_fleet_shows_per_host_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        replies = [
+            _make_ok({"model": "qwen3-8b", "port": 8091, "vram_used_mb": 5120}, host="host-a"),
+            _make_ok({"model": "qwen3-4b", "port": 8092, "vram_used_mb": 2048}, host="host-b"),
+        ]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(app, ["status", "--fleet", "--allow-anonymous"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "host-a" in result.output
+        assert "host-b" in result.output
+        assert "qwen3-8b" in result.output
+        assert "qwen3-4b" in result.output
+        assert "8091" in result.output
+        assert "8092" in result.output
+        assert "5120" in result.output
+        assert "2048" in result.output
+
+    def test_status_fleet_errors_shown_separately(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        replies = [
+            _make_ok({"model": "qwen3-8b", "port": 8091, "vram_used_mb": 5120}, host="host-a"),
+            _make_err("llm.no_engine", "no engine running", host="host-b"),
+        ]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(app, ["status", "--fleet", "--allow-anonymous"], catch_exceptions=False)
+        assert result.exit_code == 0
+        combined = result.output + (result.stderr or "")
+        assert "host-a" in result.output
+        assert "llm.no_engine" in combined
+        assert "no engine running" in combined
+
+
 class TestListCLI:
     def test_ok_exits_zero_and_publishes(
         self, fake_catalog, monkeypatch: pytest.MonkeyPatch
@@ -201,6 +277,38 @@ class TestListCLI:
 # ---------------------------------------------------------------------------
 # reload-catalog — spec N5/U5: broadcast (host=None)
 # ---------------------------------------------------------------------------
+
+
+class TestListFleetCLI:
+    def test_list_fleet_merges_models(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        replies = [
+            _make_ok(
+                {
+                    "models": [
+                        {"name": "qwen3-8b", "engine": "llamacpp", "vram_gib": 8.0, "running": True},
+                        {"name": "qwen3-4b", "engine": "llamacpp", "vram_gib": 4.0, "running": False},
+                    ]
+                },
+                host="host-a",
+            ),
+            _make_ok(
+                {
+                    "models": [
+                        {"name": "qwen3-4b", "engine": "llamacpp", "vram_gib": 4.0, "running": True},
+                    ]
+                },
+                host="host-b",
+            ),
+        ]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(app, ["list", "--fleet", "--allow-anonymous"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "qwen3-8b" in result.output
+        assert "qwen3-4b" in result.output
+        assert "host-a" in result.output
+        assert "host-b" in result.output
 
 
 class TestReloadCatalogCLI:

--- a/tests/cli/test_nats_client.py
+++ b/tests/cli/test_nats_client.py
@@ -1,0 +1,192 @@
+"""Tests for NatsClient.request_fleet() — issue #61, T6.
+
+Monkeypatches nats.aio.client.Client so no broker is required.
+request_fleet() is exercised directly against a fake NATS client that
+simulates multiple replies, timeouts, and error payloads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+from llmcli.cli._nats_client import FleetResult, NatsClient
+from roxabi_contracts.errors import WorkerError
+from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse
+
+
+def _make_ok(host: str, data: dict | None = None) -> bytes:
+    resp = LifecycleResponse(
+        contract_version="1",
+        trace_id="trace-ok",
+        issued_at=datetime.now(timezone.utc).isoformat(),
+        request_id="req-ok",
+        ok=True,
+        host=host,
+        data=data or {},
+    )
+    return resp.model_dump_json().encode()
+
+
+def _make_err(host: str, code: str, message: str) -> bytes:
+    resp = LifecycleResponse(
+        contract_version="1",
+        trace_id="trace-err",
+        issued_at=datetime.now(timezone.utc).isoformat(),
+        request_id="req-err",
+        ok=False,
+        host=host,
+        worker_error=WorkerError(code=code, message=message, retryable=False),
+    )
+    return resp.model_dump_json().encode()
+
+
+class _FakeNATSClientFleet:
+    """NATS client stub that yields pre-staged replies for request_fleet()."""
+
+    def __init__(self, replies: list[bytes]) -> None:
+        self._replies = replies
+        self._reply_idx = 0
+        self.published_subject: str | None = None
+        self.published_payload: bytes | None = None
+        self.connect = AsyncMock(return_value=None)
+        self.drain = AsyncMock(return_value=None)
+
+    def new_inbox(self):
+        return "_inbox.test.1"
+
+    async def subscribe(self, inbox):
+        client = self
+
+        class _Sub:
+            async def next_msg(self, timeout=10):
+                if client._reply_idx < len(client._replies):
+                    r = client._replies[client._reply_idx]
+                    client._reply_idx += 1
+                    return SimpleNamespace(data=r)
+                raise asyncio.TimeoutError
+
+            async def unsubscribe(self):
+                pass
+
+        return _Sub()
+
+    async def publish(self, subject, payload, reply=None):
+        self.published_subject = subject
+        self.published_payload = payload
+
+
+def _patch_nats_fleet(replies: list[bytes]):
+    client = _FakeNATSClientFleet(replies)
+    return patch("nats.aio.client.Client", return_value=client), client
+
+
+class TestNatsClientRequestFleet:
+    async def test_collects_multiple_replies(self):
+        # Arrange
+        replies = [
+            _make_ok("host-a", {"model": "qwen3-8b", "port": 8091, "vram_used_mb": 5120}),
+            _make_ok("host-b", {"model": "qwen3-4b", "port": 8092, "vram_used_mb": 2048}),
+        ]
+        patcher, fake = _patch_nats_fleet(replies)
+
+        # Act
+        with patcher:
+            client = NatsClient(allow_anonymous=True)
+            await client.connect()
+            result = await client.request_fleet("test.subject", "status", timeout=5.0)
+
+        # Assert
+        assert isinstance(result, FleetResult)
+        assert len(result.responses) == 2
+        assert result.responses[0].host == "host-a"
+        assert result.responses[1].host == "host-b"
+        assert result.errors == []
+        assert result.elapsed_ms > 0
+        assert fake.published_subject == "test.subject"
+
+    async def test_timeout_no_replies(self):
+        # Arrange
+        patcher, fake = _patch_nats_fleet([])
+
+        # Act
+        with patcher:
+            client = NatsClient(allow_anonymous=True)
+            await client.connect()
+            result = await client.request_fleet("test.subject", "status", timeout=0.1)
+
+        # Assert
+        assert result.responses == []
+        assert result.timeout_reached is True
+        assert result.errors == []
+
+    async def test_error_replies_added_to_errors(self):
+        # Arrange
+        replies = [
+            _make_ok("host-a", {"model": "qwen3-8b"}),
+            _make_err("host-b", "llm.no_engine", "no engine running"),
+        ]
+        patcher, fake = _patch_nats_fleet(replies)
+
+        # Act
+        with patcher:
+            client = NatsClient(allow_anonymous=True)
+            await client.connect()
+            result = await client.request_fleet("test.subject", "status", timeout=5.0)
+
+        # Assert
+        assert len(result.responses) == 1
+        assert result.responses[0].host == "host-a"
+        assert len(result.errors) == 1
+        host, we = result.errors[0]
+        assert host == "host-b"
+        assert we.code == "llm.no_engine"
+        assert we.message == "no engine running"
+
+    async def test_mixed_replies(self):
+        # Arrange
+        replies = [
+            _make_ok("host-a", {"model": "qwen3-8b"}),
+            _make_err("host-b", "llm.no_engine", "no engine running"),
+            _make_ok("host-c", {"model": "qwen3-4b"}),
+        ]
+        patcher, fake = _patch_nats_fleet(replies)
+
+        # Act
+        with patcher:
+            client = NatsClient(allow_anonymous=True)
+            await client.connect()
+            result = await client.request_fleet("test.subject", "status", timeout=5.0)
+
+        # Assert
+        assert len(result.responses) == 2
+        assert len(result.errors) == 1
+        assert fake.published_subject == "test.subject"
+        assert fake.published_payload is not None
+        req = LifecycleRequest.model_validate_json(fake.published_payload)
+        assert req.host is None
+        assert req.op == "status"
+
+    async def test_invalid_reply_skipped(self):
+        # Arrange — malformed JSON in the middle should be silently dropped
+        replies = [
+            _make_ok("host-a", {"model": "qwen3-8b"}),
+            b"not-valid-json",
+            _make_ok("host-c", {"model": "qwen3-4b"}),
+        ]
+        patcher, fake = _patch_nats_fleet(replies)
+
+        # Act
+        with patcher:
+            client = NatsClient(allow_anonymous=True)
+            await client.connect()
+            result = await client.request_fleet("test.subject", "status", timeout=5.0)
+
+        # Assert — only the two valid replies are collected
+        assert len(result.responses) == 2
+        assert result.responses[0].host == "host-a"
+        assert result.responses[1].host == "host-c"
+        assert result.errors == []

--- a/tests/cli/test_swap_nats.py
+++ b/tests/cli/test_swap_nats.py
@@ -22,6 +22,7 @@ causes these tests to fail — nc.request would never be called.
 
 from __future__ import annotations
 
+import asyncio
 import socket
 from datetime import datetime, timezone
 from pathlib import Path
@@ -69,7 +70,7 @@ flags    = []
 runner = CliRunner()
 
 
-def _make_ok_response(model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000) -> bytes:
+def _make_ok_response(model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000, host: str | None = None) -> bytes:
     """Build a serialised LifecycleResponse(ok=True) reply."""
     resp = LifecycleResponse(
         contract_version="1",
@@ -77,13 +78,13 @@ def _make_ok_response(model_name: str = "qwen3-8b", port: int = 8091, vram: int 
         issued_at=datetime.now(timezone.utc).isoformat(),
         request_id="req-ok",
         ok=True,
-        host=socket.gethostname(),
+        host=host or socket.gethostname(),
         data={"model": model_name, "port": port, "vram_used_mb": vram},
     )
     return resp.model_dump_json().encode()
 
 
-def _make_err_response(code: str, message: str) -> bytes:
+def _make_err_response(code: str, message: str, host: str | None = None) -> bytes:
     """Build a serialised LifecycleResponse(ok=False) error reply."""
     from roxabi_contracts.errors import WorkerError
 
@@ -93,7 +94,7 @@ def _make_err_response(code: str, message: str) -> bytes:
         issued_at=datetime.now(timezone.utc).isoformat(),
         request_id="req-err",
         ok=False,
-        host=socket.gethostname(),
+        host=host or socket.gethostname(),
         worker_error=WorkerError(code=code, message=message, retryable=False),
     )
     return resp.model_dump_json().encode()
@@ -135,6 +136,45 @@ def _nats_class_patch(nats_client: _FakeNATSClient):
     We patch the class so NATS() → nats_client.
     """
     return patch("nats.aio.client.Client", return_value=nats_client)
+
+
+class _FakeNATSClientFleet:
+    """NATS client stub that yields pre-staged replies for request_fleet()."""
+
+    def __init__(self, replies: list[bytes]) -> None:
+        self._replies = replies
+        self._reply_idx = 0
+        self.published_subject: str | None = None
+        self.published_payload: bytes | None = None
+        self.connect = AsyncMock(return_value=None)
+        self.drain = AsyncMock(return_value=None)
+
+    def new_inbox(self):
+        return "_inbox.test.1"
+
+    async def subscribe(self, inbox):
+        client = self
+
+        class _Sub:
+            async def next_msg(self, timeout=10):
+                if client._reply_idx < len(client._replies):
+                    r = client._replies[client._reply_idx]
+                    client._reply_idx += 1
+                    return SimpleNamespace(data=r)
+                raise asyncio.TimeoutError
+
+            async def unsubscribe(self):
+                pass
+
+        return _Sub()
+
+    async def publish(self, subject, payload, reply=None):
+        self.published_subject = subject
+        self.published_payload = payload
+
+
+def _patch_nats_fleet(client: _FakeNATSClientFleet):
+    return patch("nats.aio.client.Client", return_value=client)
 
 
 # ---------------------------------------------------------------------------
@@ -349,3 +389,68 @@ class TestSwapNatsFlag:
         assert nats_client.published_subject is None, (
             "nc.request must NOT be called when creds are missing without --allow-anonymous"
         )
+
+
+class TestSwapFleetCLI:
+    """Fleet-wide swap via --fleet flag — issue #61, T6."""
+
+    def test_swap_fleet_broadcasts_to_all_workers(
+        self, fake_catalog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--fleet causes request_fleet with host='*' and publishes on lifecycle_swap."""
+        replies = [_make_ok_response("qwen3-8b", port=8091, vram=5000, host="host-a")]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(
+                app, ["swap", "qwen3-8b", "--fleet", "--allow-anonymous"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert nc.published_subject == SUBJECTS.lifecycle_swap
+        assert nc.published_payload is not None
+        req = LifecycleRequest.model_validate_json(nc.published_payload)
+        assert req.host is None
+        assert req.model_name == "qwen3-8b"
+
+    def test_swap_fleet_shows_per_host_results(
+        self, fake_catalog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multiple OK replies print per-host swap confirmation lines."""
+        replies = [
+            _make_ok_response("qwen3-8b", port=8091, vram=5000, host="host-a"),
+            _make_ok_response("qwen3-8b", port=8091, vram=5000, host="host-b"),
+        ]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(
+                app, ["swap", "qwen3-8b", "--fleet", "--allow-anonymous"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert "host-a" in result.output
+        assert "host-b" in result.output
+        assert "qwen3-8b" in result.output
+        assert "OK" in result.output
+
+    def test_swap_fleet_exits_nonzero_on_any_failure(
+        self, fake_catalog, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mixed replies (OK + error) cause exit code 1 with error details in stderr."""
+        replies = [
+            _make_ok_response("qwen3-8b", port=8091, vram=5000, host="host-a"),
+            _make_err_response("llm.no_engine", "no engine running", host="host-b"),
+        ]
+        nc = _FakeNATSClientFleet(replies)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+        with _patch_nats_fleet(nc):
+            result = runner.invoke(app, ["swap", "qwen3-8b", "--fleet", "--allow-anonymous"])
+
+        assert result.exit_code == 1
+        combined = result.output + (result.stderr or "")
+        assert "llm.no_engine" in combined
+        assert "no engine running" in combined


### PR DESCRIPTION
## Summary
- Extract `cli/_nats_client.py` as reusable NATS client with fleet broadcast + reply aggregation
- Add `--fleet` flag to `status`, `list`, and `swap` commands
- Migrate `swap.py` from inline NATS block to shared helper
- Preserve single-host default behaviour unchanged

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #61: feat(cli): --fleet lifecycle ops + extract cli/_nats_client.py helper | OPEN |
| Analysis | — | Absent |
| Spec | [61-fleet-lifecycle-ops-spec.mdx](artifacts/specs/61-fleet-lifecycle-ops-spec.mdx) | Present |
| Implementation | 1 commit on `feat/61-fleet-lifecycle-ops` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (11 new) | Passed |

## Test Plan
- [ ] `llmcli status --fleet` shows per-host table across fleet
- [ ] `llmcli list --fleet` merges model lists from all workers
- [ ] `llmcli swap <name> --fleet` broadcasts to all workers
- [ ] Single-host `status`/`list`/`swap` remain backward-compatible

Closes #61

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`