### PR TITLE
chore(nats): cleanup follow-ups from #21 (A-F)

### DIFF
--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -22,6 +22,7 @@ UserNS=keep-id:uid=1502,gid=1502
 EnvironmentFile=%h/.roxabi/llmcli/env/worker.env
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/llmcli-nats-worker.seed
 Environment=LLMCLI_LITELLM_URL=http://localhost:18091/v1
+# Override the model per host: add Environment=LLMCLI_MODEL=<catalog-name> in a drop-in
 Exec=llm --model qwen3-4b
 HealthCmd=pgrep -f "llmcli nats-serve"
 HealthInterval=30s

--- a/docs/uid-registry.md
+++ b/docs/uid-registry.md
@@ -1,0 +1,9 @@
+# Container UID Registry
+
+Roxabi project container UIDs — assigned statically to avoid collisions across Quadlet services.
+
+| Project    | UID  | Purpose                              |
+|------------|------|--------------------------------------|
+| lyra       | 1500 | Lyra hub + satellite containers      |
+| voicecli   | 1501 | VoiceCLI STT/TTS worker containers   |
+| llmcli     | 1502 | llmCLI proxy + NATS worker containers |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ dev = [
     "pre-commit>=4.5.1",
     "pip-licenses>=5.5.1",
     "import-linter>=2.1",
+    "roxabi-nats>=0.4.1",
+    "roxabi-contracts>=0.4.0",
 ]
 vllm = [
     "vllm>=0.6.0",

--- a/src/llmcli/cli/lifecycle.py
+++ b/src/llmcli/cli/lifecycle.py
@@ -117,9 +117,7 @@ def status(
         await client.connect()
         try:
             if fleet:
-                result = await client.request_fleet(
-                    SUBJECTS.lifecycle_status, "status", timeout
-                )
+                result = await client.request_fleet(SUBJECTS.lifecycle_status, "status", timeout)
                 if result.responses:
                     table = Table(title="Fleet status")
                     table.add_column("host", style="cyan")

--- a/src/llmcli/cli/lifecycle_extra.py
+++ b/src/llmcli/cli/lifecycle_extra.py
@@ -52,9 +52,7 @@ def list_models(
         await client.connect()
         try:
             if fleet:
-                result = await client.request_fleet(
-                    SUBJECTS.lifecycle_list, "list", timeout
-                )
+                result = await client.request_fleet(SUBJECTS.lifecycle_list, "list", timeout)
                 # Merge model lists from all hosts
                 models: dict[str, dict] = {}
                 for resp in result.responses:

--- a/src/llmcli/cli_nats.py
+++ b/src/llmcli/cli_nats.py
@@ -53,7 +53,12 @@ def nats_serve_llm(
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("llmcli.nats-serve")
 
-    nats_url = os.environ.get("LLMCLI_NATS_URL") or os.environ.get("NATS_URL")
+    nats_url = os.environ.get("LLMCLI_NATS_URL")
+    if not nats_url:
+        legacy = os.environ.get("NATS_URL")
+        if legacy:
+            log.warning("NATS_URL is deprecated; set LLMCLI_NATS_URL instead")
+            nats_url = legacy
     if not nats_url:
         log.error("LLMCLI_NATS_URL (or legacy NATS_URL) env var is required")
         raise typer.Exit(2)

--- a/src/llmcli/cli_nats.py
+++ b/src/llmcli/cli_nats.py
@@ -42,7 +42,7 @@ def nats_serve_llm(
 ) -> None:
     """Subscribe to lyra.llm.generate.request and serve LLM completions.
 
-    Reads NATS_URL from the environment.
+    Reads LLMCLI_NATS_URL from the environment (falls back to legacy NATS_URL).
     """
     import asyncio
     import logging

--- a/src/llmcli/nats/_generation.py
+++ b/src/llmcli/nats/_generation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
     from nats.aio.msg import Msg as NatsMsg
 
 log = logging.getLogger(__name__)
+
+_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 class GenerationMixin:
@@ -56,25 +59,47 @@ class GenerationMixin:
     def _make_worker_error(code: str, msg: str, retryable: bool) -> WorkerError:
         return WorkerError(code=code, message=msg, retryable=retryable)
 
-    async def _err(self, msg, payload: dict, worker_error: WorkerError) -> None:
-        safe_payload = {
-            "request_id": str(payload.get("request_id", "unknown"))[:128],
-            "trace_id": payload.get("trace_id"),
-        }
+    @staticmethod
+    def _build_error_response(payload: dict, we: WorkerError, *, stream: bool) -> bytes:
+        """Build and serialize an error envelope (LlmChunkEvent or LlmResponse).
+
+        Sanitizes request_id to prevent Pydantic validation errors from illegal chars.
+        """
+        rid = str(payload.get("request_id", "unknown"))[:128]
+        safe_id = rid if _REQUEST_ID_RE.match(rid) else "unknown"
+        trace_id = payload.get("trace_id") or safe_id
         # builders.py does not accept worker_error= — build envelope manually.
-        data = (
+        if stream:
+            return (
+                LlmChunkEvent(
+                    contract_version=CONTRACT_VERSION,
+                    trace_id=trace_id,
+                    issued_at=datetime.now(timezone.utc),
+                    request_id=safe_id,
+                    done=True,
+                    is_error=True,
+                    error=we.message,
+                    worker_error=we,
+                )
+                .model_dump_json(exclude_none=True)
+                .encode()
+            )
+        return (
             LlmResponse(
                 contract_version=CONTRACT_VERSION,
-                trace_id=safe_payload.get("trace_id") or safe_payload["request_id"],
+                trace_id=trace_id,
                 issued_at=datetime.now(timezone.utc),
-                request_id=safe_payload["request_id"],
+                request_id=safe_id,
                 ok=False,
-                error=worker_error.message,
-                worker_error=worker_error,
+                error=we.message,
+                worker_error=we,
             )
             .model_dump_json(exclude_none=True)
             .encode()
         )
+
+    async def _err(self, msg, payload: dict, worker_error: WorkerError) -> None:
+        data = self._build_error_response(payload, worker_error, stream=False)
         await self.reply(msg, data)
 
     # ------------------------------------------------------------------
@@ -133,22 +158,10 @@ class GenerationMixin:
         )
         if stream and msg.reply and self._nc:
             try:
-                # builders.py does not accept worker_error= — build envelope manually.
-                data = (
-                    LlmChunkEvent(
-                        contract_version=CONTRACT_VERSION,
-                        trace_id=payload.get("trace_id") or request_id,
-                        issued_at=datetime.now(timezone.utc),
-                        request_id=request_id,
-                        done=True,
-                        is_error=True,
-                        error=we.message,
-                        worker_error=we,
-                    )
-                    .model_dump_json(exclude_none=True)
-                    .encode()
+                await self._nc.publish(
+                    msg.reply,
+                    self._build_error_response(payload, we, stream=True),
                 )
-                await self._nc.publish(msg.reply, data)
             except Exception:  # noqa: BLE001
                 pass
         else:
@@ -191,6 +204,11 @@ class GenerationMixin:
 
         if chunk_count == 0 and not saw_done:
             raise json.JSONDecodeError("no parseable SSE chunks", "", 0)
+        if chunk_count == 0 and saw_done:
+            log.warning(
+                "llm_adapter: empty response (only [DONE]) request_id=%s",
+                payload.get("request_id", "unknown"),
+            )
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         if msg.reply:

--- a/src/llmcli/nats/llm_adapter.py
+++ b/src/llmcli/nats/llm_adapter.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from concurrent.futures import ThreadPoolExecutor
 
 import httpx
@@ -24,13 +23,11 @@ from roxabi_nats.adapter_base import NatsAdapterBase
 
 from llmcli.config import load as load_catalog
 from llmcli.gpu import VRAMMonitor
-from llmcli.nats._generation import GenerationMixin
+from llmcli.nats._generation import GenerationMixin, _REQUEST_ID_RE
 from llmcli.nats._lifecycle import LIFECYCLE_SUBJECTS, LifecycleMixin
 from roxabi_contracts.llm import SUBJECTS
 
 log = logging.getLogger(__name__)
-
-_REQUEST_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
 class LlmNatsAdapter(LifecycleMixin, GenerationMixin, NatsAdapterBase):

--- a/tests/cli/test_lifecycle_nats.py
+++ b/tests/cli/test_lifecycle_nats.py
@@ -347,3 +347,40 @@ class TestReloadCatalogCLI:
         assert nc.published_payload is not None
         req = LifecycleRequest.model_validate_json(nc.published_payload)
         assert req.host is None, f"reload-catalog must broadcast (host=None), got: {req.host!r}"
+
+
+class TestNatsServeLLMEnvDeprecation:
+    """Deprecation warning for legacy NATS_URL → LLMCLI_NATS_URL."""
+
+    def test_legacy_nats_url_emits_deprecation_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When NATS_URL is set and LLMCLI_NATS_URL is absent, a deprecation
+        warning must be logged before the adapter starts.  No broker required —
+        asyncio.run is patched to prevent actual NATS connection."""
+        import logging
+
+        monkeypatch.setenv("NATS_URL", "nats://test:4222")
+        monkeypatch.delenv("LLMCLI_NATS_URL", raising=False)
+
+        with (
+            patch("asyncio.run", return_value=None),
+            caplog.at_level(logging.WARNING, logger="llmcli.nats-serve"),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "nats-serve",
+                    "llm",
+                    "--model",
+                    "qwen3-8b",
+                    "--litellm-key",
+                    "test-key",
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        deprecation_msgs = [r.message for r in caplog.records if "deprecated" in r.message.lower()]
+        assert deprecation_msgs, "Expected deprecation warning for NATS_URL, got none"
+        assert any("LLMCLI_NATS_URL" in m for m in deprecation_msgs)

--- a/tests/cli/test_swap_nats.py
+++ b/tests/cli/test_swap_nats.py
@@ -70,7 +70,9 @@ flags    = []
 runner = CliRunner()
 
 
-def _make_ok_response(model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000, host: str | None = None) -> bytes:
+def _make_ok_response(
+    model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000, host: str | None = None
+) -> bytes:
     """Build a serialised LifecycleResponse(ok=True) reply."""
     resp = LifecycleResponse(
         contract_version="1",

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -22,7 +22,8 @@ async def test_request_parse_invalid_request_id_emits_transport_parse(
     adapter, fake_msg_factory, make_request_payload
 ):
     # Use a 129-char all-valid-char request_id: fails _REQUEST_ID_RE (max 128 chars)
-    # but _err slices it to [:128] before building LlmResponse, so serialization succeeds.
+    # but _build_error_response slices to [:128] then re-validates via _REQUEST_ID_RE,
+    # falling back to "unknown" for illegal chars; serialization always succeeds.
     # Using "../../bad path"-style IDs would crash LlmResponse Pydantic validation.
     payload = make_request_payload(stream=False, request_id="a" * 129)
     msg = fake_msg_factory(payload)
@@ -313,3 +314,40 @@ def test_heartbeat_vram_used_zero_when_sample_returns_zeros(adapter, monkeypatch
 
     assert p["vram_free_mb"] == 0
     assert p["vram_used_mb"] == 0
+
+
+# ---------- _generation.py — empty-response warning (saw_done=True, chunk_count=0) ----------
+
+
+@pytest.mark.asyncio
+async def test_stream_only_done_emits_empty_response_warning(
+    adapter, fake_msg_factory, make_request_payload, caplog
+):
+    """A stream that yields only data: [DONE] (no content chunks) must log a warning.
+
+    This exercises the ``chunk_count == 0 and saw_done`` branch in
+    ``_generation._stream_response``.
+    """
+    import logging
+
+    payload = make_request_payload(stream=True)
+    msg = fake_msg_factory(payload)
+
+    async def _done_only():
+        yield "data: [DONE]"
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.aiter_lines = lambda: _done_only()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    adapter._client.stream.return_value = cm
+
+    with caplog.at_level(logging.WARNING, logger="llmcli.nats._generation"):
+        await adapter.handle(msg, payload)
+
+    warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("empty response" in m for m in warning_msgs), (
+        f"Expected 'empty response' warning, got: {warning_msgs}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1235,6 +1235,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "roxabi-contracts" },
+    { name = "roxabi-nats" },
     { name = "ruff" },
 ]
 vllm = [
@@ -1268,6 +1270,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout", specifier = ">=0.5" },
+    { name = "roxabi-contracts", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
+    { name = "roxabi-nats", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "ruff" },
 ]
 vllm = [{ name = "vllm", specifier = ">=0.6.0" }]


### PR DESCRIPTION
## Summary

- **A** — Extracted `_build_error_response(payload, we, *, stream)` helper in `_generation.py`; both `_err()` and the streaming-error tail now call it, eliminating manual envelope duplication.
- **B** — `_build_error_response` sanitizes `request_id` with `_REQUEST_ID_RE` (pattern imported as module-level constant in `_generation.py`) so illegal chars like `'../../bad'` fall back to `"unknown"` instead of propagating to Pydantic.
- **C** — `cli_nats.py`: split `LLMCLI_NATS_URL`/`NATS_URL` fallback into explicit branches; `log.warning` fires when the deprecated `NATS_URL` path is taken.
- **D** — Added `log.warning` for `chunk_count == 0 and saw_done` (LiteLLM returned only `[DONE]`, empty body) in `_stream_response`.
- **E** — Created `docs/uid-registry.md` with the three assigned container UIDs (lyra=1500, voicecli=1501, llmcli=1502).
- **F** — Added operator drop-in comment above `Exec=` line in `deploy/quadlet/llmcli-nats-worker.container`.

## Test plan

- [ ] `uv run ruff format . && uv run ruff check --fix .` — passes (verified locally)
- [ ] Full test suite requires `roxabi_contracts` (not available in isolated worktree); skipped per infra-dependency policy
- [ ] Smoke: `LLMCLI_NATS_URL=nats://... uv run llmcli nats-serve llm --model ...` should start without warning; `NATS_URL=nats://...` (legacy) should emit deprecation warning

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)