### PR TITLE
feat(engine): auto-pull missing GGUF via hf_hub_download

### DIFF
--- a/src/llmcli/engines/llamacpp.py
+++ b/src/llmcli/engines/llamacpp.py
@@ -10,6 +10,11 @@ from ..config import ModelSpec
 from ..engine import EngineInstance
 from ._common import _wait_ready, default_health
 
+try:
+    from huggingface_hub import hf_hub_download
+except ImportError:  # pragma: no cover
+    hf_hub_download = None  # type: ignore[assignment]
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -48,8 +53,8 @@ class LlamaCppEngine:
         Searches under ``<HF_HOME>/hub/models--<org>--<repo>/snapshots/``
         for any revision that contains ``spec.file``.
 
-        Raises FileNotFoundError with a helpful hint when the model has not
-        been pulled yet.
+        If the file is not found, automatically downloads it via
+        ``hf_hub_download`` and returns the resolved local path.
         """
         hub = _hf_hub_root()
         repo_dir = hub / _repo_to_dir_name(spec.repo)
@@ -61,10 +66,18 @@ class LlamaCppEngine:
                 if candidate.is_file():
                     return candidate
 
-        raise FileNotFoundError(
-            f"GGUF file '{spec.file}' not found in HF hub cache for repo '{spec.repo}'.\n"
-            f"Run `llmcli pull {spec.name}` to download the model first."
+        # Not cached — auto-pull.
+        if hf_hub_download is None:
+            raise FileNotFoundError(
+                f"GGUF file '{spec.file}' not found in HF hub cache for repo '{spec.repo}'.\n"
+                f"Run `llmcli pull {spec.name}` to download the model first."
+            )
+        path = hf_hub_download(
+            repo_id=spec.repo,
+            filename=spec.file,
+            cache_dir=str(_hf_hub_root()),
         )
+        return Path(path)
 
     # ------------------------------------------------------------------
     # Command builder

--- a/tests/test_llamacpp.py
+++ b/tests/test_llamacpp.py
@@ -194,27 +194,30 @@ class TestGgufPathResolution:
         )
 
     @pytest.mark.no_gpu
-    def test_missing_gguf_raises_file_not_found(
+    def test_missing_gguf_auto_pulls(
         self,
         engine: LlamaCppEngine,
         spec: ModelSpec,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If the GGUF is not cached, the engine must raise FileNotFoundError (not a silent path)."""
+        """If the GGUF is not cached, the engine must auto-pull via hf_hub_download."""
         # Point HF_HOME at an empty directory — no model files present.
         empty = tmp_path / "empty_hub"
         empty.mkdir()
         monkeypatch.setenv("HF_HOME", str(empty))
 
-        helper = getattr(engine, "_gguf_path", None) or getattr(engine, "gguf_path", None)
-        if helper is None:
-            # Fallback: start() should surface the missing file.
-            with pytest.raises((FileNotFoundError, NotImplementedError)):
-                engine.start(spec)
-        else:
-            with pytest.raises(FileNotFoundError):
-                helper(spec)
+        with patch(
+            "llmcli.engines.llamacpp.hf_hub_download",
+            return_value=str(empty / "hub" / "models--bartowski--Qwen3-8B-GGUF" / "snapshots" / "main" / spec.file),
+        ) as mock_pull:
+            result = engine._gguf_path(spec)
+            mock_pull.assert_called_once_with(
+                repo_id=spec.repo,
+                filename=spec.file,
+                cache_dir=str(empty / "hub"),
+            )
+            assert str(result).endswith(spec.file)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `LlamaCppEngine._gguf_path()` now auto-pulls missing GGUF files via `hf_hub_download()` instead of raising `FileNotFoundError`
- Prevents NATS worker crash-loop on swap requests for uncached models
- `LlamaCppTQ3Engine` inherits the fix automatically

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #93: Model auto-pull on missing GGUF | Open |
| Implementation | 1 commit on `feat/93-model-auto-pull-on-missing-gguf` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (414 passed, 11 skipped) | Passed |

## Test Plan
- [ ] Deploy `llmcli-nats-worker` on M₂ and trigger a swap for an uncached model
- [ ] Verify the model downloads automatically and the swap succeeds

Closes #93

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`