### PR TITLE
refactor(engine): lift _WAIT_TIMEOUT into ModelSpec.startup_timeout_s

### DIFF
--- a/llmcli.example.toml
+++ b/llmcli.example.toml
@@ -8,6 +8,9 @@
 #
 # Per-machine filter: set machines=["hostname"] on any spec to restrict it to
 # specific hosts. Empty list (machines=[]) means all hosts — the default.
+#
+# Startup timeout: override the engine default per model spec.
+#   # startup_timeout_s = 120  # override engine default (llamacpp=60s, vllm=180s)
 
 [host]
 bind              = "0.0.0.0"

--- a/src/llmcli/cli/lifecycle.py
+++ b/src/llmcli/cli/lifecycle.py
@@ -117,9 +117,7 @@ def status(
         await client.connect()
         try:
             if fleet:
-                result = await client.request_fleet(
-                    SUBJECTS.lifecycle_status, "status", timeout
-                )
+                result = await client.request_fleet(SUBJECTS.lifecycle_status, "status", timeout)
                 if result.responses:
                     table = Table(title="Fleet status")
                     table.add_column("host", style="cyan")

--- a/src/llmcli/cli/lifecycle_extra.py
+++ b/src/llmcli/cli/lifecycle_extra.py
@@ -52,9 +52,7 @@ def list_models(
         await client.connect()
         try:
             if fleet:
-                result = await client.request_fleet(
-                    SUBJECTS.lifecycle_list, "list", timeout
-                )
+                result = await client.request_fleet(SUBJECTS.lifecycle_list, "list", timeout)
                 # Merge model lists from all hosts
                 models: dict[str, dict] = {}
                 for resp in result.responses:

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -19,7 +19,9 @@ DEFAULT_CONFIG_PATH = Path(
 
 _VALID_PROTOCOLS = frozenset({"openai", "anthropic"})
 _LOCAL_ENGINES = frozenset({"llamacpp", "llamacpp_tq3", "vllm"})
-_REMOTE_LOCAL_FIELDS = frozenset({"repo", "file", "port", "vram_gib", "flags", "mmproj"})
+_REMOTE_LOCAL_FIELDS = frozenset(
+    {"repo", "file", "port", "vram_gib", "flags", "mmproj", "startup_timeout_s"}
+)
 
 
 @dataclass(frozen=True)

--- a/src/llmcli/config.py
+++ b/src/llmcli/config.py
@@ -47,6 +47,8 @@ class ModelSpec:
     provider: str = ""
     model_id: str = ""
     protocol: str = "openai"
+    # Startup timeout override — None = use engine default (llamacpp=60s, vllm=180s)
+    startup_timeout_s: int | None = None
     # Per-machine filter — empty = all hosts
     machines: list[str] = field(default_factory=list)
 

--- a/src/llmcli/engines/llamacpp.py
+++ b/src/llmcli/engines/llamacpp.py
@@ -103,7 +103,12 @@ class LlamaCppEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc, spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT, "llama-server")
+        _wait_ready(
+            base_url,
+            proc,
+            spec.startup_timeout_s if spec.startup_timeout_s is not None else _DEFAULT_WAIT_TIMEOUT,
+            "llama-server",
+        )
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/src/llmcli/engines/llamacpp.py
+++ b/src/llmcli/engines/llamacpp.py
@@ -14,7 +14,7 @@ from ._common import _wait_ready, default_health
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_WAIT_TIMEOUT = 60  # seconds
+_DEFAULT_WAIT_TIMEOUT = 60  # seconds — fallback when ModelSpec.startup_timeout_s is None
 
 
 def _hf_hub_root() -> Path:
@@ -103,7 +103,7 @@ class LlamaCppEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc, _WAIT_TIMEOUT, "llama-server")
+        _wait_ready(base_url, proc, spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT, "llama-server")
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -14,8 +14,9 @@ from ._common import _wait_ready, default_health
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-_WAIT_TIMEOUT = (
+_DEFAULT_WAIT_TIMEOUT = (
     180  # vLLM needs longer: safetensors load + NVFP4 JIT compile can take 60–120 s on first start
+    # fallback when ModelSpec.startup_timeout_s is None
 )
 
 
@@ -50,7 +51,7 @@ class VLLMEngine:
         Raises:
             ImportError: when the vllm package is not installed.
             RuntimeError: when the process exits early or the health endpoint
-                does not become ready within _WAIT_TIMEOUT seconds.
+                does not become ready within _DEFAULT_WAIT_TIMEOUT seconds.
         """
         if shutil.which("vllm") is None:
             raise RuntimeError(
@@ -66,7 +67,7 @@ class VLLMEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, start_new_session=True)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc, _WAIT_TIMEOUT, "vllm serve")
+        _wait_ready(base_url, proc, spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT, "vllm serve")
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/src/llmcli/engines/vllm.py
+++ b/src/llmcli/engines/vllm.py
@@ -67,7 +67,12 @@ class VLLMEngine:
         cmd = self._build_cmd(spec)
         proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, start_new_session=True)  # noqa: S603
         base_url = f"http://localhost:{spec.port}/v1"
-        _wait_ready(base_url, proc, spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT, "vllm serve")
+        _wait_ready(
+            base_url,
+            proc,
+            spec.startup_timeout_s if spec.startup_timeout_s is not None else _DEFAULT_WAIT_TIMEOUT,
+            "vllm serve",
+        )
         return EngineInstance(
             pid=proc.pid,
             port=spec.port,

--- a/tests/cli/test_swap_nats.py
+++ b/tests/cli/test_swap_nats.py
@@ -70,7 +70,9 @@ flags    = []
 runner = CliRunner()
 
 
-def _make_ok_response(model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000, host: str | None = None) -> bytes:
+def _make_ok_response(
+    model_name: str = "qwen3-8b", port: int = 8091, vram: int = 5000, host: str | None = None
+) -> bytes:
     """Build a serialised LifecycleResponse(ok=True) reply."""
     resp = LifecycleResponse(
         contract_version="1",

--- a/tests/test_llamacpp.py
+++ b/tests/test_llamacpp.py
@@ -434,6 +434,56 @@ class TestEngineInstanceShape:
 
 
 # ---------------------------------------------------------------------------
+# 4b. startup_timeout_s forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestStartupTimeoutForwarding:
+    """start() must forward the correct timeout to _wait_ready."""
+
+    @pytest.mark.no_gpu
+    @pytest.mark.parametrize(
+        ("timeout_s", "expected_timeout"),
+        [
+            (30, 30),  # explicit value — must be forwarded as-is
+            (None, 60),  # None — must fall back to _DEFAULT_WAIT_TIMEOUT (60)
+        ],
+    )
+    def test_startup_timeout_forwarded_to_wait_ready(
+        self,
+        engine: LlamaCppEngine,
+        fake_hf_cache: Path,
+        timeout_s: int | None,
+        expected_timeout: int,
+    ) -> None:
+        """_wait_ready must receive the correct timeout regardless of spec.startup_timeout_s."""
+        spec = ModelSpec(
+            name="qwen3-8b-q4",
+            engine="llamacpp",
+            repo="bartowski/Qwen3-8B-GGUF",
+            file="Qwen3-8B-Q4_K_M.gguf",
+            port=8091,
+            vram_gib=5.5,
+            startup_timeout_s=timeout_s,
+        )
+        mock_proc = MagicMock()
+        mock_proc.pid = 99999
+
+        with (
+            patch("llmcli.engines.llamacpp.subprocess.Popen", return_value=mock_proc),
+            patch("llmcli.engines.llamacpp._wait_ready", return_value=None) as mock_wait,
+        ):
+            engine.start(spec)
+
+        mock_wait.assert_called_once()
+        _, _, actual_timeout, _ = mock_wait.call_args[0]
+        assert actual_timeout == expected_timeout, (
+            f"_wait_ready timeout must be {expected_timeout} when startup_timeout_s={timeout_s!r}, "
+            f"got {actual_timeout}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # 5. health() — HTTP probe
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `startup_timeout_s: int | None = None` to `ModelSpec` — optional, backward-compatible (existing TOML files get `None` → engine default unchanged)
- Renames `_WAIT_TIMEOUT` → `_DEFAULT_WAIT_TIMEOUT` in `engines/llamacpp.py` (60s) and `engines/vllm.py` (180s), clarifying they are fallbacks not hard limits
- Both `start()` methods now use `spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT`, enabling per-model override from the catalog

## Motivation (ADR-006)

Per-engine constants for the same start-stage parameter are an ADR-006 target-axis-trap: drift surface along the non-primary axis (engine type rather than lifecycle stage). The catalog (`ModelSpec`) owns operational config — per-engine constants become engine-specific fallbacks when the catalog field is absent.

## What changed

| File | Change |
|---|---|
| `src/llmcli/config.py` | `startup_timeout_s: int \| None = None` added to `ModelSpec` |
| `src/llmcli/engines/llamacpp.py` | `_WAIT_TIMEOUT` → `_DEFAULT_WAIT_TIMEOUT`; `start()` uses `spec.startup_timeout_s or _DEFAULT_WAIT_TIMEOUT` |
| `src/llmcli/engines/vllm.py` | same pattern |
| `llmcli.example.toml` | commented-out usage example added |

`engines/llamacpp_tq3.py` requires no change — it delegates fully to `LlamaCppEngine`.

## Test plan

- [ ] `uv run ruff format . && uv run ruff check --fix .` — clean
- [ ] `uv run pytest tests/ -q` (excluding pre-existing `roxabi_contracts` import failures) — 226 passed, 1 skipped

Closes #88