### PR TITLE
feat(auth): xAI OAuth proxy — SuperGrok credentials forwarder (#99)

### DIFF
--- a/artifacts/frames/99-xai-oauth-proxy-frame.mdx
+++ b/artifacts/frames/99-xai-oauth-proxy-frame.mdx
@@ -1,0 +1,57 @@
+---
+title: feat(auth) — xAI OAuth proxy à la Hermes (SuperGrok credentials forwarder)
+issue: 99
+status: approved
+tier: F-lite
+date: 2026-05-27
+---
+
+## Problem
+
+llmCLI's LiteLLM proxy currently routes cloud requests using static API keys (`FIREWORKS_API_KEY`, `ANTHROPIC_API_KEY`, `NVIDIA_API_KEY` — see `src/llmcli/support/providers.py`). xAI/Grok would normally fit this pattern via `XAI_API_KEY` against the paid xAI API — except the user already pays for a **SuperGrok subscription**, whose credits are accessible **only via OAuth-issued bearer tokens with limited lifetime**. LiteLLM does not natively support OAuth bearer rotation; it expects static keys at config-load time.
+
+Without OAuth support in llmCLI, two paths exist: (a) pay xAI twice (subscription + API credits), or (b) skip Grok in the local LLM mesh. Neither is acceptable.
+
+Hermes solved this with a small aiohttp forwarder (`hermes_cli/proxy/`) sibling service that swaps `Authorization` headers per request and refreshes tokens lazily on 401. Porting the pattern unlocks SuperGrok now AND lays the substrate for future OAuth providers (Gemini OAuth, Anthropic Console OAuth, Qwen OAuth).
+
+## Who
+
+- **Primary:** sole operator consuming Grok-4 via SuperGrok subscription from lyra agents + claude-code aliases (`ccl`/`ccp`) routed through the LiteLLM proxy on M₁ (`roxabituwer:18091`).
+- **Secondary:** future Roxabi consumers of any OAuth-issued LLM credential — the `auth/` + `proxy_forwarder/` modules are the reusable substrate when Gemini / Anthropic Console / Qwen OAuth get added next.
+
+## Constraints
+
+- **Single-account, single-host:** M₁ only (24/7 cloud relay). M₂ off-able sans préavis → cannot host credentials that must be live for agents.
+- **Quadlet + `roxabi.network`:** forwarder must join the existing podman bridge so the `llmcli` LiteLLM container reaches it by DNS name (`http://llmcli-xai-forwarder:18645`), not via host loopback.
+- **Credentials writable from container:** OAuth refresh writes a new `access_token` back to disk → forwarder's mount of `~/.roxabi/llmcli/credentials/` must be `rw` (the `llmcli` proxy container uses `:ro,Z` today for `~/.roxabi/llmcli`; the new forwarder gets its own narrower writable mount).
+- **Library reuse:** port Hermes' xAI OAuth subset (~250 lines from `hermes_cli/auth.py:97-203` + refresh logic) without dragging in the multi-account `credential_pool` abstraction.
+- **F-lite ceiling:** ≤900 lines across `auth/`, `proxy_forwarder/`, `cli/xai.py`, and edits to `cli/_app.py` + `support/litellm_config.py` + `support/providers.py`.
+
+## Out of Scope
+
+- **M₂ deployment** — deferred. Tailnet routing (M₂ LiteLLM → `roxabituwer:18645`) is the fallback when needed.
+- **Multi-account credential pool** — Hermes feature, overkill for a single-operator setup.
+- **Eager timer-based refresh** — lazy on-401 only.
+- **Other OAuth providers** (Anthropic Console, Gemini, Qwen) — separate issues. This issue establishes the pattern; reuse is the next issue's payoff, not this one's scope.
+- **CLAUDE.md layout-doc update** — follow-up sibling issue once #99 ships (the stale `src/llmcli/cli.py` reference in CLAUDE.md will be fixed then).
+
+## Premise Validity
+
+**Success in 6 months:** SuperGrok OAuth credentials work transparently for lyra + claude-code via the existing LiteLLM proxy on M₁. `llmcli list` shows `grok-4`. Token refresh happens automatically with no manual intervention. The `auth/` + `proxy_forwarder/` pattern is reusable for Gemini / Anthropic Console OAuth (next 1–2 providers).
+
+**Failure in 6 months (falsifiable):** Forwarder uptime <99% on a rolling 30-day window, OR manual `llmcli xai login` required more than 1×/month, OR >50% of Grok requests fall back to cloud-paid relays (Kimi/DeepSeek) due to OAuth errors. Any of these → we shipped operational burden without reliable Grok access; rip out and revert to paid xAI API.
+
+**Simplest alternative:** Static `XAI_API_KEY` via existing LiteLLM provider mechanism — 2 lines of YAML in `~/.litellm/config.yaml`, no OAuth, no forwarder, no Quadlet.
+**Why not simplest:** Pays twice (SuperGrok subscription already running + API credits separately). More importantly, the investment in OAuth + forwarder is the *substrate* for future OAuth providers (Gemini, Anthropic Console) — the value is not "xAI access" but "OAuth-provider pattern in llmCLI". Static key gets Grok cheaply but leaves us flat-footed for the next OAuth provider.
+
+## Complexity
+
+**Tier: F-lite** — single domain (auth/proxy infrastructure), clear scope (port Hermes subset), bounded file count (~12 files / ~900 lines).
+
+Signals observed:
+- **Files touched:** ~12 (5 new modules + ~7 edits) — F-lite range
+- **Technical risk:** 5 — OAuth PKCE is well-known, but new for llmCLI; Hermes is the reference impl
+- **Architectural impact:** 6 — new sibling-service pattern, new `auth/` subsystem, first credential-rotating provider in llmCLI
+- **Unknowns:** 3 — minor (lazy-refresh + Podman `rw` mount semantics for credentials file)
+- **Domain breadth:** 2 (auth + HTTP forwarding) — single infrastructure cluster
+- **κ = 5** → F-lite tier confirmed (computed: `6×0.20 + 5×0.25 + 6×0.25 + 3×0.15 + 7×0.15 = 5.45 → 5`)

--- a/artifacts/plans/99-xai-oauth-proxy-plan.mdx
+++ b/artifacts/plans/99-xai-oauth-proxy-plan.mdx
@@ -1,0 +1,758 @@
+---
+title: "Plan: xAI OAuth proxy à la Hermes — SuperGrok credentials forwarder"
+issue: 99
+spec: artifacts/specs/99-xai-oauth-proxy-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-05-27
+---
+
+## Summary
+
+Port Hermes' xAI OAuth + aiohttp forwarder pattern to llmCLI. 10 new files / 6 edits across `auth/`, `proxy_forwarder/`, `cli/xai.py`, `support/{providers,litellm_config}`, deploy, docs. 16 micro-tasks + 3 RED-GATE sentinels, 3 waves, 5 named agent instances + tester-A + doc-writer-A. DI'd `OAuthAdapter` Protocol + generic `lazy_retry_on_401` keep stage logic provider-agnostic; `_OAUTH_MANAGED` sentinel keeps PROVIDERS as single registry.
+
+## Architecture
+
+### Data flow
+
+```mermaid
+flowchart TD
+  subgraph login["llmcli xai login (host)"]
+    PKCE[generate PkceVerifier] --> LOOP[loopback :56121]
+    LOOP --> BROWSER[browser → auth.x.ai/oauth/authorize?plan=generic]
+    BROWSER --> EXCH[exchange_code: POST /oauth/token]
+    EXCH --> SAVE[store.save → xai.json 0600]
+  end
+  subgraph runtime["forwarder runtime (Quadlet)"]
+    LITE[LiteLLM :18091] -->|Bearer dummy| SRV[create_app + adapter]
+    SRV --> LR[lazy_retry_on_401]
+    LR --> READ[store.load]
+    READ -->|access_token| SWAP[bearer swap]
+    SWAP --> XAI[api.x.ai/v1]
+    XAI -->|401| LOCK[async with _REFRESH_LOCK]
+    LOCK --> REL[re-load]
+    REL --> REFRESH[adapter.refresh → POST /oauth/token]
+    REFRESH --> SAVE2[store.save]
+    SAVE2 --> RETRY[retry once]
+  end
+  subgraph catalog["catalog reload"]
+    REG[llmcli register-proxy] -->|presence check| READ
+    REG -->|emit grok-4, grok-4-fast| YAML[~/.litellm/config.yaml]
+  end
+  SAVE -.-> READ
+  classDef hot fill:#fde68a,stroke:#92400e
+  class SWAP,SRV,LR hot
+```
+
+### File × Function map
+
+```mermaid
+flowchart LR
+  subgraph auth["src/llmcli/auth/"]
+    store_py["store.py<br/>XaiCredentials<br/>load() save()<br/>CredentialsCorruptError"]
+    oauth_py["xai_oauth.py<br/>PKCE helpers<br/>_loopback_server<br/>exchange_code()<br/>refresh_credentials()<br/>login_flow()"]
+  end
+  subgraph fwd["src/llmcli/proxy_forwarder/"]
+    common["_common.py<br/>OAuthAdapter Protocol<br/>_REFRESH_LOCK<br/>lazy_retry_on_401()"]
+    adapter["xai_adapter.py<br/>XaiAdapter"]
+    server["_server.py<br/>create_app(adapter)<br/>health_handler<br/>proxy_handler<br/>main()"]
+  end
+  subgraph cli["src/llmcli/cli/"]
+    xai_cli["xai.py<br/>login_cmd<br/>logout_cmd<br/>status_cmd"]
+    app["_app.py<br/>add_typer(xai)"]
+  end
+  subgraph sup["src/llmcli/support/"]
+    prov["providers.py<br/>PROVIDERS xai-oauth"]
+    litcfg["litellm_config.py<br/>build_model_list +<br/>_XAI_OAUTH_MODELS"]
+  end
+  subgraph tests["tests/"]
+    test_oauth["test_xai_oauth_pkce.py<br/>4 unit tests"]
+  end
+  store_py --> oauth_py
+  oauth_py --> xai_cli
+  store_py --> common
+  common --> adapter
+  adapter --> server
+  oauth_py --> adapter
+  prov --> litcfg
+  store_py --> test_oauth
+  oauth_py --> test_oauth
+  adapter --> test_oauth
+```
+
+## Agents
+
+| Agent instance | Tasks | Files |
+|---|---|---|
+| backend-dev-A | T1, T2, T3 | `src/llmcli/auth/{__init__,store,xai_oauth}.py` |
+| backend-dev-B | T7, T8, T9, T10 | `src/llmcli/proxy_forwarder/{__init__,_common,xai_adapter,_server}.py` |
+| backend-dev-C | T5, T6, T11, T12 | `src/llmcli/cli/xai.py`, `cli/_app.py`, `support/{providers,litellm_config}.py` |
+| devops-A | T13, T14, T15 | `deploy/quadlet/llmcli-xai-forwarder.container`, `deploy/quadlet.toml`, `deploy/install.sh` |
+| tester-A | T4, T17 (RG1), T18 (RG2), T19 (RG3) | `tests/test_xai_oauth_pkce.py` + smoke verifications |
+| doc-writer-A | T16 | `docs/QUADLET-DEPLOYMENT.md` |
+
+→ `security-auditor` invoked at `/code-review` time (post-impl, advisory — not a build instance).
+
+## Wave Structure
+
+3 waves + 3 RED-GATE sentinels. Max 4 parallel agents (Wave 1). Elapsed ~1.5d vs ~3d sequential.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 4 ∥ | backend-dev-A: T1→T2→T3 · tester-A: T4 · *(backend-dev-B/C/devops-A idle)* |
+| RG1 | Wave 1 done | tester-A | T17 (pytest exchange + corrupted PASS) |
+| 2 | RG1 GREEN | 2 ∥ | backend-dev-B: T7→T8→T9→T10 · backend-dev-C: T5→T6→T11→T12 |
+| RG2 | Wave 2 done | tester-A | T18 (pytest full + local forwarder curl smoke) |
+| 3 | RG2 GREEN | 2 ∥ | devops-A: T13→T14→T15 · doc-writer-A: T16 |
+| RG3 | Wave 3 done | tester-A | T19 (systemctl + LiteLLM end-to-end) |
+
+### Budget — per task
+
+| Task | Items | Class | Est. ops | Split? |
+|------|-------|-------|----------|--------|
+| T1 init | 1 file | trivial | 1 | — |
+| T2 store.py | ~80 LOC, 5 fns | judgmental | 5 | — |
+| T3 xai_oauth.py | ~250 LOC, port + PKCE | judgmental | 6 | — |
+| T4 tests | 4 mocked tests | judgmental | 6 | — |
+| T5 cli/xai.py | ~60 LOC, 3 Typer cmds | judgmental | 4 | — |
+| T6 _app.py edit | 2 lines | trivial | 2 | — |
+| T7 fwd init | 1 file | trivial | 1 | — |
+| T8 _common.py | ~80 LOC, Protocol + lock | judgmental | 5 | — |
+| T9 xai_adapter.py | ~60 LOC, impl Protocol | judgmental | 4 | — |
+| T10 _server.py | ~180 LOC, aiohttp | judgmental | 6 | — |
+| T11 providers.py | 1 line | trivial | 1 | — |
+| T12 litellm_config | ~20 LOC, build_model_list ext | judgmental | 5 | — |
+| T13 Quadlet | full unit | bounded | 3 | — |
+| T14 quadlet.toml | 3 lines | trivial | 1 | — |
+| T15 install.sh | unit + mkdir | bounded | 3 | — |
+| T16 docs section | runbook ~50 LOC | judgmental | 4 | — |
+| T17-T19 RED-GATEs | bash + curl | bounded | 2 each = 6 | — |
+
+**Total estimated ops: ~63**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T1, T2, T3 | 12 | auth, store | — |
+| backend-dev-B | T7, T8, T9, T10 | 16 | forwarder, refresh | — |
+| backend-dev-C | T5, T6, T11, T12 | 12 | cli, config | — |
+| devops-A | T13, T14, T15 | 7 | quadlet, install | — |
+| tester-A | T4, T17, T18, T19 | 12 | tests | — |
+| doc-writer-A | T16 | 4 | docs | — |
+
+All within caps (Σ ≤50 ops, |tasks| ≤4, subjects ≤2).
+
+## Consistency Report
+
+- **Spec ACs covered:** 19/19 (15 operator-observable + 4 test-only)
+- **Affordances covered:** 13/13 (N1-N13, U1-U2, S1)
+- **Uncovered:** none
+- **Untraced micro-tasks:** none
+- **Exemptions:** none
+
+| AC# | Task(s) |
+|---|---|
+| AC1 `xai login` 0600 + plan=generic | T3, T5 |
+| AC2 `xai logout` | T5 |
+| AC3 `xai status` no token leak | T5 (impl), T2 (`__repr__` redact) |
+| AC4 Quadlet install + start + roxabi.network | T13, T14, T15 |
+| AC5 :18645 not host-published + path allowlist | T13 (¬PublishPort), T10 (ALLOWED_PATHS) |
+| AC6 Bearer swap | T10 (proxy_handler) |
+| AC7 401 → refresh → retry once + X-Llmcli-Reauth | T8 (lazy_retry_on_401) |
+| AC8 Concurrent dedup (exactly 1 POST) | T8 (_REFRESH_LOCK) + T4 (test_concurrent_refresh_dedup) |
+| AC9 /health post-restart | T10 (health_handler), T13 (HealthCmd) |
+| AC10 register-proxy + WARNING stderr | T12 |
+| AC11 LiteLLM end-to-end curl grok-4 | T19 (RG3) |
+| AC12 `llmcli list` reflects creds presence | T12 (via build_model_list) |
+| AC13 journalctl no JWT material | T2 (`__repr__`), T18 (RG2) |
+| AC14 `XaiCredentials.__repr__` redact | T2 + T4 (covers) |
+| AC15 docs section | T16 |
+| Test AC: test_pkce_code_exchange | T4 |
+| Test AC: test_lazy_refresh_on_401 | T4 |
+| Test AC: test_concurrent_refresh_dedup | T4 |
+| Test AC: test_credentials_corrupted | T4 |
+
+## Micro-Tasks
+
+> Each task: handler, file, code skeleton, verify command, expected output. Difficulty 1–5. Subject + spec trace + slice + phase.
+
+---
+
+### V1 — Auth core (Wave 1)
+
+#### T1 — Create `auth/__init__.py`
+- **Agent:** backend-dev-A · **Subject:** auth · **Difficulty:** 1 · **Phase:** GREEN · **[P]** with T4 · **Time:** 2min
+- **File:** `src/llmcli/auth/__init__.py`
+- **Skeleton:**
+  ```python
+  """OAuth credential management for llmCLI providers."""
+  from .store import XaiCredentials, CredentialsCorruptError, load, save
+  from .xai_oauth import login_flow, refresh_credentials
+
+  __all__ = ["XaiCredentials", "CredentialsCorruptError", "load", "save",
+             "login_flow", "refresh_credentials"]
+  ```
+- **Verify:** `python -c "from llmcli.auth import XaiCredentials, login_flow; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** S1 setup · **Depends on:** —
+
+#### T2 — Create `auth/store.py`
+- **Agent:** backend-dev-A · **Subject:** store · **Difficulty:** 3 · **Phase:** GREEN · **Time:** 8min
+- **File:** `src/llmcli/auth/store.py`
+- **Skeleton:**
+  ```python
+  import fcntl, json, os
+  from dataclasses import dataclass, field
+  from pathlib import Path
+
+  CREDENTIALS_DIR = Path.home() / ".roxabi" / "llmcli" / "credentials"
+  XAI_CREDENTIALS_PATH = CREDENTIALS_DIR / "xai.json"
+
+  class CredentialsCorruptError(RuntimeError): ...
+
+  @dataclass(frozen=True)
+  class XaiCredentials:
+      access_token: str
+      refresh_token: str
+      id_token: str
+      expires_at: int  # unix epoch seconds
+      token_type: str = "Bearer"
+      scope: str = ""
+
+      def __repr__(self) -> str:
+          return (f"XaiCredentials(access_token=***, refresh_token=***, "
+                  f"id_token=***, expires_at={self.expires_at}, "
+                  f"token_type={self.token_type!r}, scope={self.scope!r})")
+
+  def load(path: Path = XAI_CREDENTIALS_PATH) -> XaiCredentials | None:
+      if not path.exists():
+          return None
+      try:
+          data = json.loads(path.read_text())
+      except json.JSONDecodeError as exc:
+          raise CredentialsCorruptError(
+              f"credentials corrupted at {path} — re-run `llmcli xai login`"
+          ) from exc
+      return XaiCredentials(**data)
+
+  def save(creds: XaiCredentials, path: Path = XAI_CREDENTIALS_PATH) -> None:
+      path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+      tmp = path.with_suffix(".tmp")
+      with open(tmp, "w") as f:
+          fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+          json.dump({...}, f)
+          fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+      os.chmod(tmp, 0o600)
+      os.replace(tmp, path)  # atomic rename
+  ```
+- **Verify:** `python -c "from llmcli.auth.store import XaiCredentials; c = XaiCredentials('a','b','c',123); assert 'access_token=***' in repr(c); print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** S1, AC14 · **Depends on:** —
+
+#### T3 — Create `auth/xai_oauth.py`
+- **Agent:** backend-dev-A · **Subject:** auth · **Difficulty:** 4 · **Phase:** GREEN · **Time:** 20min
+- **File:** `src/llmcli/auth/xai_oauth.py`
+- **Skeleton:** Port from `hermes_cli/auth.py:97-203` (constants) + PKCE flow + token exchange. **MUST** include `plan=generic` in authorize URL. Constants:
+  ```python
+  XAI_OAUTH_ISSUER = "https://auth.x.ai"
+  XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+  XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+  XAI_OAUTH_REDIRECT_PORT = 56121
+  XAI_OAUTH_REDIRECT_PATH = "/callback"
+  XAI_OAUTH_PLAN = "generic"  # load-bearing per Hermes
+
+  def _build_authorize_url(challenge: str, state: str, nonce: str) -> str:
+      # MUST include plan=generic
+      ...
+
+  def exchange_code(code: str, verifier: str) -> XaiCredentials: ...
+  def refresh_credentials(creds: XaiCredentials) -> XaiCredentials: ...
+  def login_flow() -> XaiCredentials: ...  # orchestrator
+  ```
+- **Verify:** `python -c "from llmcli.auth.xai_oauth import _build_authorize_url, XAI_OAUTH_PLAN; assert XAI_OAUTH_PLAN == 'generic'; u = _build_authorize_url('c','s','n'); assert 'plan=generic' in u; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** U1, U2, N4, N5 · **Depends on:** T2 (uses XaiCredentials)
+
+#### T4 — Create `tests/test_xai_oauth_pkce.py`
+- **Agent:** tester-A · **Subject:** tests · **Difficulty:** 4 · **Phase:** RED · **[P]** with T1-T3 · **Time:** 25min
+- **File:** `tests/test_xai_oauth_pkce.py`
+- **Skeleton:**
+  ```python
+  import pytest
+  from aioresponses import aioresponses
+  from llmcli.auth.store import XaiCredentials, CredentialsCorruptError, load, save
+  from llmcli.auth.xai_oauth import exchange_code, refresh_credentials, _build_authorize_url, XAI_OAUTH_PLAN
+
+  def test_pkce_code_exchange(tmp_path, monkeypatch):
+      # mock auth.x.ai /oauth/token; assert verifier + plan=generic in request
+      ...
+
+  @pytest.mark.asyncio
+  async def test_lazy_refresh_on_401(tmp_path, monkeypatch):
+      # mock api.x.ai 401 then 200; assert refresh POSTed + retry succeeded
+      ...
+
+  @pytest.mark.asyncio
+  async def test_concurrent_refresh_dedup(tmp_path, monkeypatch):
+      # 5 concurrent 401s; assert exactly 1 POST to /oauth/token
+      ...
+
+  def test_credentials_corrupted(tmp_path, monkeypatch):
+      # write partial JSON; assert load() raises CredentialsCorruptError
+      ...
+  ```
+- **Verify:** `uv run pytest tests/test_xai_oauth_pkce.py -v --collect-only`
+- **Expected:** `4 tests collected`
+- **Spec trace:** Test-only AC × 4 · **Depends on:** —
+
+---
+
+### RG1 — RED-GATE 1 (after Wave 1)
+
+#### T17 — Verify Wave 1
+- **Agent:** tester-A · **Subject:** tests · **Difficulty:** 1 · **Phase:** RED-GATE · **Time:** 2min
+- **Verify:** `uv run pytest tests/test_xai_oauth_pkce.py::test_pkce_code_exchange tests/test_xai_oauth_pkce.py::test_credentials_corrupted -v`
+- **Expected:** `2 passed`
+- **Spec trace:** auth core unit gate · **Depends on:** T2, T3, T4
+
+---
+
+### V2 — CLI subcommand (Wave 2)
+
+#### T5 — Create `cli/xai.py`
+- **Agent:** backend-dev-C · **Subject:** cli · **Difficulty:** 3 · **Phase:** GREEN · **Time:** 10min
+- **File:** `src/llmcli/cli/xai.py`
+- **Skeleton:**
+  ```python
+  import typer
+  from llmcli.auth import login_flow, store
+  from llmcli.cli._app import console, err_console
+
+  xai_app = typer.Typer(help="xAI / SuperGrok OAuth credentials")
+
+  @xai_app.command("login")
+  def login_cmd() -> None:
+      creds = login_flow()
+      console.print(f"✓ Logged in. expires_at={creds.expires_at}")
+
+  @xai_app.command("logout")
+  def logout_cmd() -> None:
+      store.XAI_CREDENTIALS_PATH.unlink(missing_ok=True)
+
+  @xai_app.command("status")
+  def status_cmd() -> None:
+      creds = store.load()
+      if creds is None:
+          console.print({"logged_in": False})
+          raise typer.Exit(1)
+      console.print({"logged_in": True, "expires_at": creds.expires_at,
+                     "scope": creds.scope})
+  ```
+- **Verify:** `uv run llmcli xai --help`
+- **Expected:** `login`, `logout`, `status` listed
+- **Spec trace:** N1, N2, N3 · **Depends on:** T2, T3
+
+#### T6 — Edit `cli/_app.py`
+- **Agent:** backend-dev-C · **Subject:** cli · **Difficulty:** 1 · **Phase:** GREEN · **Time:** 1min
+- **File:** `src/llmcli/cli/_app.py`
+- **Edit:** Append at end:
+  ```python
+  from llmcli.cli.xai import xai_app  # noqa: E402
+  app.add_typer(xai_app, name="xai")
+  ```
+- **Verify:** `uv run llmcli xai status` (with no creds)
+- **Expected:** `{'logged_in': False}` + exit 1
+- **Spec trace:** N1-N3 wiring · **Depends on:** T5
+
+---
+
+### V3 — Forwarder service (Wave 2, parallel with V2)
+
+#### T7 — Create `proxy_forwarder/__init__.py`
+- **Agent:** backend-dev-B · **Subject:** forwarder · **Difficulty:** 1 · **Phase:** GREEN · **Time:** 1min
+- **File:** `src/llmcli/proxy_forwarder/__init__.py`
+- **Skeleton:**
+  ```python
+  from ._common import OAuthAdapter, lazy_retry_on_401, ALLOWED_PATHS
+  from ._server import create_app, main
+  from .xai_adapter import XaiAdapter
+
+  __all__ = ["OAuthAdapter", "lazy_retry_on_401", "ALLOWED_PATHS",
+             "create_app", "main", "XaiAdapter"]
+  ```
+- **Verify:** `python -c "from llmcli.proxy_forwarder import create_app, XaiAdapter; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** package setup · **Depends on:** T8, T9, T10 (for imports to work) — but file itself first
+
+#### T8 — Create `proxy_forwarder/_common.py`
+- **Agent:** backend-dev-B · **Subject:** refresh · **Difficulty:** 4 · **Phase:** GREEN · **Time:** 15min
+- **File:** `src/llmcli/proxy_forwarder/_common.py`
+- **Skeleton:**
+  ```python
+  import asyncio
+  from pathlib import Path
+  from typing import Protocol, Callable, Awaitable
+
+  ALLOWED_PATHS = frozenset({
+      "/v1/chat/completions", "/v1/completions", "/v1/responses",
+      "/v1/embeddings", "/v1/models", "/health",
+  })
+
+  _REFRESH_LOCK = asyncio.Lock()
+
+  class OAuthAdapter(Protocol):
+      api_base: str
+      credential_path: Path
+      async def refresh(self, creds): ...
+
+  async def lazy_retry_on_401(request_fn, refresh_fn, store_load, store_save):
+      """Single-flight 401 retry: refresh-lock + re-read-on-entry."""
+      creds = store_load()
+      resp = await request_fn(creds.access_token)
+      if resp.status != 401:
+          return resp
+      async with _REFRESH_LOCK:
+          creds = store_load()  # may already be refreshed by another handler
+          # check expires_at; if not expired, skip refresh, otherwise:
+          new = await refresh_fn(creds)
+          store_save(new)
+          return await request_fn(new.access_token)
+  ```
+- **Verify:** `python -c "from llmcli.proxy_forwarder._common import OAuthAdapter, lazy_retry_on_401, ALLOWED_PATHS, _REFRESH_LOCK; assert '/v1/chat/completions' in ALLOWED_PATHS; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** N8 · **Depends on:** T2
+
+#### T9 — Create `proxy_forwarder/xai_adapter.py`
+- **Agent:** backend-dev-B · **Subject:** forwarder · **Difficulty:** 2 · **Phase:** GREEN · **Time:** 7min
+- **File:** `src/llmcli/proxy_forwarder/xai_adapter.py`
+- **Skeleton:**
+  ```python
+  from llmcli.auth.store import XAI_CREDENTIALS_PATH, XaiCredentials
+  from llmcli.auth.xai_oauth import refresh_credentials
+
+  class XaiAdapter:
+      api_base = "https://api.x.ai/v1"
+      credential_path = XAI_CREDENTIALS_PATH
+
+      async def refresh(self, creds: XaiCredentials) -> XaiCredentials:
+          # delegates to sync auth.xai_oauth.refresh_credentials in executor
+          loop = asyncio.get_running_loop()
+          return await loop.run_in_executor(None, refresh_credentials, creds)
+  ```
+- **Verify:** `python -c "from llmcli.proxy_forwarder.xai_adapter import XaiAdapter; a = XaiAdapter(); assert a.api_base == 'https://api.x.ai/v1'; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** N7 · **Depends on:** T2, T3, T8
+
+#### T10 — Create `proxy_forwarder/_server.py`
+- **Agent:** backend-dev-B · **Subject:** forwarder · **Difficulty:** 4 · **Phase:** GREEN · **Time:** 20min
+- **File:** `src/llmcli/proxy_forwarder/_server.py`
+- **Skeleton:** Port from `hermes_cli/proxy/server.py`. Provider-agnostic; adapter injected.
+  ```python
+  import os, time
+  from aiohttp import web, ClientSession
+  from llmcli.auth import store
+  from ._common import OAuthAdapter, ALLOWED_PATHS, lazy_retry_on_401
+
+  def create_app(adapter: OAuthAdapter) -> web.Application:
+      app = web.Application()
+      app.router.add_get("/health", _health(adapter))
+      app.router.add_route("*", "/{path:.*}", _proxy(adapter))
+      return app
+
+  def _health(adapter):
+      async def handler(req):
+          try:
+              creds = store.load(adapter.credential_path)
+              return web.json_response({
+                  "status": "ok",
+                  "logged_in": creds is not None,
+                  "expires_at": creds.expires_at if creds else None,
+              })
+          except store.CredentialsCorruptError:
+              return web.json_response({"status": "ok", "logged_in": False}, status=200)
+      return handler
+
+  def _proxy(adapter):
+      async def handler(req):
+          if req.path not in ALLOWED_PATHS:
+              return web.Response(status=404)
+          body = await req.read()
+          async def request_fn(token):
+              # forward to adapter.api_base + req.path with token
+              ...
+          resp = await lazy_retry_on_401(request_fn, adapter.refresh,
+                                          lambda: store.load(adapter.credential_path),
+                                          lambda c: store.save(c, adapter.credential_path))
+          if resp.status == 401:
+              return web.Response(status=401, headers={"X-Llmcli-Reauth": "required"})
+          return resp
+      return handler
+
+  def main():
+      provider = os.environ.get("LLMCLI_FORWARDER_PROVIDER", "xai")
+      if provider == "xai":
+          from .xai_adapter import XaiAdapter
+          adapter = XaiAdapter()
+      web.run_app(create_app(adapter), host="0.0.0.0", port=18645)
+  ```
+- **Verify:** Start in background `python -m llmcli.proxy_forwarder._server & sleep 1 && curl -f http://localhost:18645/health`
+- **Expected:** HTTP 200 with `{"status": "ok", "logged_in": ..., "expires_at": ...}`
+- **Spec trace:** N6, N9 · **Depends on:** T8, T9
+
+---
+
+### V4 — LiteLLM integration (Wave 2)
+
+#### T11 — Edit `support/providers.py`
+- **Agent:** backend-dev-C · **Subject:** config · **Difficulty:** 1 · **Phase:** GREEN · **Time:** 1min
+- **File:** `src/llmcli/support/providers.py`
+- **Edit:** Add to `PROVIDERS` dict:
+  ```python
+  "xai-oauth": Provider("http://llmcli-xai-forwarder:18645/v1", "_OAUTH_MANAGED"),
+  ```
+- **Verify:** `python -c "from llmcli.support.providers import PROVIDERS; assert PROVIDERS['xai-oauth'].key_env == '_OAUTH_MANAGED'; print('ok')"`
+- **Expected:** `ok`
+- **Spec trace:** N12 · **Depends on:** —
+
+#### T12 — Edit `support/litellm_config.py`
+- **Agent:** backend-dev-C · **Subject:** config · **Difficulty:** 4 · **Phase:** GREEN · **Time:** 15min
+- **File:** `src/llmcli/support/litellm_config.py`
+- **Edit:** Add module-level constants + extend `build_model_list`:
+  ```python
+  _XAI_OAUTH_MODELS: list[str] = ["grok-4", "grok-4-fast"]
+  _XAI_CREDENTIALS_PATH = Path.home() / ".roxabi" / "llmcli" / "credentials" / "xai.json"
+
+  def build_model_list(catalog: dict, ...) -> list[dict]:
+      models = []
+      for name, spec in catalog.items():
+          provider = PROVIDERS.get(spec["provider"])
+          if provider is None: continue
+          if provider.key_env == "_OAUTH_MANAGED":
+              # OAuth-managed: gate on credentials presence; emit api_key="dummy"
+              if not _XAI_CREDENTIALS_PATH.exists():
+                  continue  # silently omit
+              models.append({
+                  "model_name": name,
+                  "litellm_params": {"model": f"openai/{name}",
+                                      "api_base": provider.api_base,
+                                      "api_key": "dummy"},
+              })
+          else:
+              models.append({"model_name": name, "litellm_params": {
+                  "model": ..., "api_key": f"os.environ/{provider.key_env}"}})
+      return models
+
+  def emit_xai_oauth_warning_if_absent(stderr) -> None:
+      """Called from cli/proxy.py:register_proxy."""
+      if not _XAI_CREDENTIALS_PATH.exists():
+          stderr.print("[yellow]WARNING:[/yellow] xAI credentials not found — "
+                       "run `llmcli xai login` to enable Grok models")
+
+  # Auto-extend catalog with hardcoded xAI-OAuth models when creds present:
+  def _inject_xai_oauth_models(catalog: dict) -> None:
+      if _XAI_CREDENTIALS_PATH.exists():
+          for model in _XAI_OAUTH_MODELS:
+              catalog.setdefault(model, {"provider": "xai-oauth"})
+  ```
+  Also call `emit_xai_oauth_warning_if_absent(err_console)` from `cli/proxy.py:register_proxy_cmd` (the call site — implementer adds the 1-line invocation).
+- **Verify:** Without `xai.json`: `uv run llmcli register-proxy 2>&1 | grep WARNING` → contains warning; with creds present: `grep grok-4 ~/.litellm/config.yaml` → finds entry
+- **Expected:** WARNING printed when absent; Grok block present when creds exist
+- **Spec trace:** AC10, AC12 · **Depends on:** T11
+
+---
+
+### RG2 — RED-GATE 2 (after Wave 2)
+
+#### T18 — Verify Wave 2
+- **Agent:** tester-A · **Subject:** tests · **Difficulty:** 2 · **Phase:** RED-GATE · **Time:** 5min
+- **Verify:**
+  1. `uv run pytest tests/test_xai_oauth_pkce.py -v` (all 4 PASS — concurrent dedup + lazy retry now exercised)
+  2. Start local forwarder: `python -m llmcli.proxy_forwarder._server &` then `curl -f http://localhost:18645/health` → 200
+  3. Path allowlist: `curl -o /dev/null -w "%{http_code}" http://localhost:18645/wrong-path` → 404
+- **Expected:** All 4 tests pass; health=200; wrong path=404
+- **Spec trace:** AC5, AC6, AC7, AC8, AC9 (local pre-Quadlet) · **Depends on:** T10, T12
+
+---
+
+### V5 — Quadlet deploy (Wave 3)
+
+#### T13 — Create `deploy/quadlet/llmcli-xai-forwarder.container`
+- **Agent:** devops-A · **Subject:** quadlet · **Difficulty:** 3 · **Phase:** GREEN · **Time:** 10min
+- **File:** `deploy/quadlet/llmcli-xai-forwarder.container`
+- **Skeleton:**
+  ```ini
+  [Unit]
+  Description=llmCLI xAI OAuth forwarder (:18645)
+  StartLimitIntervalSec=60
+  StartLimitBurst=5
+
+  [Container]
+  Image=ghcr.io/roxabi/llmcli:staging
+  Label=io.containers.autoupdate=registry
+  ContainerName=llmcli-xai-forwarder
+  Network=roxabi.network
+  # NO PublishPort — internal to roxabi.network only
+  Volume=%h/.roxabi/llmcli/credentials:/home/llmcli/.roxabi/llmcli/credentials:rw,Z
+  Environment=LLMCLI_FORWARDER_PROVIDER=xai
+  Environment=LLMCLI_FORWARDER_PORT=18645
+  UserNS=keep-id:uid=1502,gid=1502
+  Exec=python -m llmcli.proxy_forwarder._server
+  HealthCmd=curl -f http://localhost:18645/health || exit 1
+  HealthInterval=30s
+  HealthStartPeriod=15s
+  NoNewPrivileges=true
+  DropCapability=all
+
+  [Service]
+  Restart=on-failure
+  RestartSec=10
+  TimeoutStopSec=20s
+
+  [Install]
+  WantedBy=default.target
+  ```
+- **Verify:** `/usr/lib/systemd/system-generators/podman-user-generator --user --dryrun < deploy/quadlet/llmcli-xai-forwarder.container 2>&1` (or `quadlet -user -dryrun`)
+- **Expected:** Valid systemd unit output without warnings; if quadlet binary unavailable, fall back to `podman quadlet --user list` post-install
+- **Spec trace:** N10 · **Depends on:** T10
+
+#### T14 — Edit `deploy/quadlet.toml`
+- **Agent:** devops-A · **Subject:** quadlet · **Difficulty:** 1 · **Phase:** GREEN · **Time:** 2min
+- **File:** `deploy/quadlet.toml`
+- **Edit:** Add component entry:
+  ```toml
+  [component.xai-forwarder]
+  unit = "llmcli-xai-forwarder.container"
+  host_roles = ["lyra-hub"]  # M₁ only
+  secrets = []  # credentials via bind-mount, not Podman secrets
+  ```
+- **Verify:** `grep -A3 "\[component.xai-forwarder\]" deploy/quadlet.toml`
+- **Expected:** entry present with host_roles=["lyra-hub"]
+- **Spec trace:** N13 · **Depends on:** —
+
+#### T15 — Edit `deploy/install.sh`
+- **Agent:** devops-A · **Subject:** install · **Difficulty:** 2 · **Phase:** GREEN · **Time:** 5min
+- **File:** `deploy/install.sh`
+- **Edits:**
+  1. Add `llmcli-xai-forwarder.container` to the unit installation loop
+  2. In the Directories section: `mkdir -p "${DATA_DIR}/credentials" && chmod 700 "${DATA_DIR}/credentials"`
+- **Verify:** `bash -n deploy/install.sh && bash deploy/install.sh && ls -ld ~/.roxabi/llmcli/credentials`
+- **Expected:** Syntax OK; idempotent re-run; `credentials/` dir exists with mode 700
+- **Spec trace:** N13, AC1 (0700 dir) · **Depends on:** T13
+
+---
+
+### Wave 3 (parallel — V5 doc)
+
+#### T16 — Edit `docs/QUADLET-DEPLOYMENT.md`
+- **Agent:** doc-writer-A · **Subject:** docs · **Difficulty:** 2 · **Phase:** GREEN · **[P]** with T13-T15 · **Time:** 12min
+- **File:** `docs/QUADLET-DEPLOYMENT.md`
+- **Edit:** Add section "## xAI OAuth setup":
+  - Subsection: One-time login (`llmcli xai login` flow, expected output, what to do if browser doesn't open)
+  - Subsection: Status checks (`llmcli xai status` + `systemctl --user status llmcli-xai-forwarder` + `curl :18645/health`)
+  - Subsection: Refresh expiry behavior (access_token ~1h auto-refresh; refresh_token expiry after ~30d offline → re-login)
+  - Subsection: Logout / secret rotation (`llmcli xai logout` + `systemctl --user restart llmcli-xai-forwarder`)
+- **Verify:** `grep -c "## xAI OAuth setup" docs/QUADLET-DEPLOYMENT.md`
+- **Expected:** `1`
+- **Spec trace:** AC15 · **Depends on:** T5, T13
+
+---
+
+### RG3 — RED-GATE 3 (after Wave 3) — final smoke
+
+#### T19 — End-to-end verification
+- **Agent:** tester-A · **Subject:** tests · **Difficulty:** 3 · **Phase:** RED-GATE · **Time:** 10min
+- **Preconditions:** `llmcli xai login` was run with a real SuperGrok account (operator-provided, not automated in CI)
+- **Verify:**
+  1. `systemctl --user start llmcli-xai-forwarder && sleep 5 && systemctl --user status llmcli-xai-forwarder` → active (running) with HealthState=healthy
+  2. `podman exec llmcli curl -f http://llmcli-xai-forwarder:18645/health` → 200, `logged_in: true`, `expires_at: <future int>`
+  3. `ss -tlnp | grep 18645` (on host) → no output (¬PublishPort verified)
+  4. `llmcli register-proxy` → block written, `grep -E '(grok-4|grok-4-fast)' ~/.litellm/config.yaml` returns 2 lines
+  5. `curl -sf http://localhost:18091/v1/chat/completions -H "Authorization: Bearer dummy" -d '{"model":"grok-4","messages":[{"role":"user","content":"reply with the word pong"}]}' | jq -r '.choices[0].message.content'` → non-empty response containing "pong" (or any valid Grok reply)
+  6. `journalctl --user -u llmcli-xai-forwarder --since "5 minutes ago" | grep -cE 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'` → 0
+- **Expected:** Steps 1-6 all PASS
+- **Spec trace:** AC4, AC5, AC9, AC10, AC11, AC13 · **Depends on:** T13, T14, T15, T16
+
+---
+
+## Task Seeding Blueprint
+
+<!-- Used by /implement to seed TaskCreate calls on session start.
+     Format: T{n} | agent-instance | blockedBy | subject
+     blockedBy refs T-numbers within this list (not session task IDs).
+     Wave 1 → RG1 → Wave 2 → RG2 → Wave 3 → RG3 -->
+
+### Wave 1 — no deps, 4 agents ∥ (3 backend-dev-A serialized + 1 tester-A parallel)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | backend-dev-A | — | auth |
+| T2 | backend-dev-A | T1 | store |
+| T3 | backend-dev-A | T2 | auth |
+| T4 | tester-A | — | tests |
+
+### RG1 — after Wave 1
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T17 | tester-A | T2, T3, T4 | tests |
+
+### Wave 2 — after RG1, 2 agents ∥ (backend-dev-B serial 4 tasks + backend-dev-C serial 4 tasks)
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T8 | backend-dev-B | T17 | refresh |
+| T9 | backend-dev-B | T8 | forwarder |
+| T10 | backend-dev-B | T9 | forwarder |
+| T7 | backend-dev-B | T10 | forwarder |
+| T5 | backend-dev-C | T17 | cli |
+| T6 | backend-dev-C | T5 | cli |
+| T11 | backend-dev-C | T17 | config |
+| T12 | backend-dev-C | T11 | config |
+
+### RG2 — after Wave 2
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T18 | tester-A | T7, T10, T12 | tests |
+
+### Wave 3 — after RG2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T13 | devops-A | T18 | quadlet |
+| T14 | devops-A | T13 | quadlet |
+| T15 | devops-A | T14 | install |
+| T16 | doc-writer-A | T18 | docs |
+
+### RG3 — after Wave 3
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T19 | tester-A | T15, T16 | tests |
+
+## Task IDs
+
+<!-- Generated by /plan 2026-05-27. Used by /implement to resume tasks on session restart. -->
+
+| T# | Task ID | Subject |
+|----|---------|---------|
+| T1 | 13 | auth |
+| T2 | 14 | store |
+| T3 | 15 | auth |
+| T4 | 16 | tests |
+| T17 (RG1) | 17 | tests |
+| T5 | 18 | cli |
+| T6 | 19 | cli |
+| T7 | 20 | forwarder |
+| T8 | 21 | refresh |
+| T9 | 22 | forwarder |
+| T10 | 23 | forwarder |
+| T11 | 24 | config |
+| T12 | 25 | config |
+| T18 (RG2) | 26 | tests |
+| T13 | 27 | quadlet |
+| T14 | 28 | quadlet |
+| T15 | 29 | install |
+| T16 | 30 | docs |
+| T19 (RG3) | 31 | tests |

--- a/artifacts/specs/99-xai-oauth-proxy-spec.mdx
+++ b/artifacts/specs/99-xai-oauth-proxy-spec.mdx
@@ -1,0 +1,245 @@
+---
+title: feat(auth) — xAI OAuth proxy à la Hermes (SuperGrok credentials forwarder)
+issue: 99
+status: approved
+tier: F-lite
+date: 2026-05-27
+promoted_from: artifacts/frames/99-xai-oauth-proxy-frame.mdx
+---
+
+## Context
+
+Source: [frame 99](../frames/99-xai-oauth-proxy-frame.mdx) (approved 2026-05-27). Analysis skipped (F-lite). Issue [#99](https://github.com/Roxabi/llmCLI/issues/99).
+
+Frame conclusions carried in:
+- LiteLLM ¬supports OAuth bearer rotation → need sibling forwarder that swaps `Authorization` per request
+- Lazy refresh on 401 (¬eager timer)
+- M₁ only (24/7 cloud relay)
+- Port subset of Hermes (`hermes_cli/auth.py:97-203` + `hermes_cli/proxy/`) — ¬`credential_pool` (single-account)
+- New `auth/` + `proxy_forwarder/` packages; the pattern is the **substrate** for future OAuth providers (Gemini, Anthropic Console, Qwen)
+
+### Tier risk note
+
+Computed κ = 5.45 → F-lite (borderline). If `/plan` surfaces unexpected constraints around Podman `rw` credential-mount semantics OR aiohttp streaming behavior under SSE/concurrent-401 load, **escalate to F-full and run `/analyze` before implementation**. Hermes serves as reference but its multi-account `credential_pool` is *not* being ported, so its corresponding test coverage doesn't transfer directly.
+
+## Goal
+
+Add Grok-4 to the llmCLI mesh via SuperGrok OAuth credentials, routed transparently through the existing LiteLLM proxy (`:18091`) using a sibling aiohttp forwarder (`:18645`) that handles lazy token refresh.
+
+## Users
+
+- **Primary:** sole operator consuming Grok-4 from lyra agents + claude-code aliases (`ccl`/`ccp`) through M₁'s LiteLLM proxy.
+- **Secondary:** future Roxabi consumers of any OAuth-issued LLM credential — `auth/` and `proxy_forwarder/` are the reusable substrate.
+
+## Expected Behavior
+
+### One-time setup (host-side)
+
+```
+$ llmcli xai login
+→ Opening browser at https://auth.x.ai/oauth/authorize?...&code_challenge=…&plan=generic
+  (loopback listener on 127.0.0.1:56121)
+→ [user logs into auth.x.ai with SuperGrok account]
+→ Authorization code received, exchanging for tokens…
+✓ Logged in. Credentials stored at ~/.roxabi/llmcli/credentials/xai.json
+  expires_at: 2026-05-27T15:42:11Z (in 1h)
+  refresh_token: stored (long-lived)
+```
+
+### Runtime (M₁, always-on)
+
+1. `llmcli-xai-forwarder` Quadlet starts → joins `roxabi.network` → listens on `:18645` (¬published on host LAN)
+2. lyra agent / claude-code → `litellm:18091` (`model: grok-4`, `Authorization: Bearer dummy`)
+3. LiteLLM routes to `http://llmcli-xai-forwarder:18645/v1/chat/completions`
+4. Forwarder: read `xai.json` → swap `Authorization: Bearer <real_token>` → forward body to `api.x.ai/v1/chat/completions`
+5. Stream response back through LiteLLM to caller
+
+### Token expiry edges
+
+- **`access_token` expired (~1h):** api.x.ai responds 401 → `lazy_retry_on_401` acquires `_REFRESH_LOCK` → POSTs `auth.x.ai/oauth/token` with `refresh_token` → writes new `access_token` to `xai.json` → retries original request once.
+- **Concurrent requests both 401:** module-level `asyncio.Lock` ensures only ONE refresh POST is in-flight; the second handler enters the lock and discovers the refreshed token already on disk (skip POST, retry directly).
+- **`refresh_token` expired (>30d offline):** refresh POST fails (4xx) → forwarder propagates 401 + header `X-Llmcli-Reauth: required` → operator re-runs `llmcli xai login`.
+- **Credentials file corrupted (mid-write crash):** `store.load()` catches `json.JSONDecodeError` → raises `CredentialsCorruptError` → forwarder `/health` reports `logged_in: false`; request handlers return 503 with `X-Llmcli-Reauth: required`.
+
+### Catalog registration
+
+`llmcli register-proxy` checks `xai.json` presence:
+- ∃ → emits Grok models in the managed LiteLLM block pointing at `http://llmcli-xai-forwarder:18645/v1`
+- ¬∃ → omits Grok models AND prints `WARNING: xAI credentials not found — run 'llmcli xai login' to enable Grok models` to stderr (discoverability hint)
+
+## Data Model & Consumers
+
+### Data structure
+
+```mermaid
+classDiagram
+    class XaiCredentials {
+        +str access_token
+        +str refresh_token
+        +str id_token
+        +int expires_at
+        +str token_type
+        +str scope
+        __repr__() redacts tokens
+    }
+    class PkceVerifier {
+        +str code_verifier
+        +str code_challenge
+        +str state
+        +str nonce
+    }
+    class OAuthAdapter {
+        <<Protocol>>
+        +str api_base
+        +Path credential_path
+        +refresh(creds) XaiCredentials
+    }
+    class XaiAdapter {
+        +str api_base
+        +Path credential_path
+        +refresh(creds)
+    }
+    PkceVerifier ..> XaiCredentials : produces via /oauth/token
+    XaiCredentials --> XaiAdapter : injected into Authorization
+    XaiAdapter ..|> OAuthAdapter : implements
+```
+
+### Consumer map
+
+```mermaid
+flowchart LR
+    CLI[llmcli xai login] -->|writes| F[(xai.json 0600)]
+    F -->|reads on each req| FWD[forwarder :18645]
+    LITELLM[LiteLLM :18091] -->|Bearer dummy| FWD
+    FWD -->|Bearer real_token| XAI[api.x.ai/v1]
+    FWD -->|GET /health| HEALTH[":18645/health"]
+    FWD -.->|on 401, asyncio.Lock| AUTH[auth.x.ai/oauth/token]
+    AUTH -.->|new access_token| F
+    REG[llmcli register-proxy] -->|presence check| F
+    REG -->|writes block| YAML[(~/.litellm/config.yaml)]
+    GEMINI[future: gemini.json] -.->|same OAuthAdapter pattern| FWD
+```
+
+### Consumer summary
+
+| Consumer | Fields consumed | When | Status |
+|---|---|---|---|
+| `cli/xai.py:login_cmd` | (writes) XaiCredentials | one-time / on re-auth | this issue |
+| `cli/xai.py:status_cmd` | expires_at, scope | on-demand | this issue |
+| `proxy_forwarder/_server` health | logged_in, expires_at | systemd HealthCmd + curl | this issue |
+| `proxy_forwarder/xai_adapter` | access_token | every forwarded request (re-read per call) | this issue |
+| `proxy_forwarder/_common.lazy_retry_on_401` | refresh_token | on 401 from api.x.ai | this issue |
+| `cli/proxy.py:register-proxy` | presence (file exists) | catalog reload | this issue |
+| Future: Gemini OAuth | analogous fields, different file | next issue | dashed |
+
+## Breadboard
+
+### Affordances
+
+| ID | Element | Handler | Behavior |
+|---|---|---|---|
+| **N1** | `llmcli xai login` CLI | `cli/xai.py:login_cmd` | Spawns loopback server, opens browser w/ `plan=generic`, exchanges code → writes XaiCredentials |
+| **N2** | `llmcli xai logout` CLI | `cli/xai.py:logout_cmd` | Deletes `xai.json` (silent no-op if absent) |
+| **N3** | `llmcli xai status` CLI | `cli/xai.py:status_cmd` | Reads `xai.json`; prints `logged_in`, `expires_at`, `scope` — **never prints token material** |
+| **U1** | Browser OAuth flow | `auth.x.ai/oauth/authorize` (external) | Redirects to `127.0.0.1:56121/callback?code=…` |
+| **U2** | Loopback HTTP listener | `auth/xai_oauth.py:_loopback_server` | `http.server` on `:56121`, single-request, timeout 120s |
+| **N4** | Token exchange | `auth/xai_oauth.py:exchange_code` | POST `auth.x.ai/oauth/token` (code + verifier) → XaiCredentials |
+| **N5** | Token refresh | `auth/xai_oauth.py:refresh_credentials` | POST `auth.x.ai/oauth/token` (refresh_token) → new access_token |
+| **S1** | Credentials store | `auth/store.py:load`, `save` | `~/.roxabi/llmcli/credentials/xai.json` (0600); fcntl flock on save; `load()` raises `CredentialsCorruptError` on `JSONDecodeError` |
+| **N6** | Forwarder app (generic) | `proxy_forwarder/_server.py:create_app(adapter)` | aiohttp `web.Application`; accepts an `OAuthAdapter` instance via DI; mounts path allowlist only — unknown paths → 404 |
+| **N7** | xAI adapter | `proxy_forwarder/xai_adapter.py:XaiAdapter` | Implements `OAuthAdapter` Protocol: `api_base`, `credential_path`, `refresh(creds)`. Provider-specific endpoint config; **no stage logic** |
+| **N8** | Lazy retry-on-401 (generic) | `proxy_forwarder/_common.py:lazy_retry_on_401(request_fn, refresh_fn)` | Async coroutine. Acquires module-level `_REFRESH_LOCK` (asyncio.Lock); on 401 → refresh → store.save → retry once → propagate if still 401 |
+| **N9** | Health endpoint | `proxy_forwarder/_server.py:health_handler` | `GET /health` → `{status, logged_in, expires_at}`. Wired to systemd `HealthCmd` |
+| **N10** | Quadlet unit | `deploy/quadlet/llmcli-xai-forwarder.container` | `Network=roxabi.network` (no PublishPort); `Volume=…/credentials:rw,Z`; `UserNS=keep-id:uid=1502,gid=1502`; `Image=ghcr.io/roxabi/llmcli:staging` (reuse); `HealthCmd=curl -f http://localhost:18645/health` |
+| **N11** | LiteLLM block emission | `support/litellm_config.py:build_model_list` (extended) | Detects `provider.key_env == "_OAUTH_MANAGED"` → gates `api_key` emission, points at `api_base`; single emission path for static + OAuth |
+| **N12** | Provider registry entry | `support/providers.py:PROVIDERS["xai-oauth"]` | Sentinel: `Provider("http://llmcli-xai-forwarder:18645/v1", "_OAUTH_MANAGED")` |
+| **N13** | install.sh / quadlet.toml | `deploy/install.sh`, `deploy/quadlet.toml` | Adds new unit; `mkdir -p ~/.roxabi/llmcli/credentials && chmod 700`; `[component.xai-forwarder] host_roles=["lyra-hub"]` |
+
+### Wiring (forwarder request path)
+
+```
+LiteLLM /v1/chat/completions
+  → N6 (_server.create_app handler, dispatched via OAuthAdapter)
+    → N8 (lazy_retry_on_401)
+      → S1.load() — read XaiCredentials (raises CredentialsCorruptError on bad JSON → 503)
+      → swap Authorization header (Bearer <real>)
+      → request_fn(adapter.api_base + path) — aiohttp ClientSession.request
+      ↳ if response.status == 401:
+          → async with _REFRESH_LOCK:
+              → S1.load() AGAIN (another handler may have already refreshed)
+              → if still expired → adapter.refresh(creds) → S1.save(new) — flock + atomic-ish write
+          → retry once
+      ↳ return response (or propagated 401 + X-Llmcli-Reauth: required)
+```
+
+### Wiring (login flow)
+
+```
+llmcli xai login
+  → N1 (login_cmd)
+    → generate PkceVerifier (verifier, challenge, state, nonce)
+    → spawn U2 (_loopback_server on :56121)
+    → open browser → U1 (auth.x.ai/oauth/authorize?... &plan=generic &code_challenge=…)
+    ↳ wait for /callback?code=...&state=… (timeout 120s)
+    → verify state match
+    → N4 (exchange_code) — POST auth.x.ai/oauth/token (code + verifier)
+    → S1.save(XaiCredentials) — fcntl flock + chmod 0600
+    → print expires_at + redacted summary
+```
+
+## Slices
+
+> **Split decision:** Evaluated smart-split trigger (15 AC, 5 slices). Slices are sequential with tight state dependencies (each slice consumes artifacts from prior). Single PR retained. **Trigger to split** = if PR review exceeds 3 days, cut at Slice 3/4 boundary.
+
+| # | Goal | Files | Demo |
+|---|---|---|---|
+| **1. Auth core** | PKCE + token exchange + refresh + store work end-to-end on host (no forwarder) | `src/llmcli/auth/__init__.py`, `auth/xai_oauth.py`, `auth/store.py`, `tests/test_xai_oauth_pkce.py` | `python -c "from llmcli.auth.xai_oauth import login_flow; login_flow()"` → browser → `xai.json` written 0600; pytest green |
+| **2. CLI subcommand** | `llmcli xai login`/`logout`/`status` exposed via Typer; reuses slice 1 | `cli/xai.py`, `cli/_app.py` (+2) | `llmcli xai login` → token stored. `llmcli xai status` → `logged_in: true, expires_at: …` |
+| **3. Forwarder service** | aiohttp DI'd service forwards `/v1/*` with bearer swap + lazy 401 refresh + concurrent-safe refresh | `proxy_forwarder/__init__.py`, `_server.py`, `_common.py`, `xai_adapter.py` | `curl :18645/v1/chat/completions -H "Authorization: Bearer dummy" -d '{"model":"grok-4",…}'` → Grok response |
+| **4. LiteLLM integration** | `build_model_list` extended for `_OAUTH_MANAGED` sentinel; `register-proxy` emits xAI block + WARNING hint | `support/providers.py` (+1), `support/litellm_config.py` (~+10) | `llmcli register-proxy` adds managed Grok block; `curl :18091/v1/chat/completions -d '{"model":"grok-4",…}'` works end-to-end |
+| **5. Quadlet deploy** | Forwarder runs as Quadlet on M₁; survives restart; reachable on `roxabi.network` | `deploy/quadlet/llmcli-xai-forwarder.container`, `deploy/quadlet.toml` (+component), `deploy/install.sh` (+unit, +mkdir creds), `docs/QUADLET-DEPLOYMENT.md` (+section) | `systemctl --user start llmcli-xai-forwarder`; from inside `llmcli` container: `curl http://llmcli-xai-forwarder:18645/health` → 200 |
+
+## Success Criteria
+
+> **Operator-observable** — each item is binary AND visible without reading source.
+
+- [ ] `llmcli xai login` opens browser, completes PKCE flow on `127.0.0.1:56121` (authorize URL includes `plan=generic`), stores credentials at `~/.roxabi/llmcli/credentials/xai.json` with mode `0600` and dir mode `0700`
+- [ ] `llmcli xai logout` deletes `xai.json` (silent no-op if absent)
+- [ ] `llmcli xai status` reports `logged_in: true` + `expires_at` (ISO 8601) + `scope` when credentials exist; `logged_in: false` otherwise — **stdout contains no `eyJ` (JWT prefix) or `xai-` token substring**
+- [ ] `llmcli-xai-forwarder` Quadlet installs via `deploy/install.sh` (idempotent), starts via `systemctl --user start llmcli-xai-forwarder`, joins `roxabi.network`
+- [ ] Forwarder listens on `:18645` (¬published on host LAN — `ss -tlnp | grep 18645` returns nothing on host) and accepts allowed paths only: `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/embeddings`, `/v1/models`, `/health` (any other path → 404)
+- [ ] Forwarder replaces incoming `Authorization: Bearer *` with real OAuth token from `xai.json` and forwards body verbatim
+- [ ] On 401 from `api.x.ai`, forwarder calls `auth.x.ai/oauth/token` with `refresh_token`, persists new `access_token` to `xai.json`, retries the original request **once**; if retry still 401, propagates 401 + header `X-Llmcli-Reauth: required`
+- [ ] Concurrent 401s on the same expired token result in **exactly one** refresh POST to `auth.x.ai` (verified by counting POSTs in test with `aioresponses`)
+- [ ] `GET http://llmcli-xai-forwarder:18645/health` returns 200 with body `{status:"ok", logged_in:bool, expires_at:int}` after Quadlet restart (`systemctl --user restart llmcli-xai-forwarder` → `curl /health` within 15s succeeds)
+- [ ] `llmcli register-proxy` emits a managed LiteLLM block containing Grok models (`grok-4`, `grok-4-fast` — hardcoded `_XAI_OAUTH_MODELS` constant) pointing at `http://llmcli-xai-forwarder:18645/v1` when `xai.json` exists; **removes** the block when absent AND prints `WARNING: xAI credentials not found — run 'llmcli xai login' to enable Grok models` to stderr
+- [ ] LiteLLM at `:18091` routes `grok-4` end-to-end: `curl http://localhost:18091/v1/chat/completions -H "Authorization: Bearer dummy" -d '{"model":"grok-4","messages":[{"role":"user","content":"ping"}]}'` returns a 200 with a non-empty `choices[0].message.content`
+- [ ] `llmcli list` shows Grok models when `xai.json` exists, hides them when absent
+- [ ] After 100 forwarded requests + 1 refresh, `journalctl --user -u llmcli-xai-forwarder --since "1 hour ago" | grep -E 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'` returns 0 matches (no JWT material logged)
+- [ ] `XaiCredentials.__repr__()` returns `XaiCredentials(access_token=***, refresh_token=***, expires_at=…, scope=…)` — covered by unit test
+- [ ] `docs/QUADLET-DEPLOYMENT.md` includes a "xAI OAuth setup" runbook (login, status, logout, refresh expiry, secret rotation)
+
+### Test-only (not operator-observable)
+
+- [ ] Unit `tests/test_xai_oauth_pkce.py::test_pkce_code_exchange` — mocks `auth.x.ai`, asserts verifier/challenge/state/nonce + `plan=generic` in request
+- [ ] Unit `tests/test_xai_oauth_pkce.py::test_lazy_refresh_on_401` — mocked `api.x.ai`; asserts retry-once semantics + X-Llmcli-Reauth header on second 401
+- [ ] Unit `tests/test_xai_oauth_pkce.py::test_concurrent_refresh_dedup` — 5 concurrent 401 handlers → asserts exactly 1 refresh POST
+- [ ] Unit `tests/test_xai_oauth_pkce.py::test_credentials_corrupted` — write partial JSON to `xai.json` → `store.load()` raises `CredentialsCorruptError`; forwarder `/health` shows `logged_in: false`
+
+## Implementation Notes (carry forward to /plan)
+
+- **PKCE authorize URL:** `plan=generic` parameter is **load-bearing** (Hermes `auth.py:6383-6392`); without it `accounts.x.ai` rejects loopback OAuth from non-allowlisted clients.
+- **`store.load()` corrupt-creds:** catch `json.JSONDecodeError`, raise domain-specific `CredentialsCorruptError("credentials corrupted, re-run llmcli xai login")`. Forwarder maps it to 503 + `X-Llmcli-Reauth: required`.
+- **Refresh mutex:** module-level `_REFRESH_LOCK = asyncio.Lock()` in `proxy_forwarder/_common.py`. Pattern: `async with _REFRESH_LOCK:` → re-read creds → only refresh if still expired (other handler may have already refreshed). Protects single-use refresh tokens.
+- **Logging redaction:** `XaiCredentials.__repr__` and `__str__` mask `access_token` + `refresh_token` + `id_token` to `***`. The journalctl AC is the operator-observable enforcement; the `__repr__` AC is the architectural enforcement.
+- **`build_model_list` extension:** detect `provider.key_env == "_OAUTH_MANAGED"` → emit `api_base` + `api_key: "dummy"` (LiteLLM requires some value; the forwarder ignores it). Single emission path; no parallel `_xai_oauth_block` function.
+
+## Revisit Triggers (axial discipline)
+
+**When a 2nd OAuth provider arrives (Gemini, Anthropic Console, Qwen) — BEFORE shipping it:**
+
+1. Extract `auth/_common.py` with 5 OAuth primitives (`pkce_generate`, `loopback_callback`, `exchange_code`, `refresh_credentials`, parameterized by a `ProviderConfig` dataclass). `auth/xai_oauth.py` then becomes ≤30 LOC supplying only xAI-specific endpoints + PKCE params.
+2. Consider collapsing per-provider Quadlets into a single `llmcli-oauth-forwarder` mounting adapters on path prefixes (`/xai/v1/*`, `/gemini/v1/*`, …). Single port, single Quadlet, single install.sh entry. LiteLLM `api_base` changes to `http://llmcli-oauth-forwarder:18645/xai/v1`.
+3. Update ADR-006 with the OAuth-providers sub-axis decision.
+
+**Why now (not in #99):** for 1 provider the abstraction is premature. The DI'd `OAuthAdapter` Protocol in N6/N7/N8 already keeps stage logic (`_server.py`, `_common.py`) provider-agnostic — the second provider only needs to add its adapter file. The `_common.py` extraction in `auth/` becomes payoff-positive at N=2.

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -88,6 +88,10 @@ echo "--- Directories ---"
 run mkdir -p "$QUADLET_DIR"
 run mkdir -p "$ENV_DIR"
 run mkdir -p "${HOME}/.cache/huggingface"
+run mkdir -p "${DATA_DIR}/credentials"
+if ! "$DRY_RUN"; then
+  chmod 700 "${DATA_DIR}/credentials"
+fi
 echo "  dirs ok"
 
 # --- Networks ---
@@ -120,7 +124,7 @@ fi
 # --- Quadlet units ---
 echo ""
 echo "--- Quadlet units ---"
-for unit in llmcli.container llmcli-nats-worker.container; do
+for unit in llmcli.container llmcli-nats-worker.container llmcli-xai-forwarder.container; do
   src="${SCRIPT_DIR}/quadlet/${unit}"
   dst="${QUADLET_DIR}/${unit}"
   if [ ! -f "$src" ]; then

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -89,9 +89,7 @@ run mkdir -p "$QUADLET_DIR"
 run mkdir -p "$ENV_DIR"
 run mkdir -p "${HOME}/.cache/huggingface"
 run mkdir -p "${DATA_DIR}/credentials"
-if ! "$DRY_RUN"; then
-  chmod 700 "${DATA_DIR}/credentials"
-fi
+run chmod 700 "${DATA_DIR}/credentials"
 echo "  dirs ok"
 
 # --- Networks ---
@@ -195,3 +193,5 @@ echo "  1. Edit ${PROXY_ENV} (fill in API keys)"
 echo "  2. Edit ${WORKER_ENV} (set LLMCLI_NATS_URL — llm-worker hosts only)"
 echo "  3. systemctl --user start llmcli               # proxy (all hosts)"
 echo "  4. systemctl --user start llmcli-nats-worker   # worker (llm-worker hosts only)"
+echo "  5. llmcli xai login                              # xAI OAuth credentials (lyra-hub / M₁ only)"
+echo "  6. systemctl --user start llmcli-xai-forwarder   # xAI OAuth forwarder (lyra-hub / M₁ only)"

--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -16,3 +16,10 @@ host_roles = ["llm-worker"]
 # M₁ ¬llm-worker (VRAM voiceCLI). M₂ small test pour éviter pression VRAM 16 GB.
 # Override = informational pour l'instant — .container hardcode --model qwen3-4b.
 host_overrides.roxabitower = { model = "qwen3-4b" }
+
+[component.xai-forwarder]
+container = "llmcli-xai-forwarder.container"
+required_secrets = []
+# credentials via bind-mount (rw) — not Podman secrets
+host_roles = ["lyra-hub"]
+# M₁ only — 24/7 cloud relay. xAI OAuth credentials at ~/.roxabi/llmcli/credentials/

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -1,0 +1,30 @@
+[Unit]
+Description=llmCLI xAI OAuth forwarder (:18645)
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Container]
+Image=ghcr.io/roxabi/llmcli:staging
+Label=io.containers.autoupdate=registry
+ContainerName=llmcli-xai-forwarder
+# No PublishPort — internal to roxabi.network only (reachable as
+# http://llmcli-xai-forwarder:18645 from other containers on roxabi.network)
+Network=roxabi.network
+Volume=%h/.roxabi/llmcli/credentials:/home/llmcli/.roxabi/llmcli/credentials:rw,Z
+Environment=LLMCLI_FORWARDER_PROVIDER=xai
+Environment=LLMCLI_FORWARDER_PORT=18645
+UserNS=keep-id:uid=1502,gid=1502
+Exec=python -m llmcli.proxy_forwarder._server
+HealthCmd=curl -f http://localhost:18645/health || exit 1
+HealthInterval=30s
+HealthStartPeriod=15s
+NoNewPrivileges=true
+DropCapability=all
+
+[Service]
+Restart=on-failure
+RestartSec=10
+TimeoutStopSec=20s
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -15,7 +15,7 @@ Environment=LLMCLI_FORWARDER_PROVIDER=xai
 Environment=LLMCLI_FORWARDER_PORT=18645
 UserNS=keep-id:uid=1502,gid=1502
 Exec=python -m llmcli.proxy_forwarder._server
-HealthCmd=curl -f http://localhost:18645/health || exit 1
+HealthCmd=python -c "import urllib.request; urllib.request.urlopen('http://localhost:18645/health', timeout=5)"
 HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -176,6 +176,156 @@ systemctl --user restart llmcli-nats-worker
 
 ---
 
+## xAI OAuth setup
+
+> **M₁ (roxabituwer / lyra-hub host) only.** The xAI forwarder Quadlet runs on M₁.
+> These steps must be performed on that host, not inside a container.
+
+The `llmcli-xai-forwarder` Quadlet forwards requests from the LiteLLM proxy (`:18091`) to
+`api.x.ai/v1`, replacing the incoming bearer token with a real SuperGrok OAuth token on
+every request. Credentials live at `~/.roxabi/llmcli/credentials/xai.json` (mode 0600).
+
+### One-time login
+
+Run the PKCE OAuth flow from the M₁ host shell:
+
+```bash
+llmcli xai login
+```
+
+What happens:
+
+1. The CLI generates a PKCE verifier/challenge and opens a browser to
+   `https://auth.x.ai/oauth/authorize?...&plan=generic` (the `plan=generic`
+   parameter is load-bearing — xAI rejects loopback OAuth without it).
+2. A loopback HTTP listener starts on `127.0.0.1:56121` waiting for the callback
+   (120 s timeout).
+3. You log in with your SuperGrok account and grant consent.
+4. The browser redirects to `http://127.0.0.1:56121/callback?code=…`; the CLI
+   exchanges the authorization code for tokens and writes them to
+   `~/.roxabi/llmcli/credentials/xai.json` (mode 0600, dir mode 0700).
+
+Expected output:
+
+```
+✓ Logged in. expires_at=<unix int>
+```
+
+**If the browser does not open (headless server / SSH session):**
+The CLI prints the full authorize URL to stdout. Open that URL on any browser-capable
+device. The callback redirect targets `127.0.0.1:56121`, so you need an SSH port
+forward so the callback reaches M₁:
+
+```bash
+ssh -L 56121:127.0.0.1:56121 roxabituwer
+# then run llmcli xai login in that SSH session
+```
+
+---
+
+### Status checks
+
+Run these three checks after login to confirm end-to-end wiring:
+
+**1. CLI credential status:**
+
+```bash
+llmcli xai status
+```
+
+Expected (note: no token material ever appears):
+
+```json
+{"logged_in": true, "expires_at": 1748454131, "scope": "openid profile email offline_access grok-cli:access api:access"}
+```
+
+If `logged_in: false`, re-run `llmcli xai login`.
+
+**2. Forwarder service health:**
+
+```bash
+systemctl --user status llmcli-xai-forwarder
+```
+
+Expected: `Active: active (running)` with `Health: healthy`.
+
+**3. Health endpoint from inside the `llmcli` proxy container** (verifies network reachability on `roxabi.network`):
+
+```bash
+podman exec llmcli curl -f http://llmcli-xai-forwarder:18645/health
+```
+
+Expected:
+
+```json
+{"status": "ok", "logged_in": true, "expires_at": 1748454131}
+```
+
+---
+
+### Refresh expiry behavior
+
+**`access_token` (short-lived, ~1 h):**
+The forwarder refreshes lazily — no background timer. When `api.x.ai` returns
+HTTP 401, the forwarder acquires a module-level `asyncio.Lock`, POSTs to
+`auth.x.ai/oauth/token` with the `refresh_token`, persists the new
+`access_token` to `xai.json`, and retries the original request once. Callers
+experience at most one extra round-trip; no manual intervention required.
+
+**Concurrent requests with an expired token:**
+Exactly one refresh POST is in-flight at any time (protected by the asyncio
+Lock). Additional concurrent handlers that enter the lock after a refresh is
+complete re-read the already-fresh credentials from disk and skip their own
+refresh POST.
+
+**`refresh_token` (long-lived, ~30 d while actively used):**
+If the forwarder is offline for ~30 days continuously the refresh token expires.
+The next forwarded request fails with HTTP 401 and header `X-Llmcli-Reauth: required`.
+Operator action: re-run `llmcli xai login`.
+
+To check logs for the reauth signal:
+
+```bash
+journalctl --user -u llmcli-xai-forwarder --since today | grep X-Llmcli-Reauth
+```
+
+---
+
+### Logout / secret rotation
+
+**Logout:**
+
+```bash
+llmcli xai logout
+```
+
+This deletes `~/.roxabi/llmcli/credentials/xai.json` (silent no-op if already absent).
+
+**Restart the forwarder** so it picks up the absent file immediately:
+
+```bash
+systemctl --user restart llmcli-xai-forwarder
+```
+
+After restart the health endpoint reports:
+
+```json
+{"status": "ok", "logged_in": false, "expires_at": null}
+```
+
+LiteLLM will also stop advertising Grok models (re-run `llmcli register-proxy` to
+refresh the managed block in `~/.litellm/config.yaml`).
+
+**New login:**
+
+```bash
+llmcli xai login
+```
+
+The forwarder picks up the new `xai.json` on the next request — no restart needed.
+
+---
+
 ## 4. Diagnostics
 
 ### Unit enters `failed` immediately (no retries)
@@ -246,8 +396,10 @@ podman exec llmcli llmcli proxy --config-out /dev/stdout
 |---|---|
 | `deploy/quadlet/llmcli.container` | Proxy Quadlet unit |
 | `deploy/quadlet/llmcli-nats-worker.container` | Worker Quadlet unit |
+| `deploy/quadlet/llmcli-xai-forwarder.container` | xAI OAuth forwarder Quadlet unit (M₁ only) |
 | `deploy/quadlet.toml` | Manifest (components, host_roles, secrets) |
 | `deploy/install.sh` | Idempotent install script |
 | `~/.roxabi/llmcli/env/proxy.env` | Proxy env file (API keys) |
 | `~/.roxabi/llmcli/env/worker.env` | Worker env file (NATS URL) |
 | `~/.roxabi/llmcli/llmcli.toml` | LLM catalog (model list, host settings) |
+| `~/.roxabi/llmcli/credentials/xai.json` | xAI OAuth credentials (mode 0600, written by `llmcli xai login`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.12,<3.13"
 dependencies = [
     "typer[all]>=0.12",
     "httpx>=0.27",
+    "aiohttp>=3.9",
     "pyyaml>=6.0",
     "huggingface-hub>=1.0",
     "tomli>=2.0; python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "import-linter>=2.1",
     "roxabi-nats>=0.4.1",
     "roxabi-contracts>=0.4.0",
+    "aioresponses>=0.7.8",
 ]
 vllm = [
     "vllm>=0.6.0",

--- a/src/llmcli/auth/__init__.py
+++ b/src/llmcli/auth/__init__.py
@@ -1,0 +1,6 @@
+"""OAuth credential management for llmCLI providers."""
+from .store import XaiCredentials, CredentialsCorruptError, load, save
+from .xai_oauth import login_flow, refresh_credentials
+
+__all__ = ["XaiCredentials", "CredentialsCorruptError", "load", "save",
+           "login_flow", "refresh_credentials"]

--- a/src/llmcli/auth/store.py
+++ b/src/llmcli/auth/store.py
@@ -1,0 +1,79 @@
+"""Credential storage for xAI OAuth tokens.
+
+Atomic-write with fcntl flock. Credentials dir mode 0700, file mode 0600.
+"""
+import fcntl
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+CREDENTIALS_DIR = Path.home() / ".roxabi" / "llmcli" / "credentials"
+XAI_CREDENTIALS_PATH = CREDENTIALS_DIR / "xai.json"
+
+
+class CredentialsCorruptError(RuntimeError):
+    """Raised when credentials JSON cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class XaiCredentials:
+    """Immutable OAuth credentials for xAI / SuperGrok."""
+
+    access_token: str
+    refresh_token: str
+    id_token: str
+    expires_at: int  # unix epoch seconds
+    token_type: str = "Bearer"
+    scope: str = ""
+
+    def __repr__(self) -> str:
+        return (
+            f"XaiCredentials(access_token=***, refresh_token=***, "
+            f"id_token=***, expires_at={self.expires_at}, "
+            f"token_type={self.token_type!r}, scope={self.scope!r})"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+
+def load(path: Path = XAI_CREDENTIALS_PATH) -> XaiCredentials | None:
+    """Load credentials from *path*.
+
+    Returns None if the file does not exist.
+    Raises CredentialsCorruptError if the JSON cannot be parsed.
+    """
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise CredentialsCorruptError(
+            f"credentials corrupted at {path} — re-run `llmcli xai login`"
+        ) from exc
+    return XaiCredentials(**data)
+
+
+def save(creds: XaiCredentials, path: Path = XAI_CREDENTIALS_PATH) -> None:
+    """Atomically write *creds* to *path*.
+
+    Parent directory is created with mode 0700 if absent.
+    Uses an exclusive flock + os.replace for atomicity; final file mode 0600.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_suffix(".tmp")
+    payload = {
+        "access_token": creds.access_token,
+        "refresh_token": creds.refresh_token,
+        "id_token": creds.id_token,
+        "expires_at": creds.expires_at,
+        "token_type": creds.token_type,
+        "scope": creds.scope,
+    }
+    with open(tmp, "w") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        json.dump(payload, f)
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)  # atomic rename

--- a/src/llmcli/auth/store.py
+++ b/src/llmcli/auth/store.py
@@ -48,9 +48,9 @@ def load(path: Path = XAI_CREDENTIALS_PATH) -> XaiCredentials | None:
         return None
     try:
         data = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
+    except (json.JSONDecodeError, OSError) as exc:
         raise CredentialsCorruptError(
-            f"credentials corrupted at {path} — re-run `llmcli xai login`"
+            f"cannot read credentials at {path} ({type(exc).__name__}) — re-run `llmcli xai login`"
         ) from exc
     return XaiCredentials(**data)
 
@@ -62,6 +62,7 @@ def save(creds: XaiCredentials, path: Path = XAI_CREDENTIALS_PATH) -> None:
     Uses an exclusive flock + os.replace for atomicity; final file mode 0600.
     """
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path.parent, 0o700)
     tmp = path.with_suffix(".tmp")
     payload = {
         "access_token": creds.access_token,
@@ -71,9 +72,11 @@ def save(creds: XaiCredentials, path: Path = XAI_CREDENTIALS_PATH) -> None:
         "token_type": creds.token_type,
         "scope": creds.scope,
     }
-    with open(tmp, "w") as f:
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         json.dump(payload, f)
-        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-    os.chmod(tmp, 0o600)
+        f.flush()
+        os.fsync(f.fileno())
+        # lock held until file close (with-block exit)
     os.replace(tmp, path)  # atomic rename

--- a/src/llmcli/auth/xai_oauth.py
+++ b/src/llmcli/auth/xai_oauth.py
@@ -1,0 +1,287 @@
+"""xAI OAuth PKCE flow for llmCLI.
+
+Ported from hermes_cli/auth.py (Hermes Agent). Omits multi-account
+credential_pool — single-account only.
+"""
+import base64
+import hashlib
+import secrets
+import threading
+import time
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from llmcli.auth.store import XaiCredentials, XAI_CREDENTIALS_PATH, save
+
+# ---------------------------------------------------------------------------
+# Constants — load-bearing values, do NOT modify without testing against xAI
+# ---------------------------------------------------------------------------
+XAI_OAUTH_ISSUER = "https://auth.x.ai"
+XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"
+XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access"
+XAI_OAUTH_REDIRECT_PORT = 56121
+XAI_OAUTH_REDIRECT_PATH = "/callback"
+XAI_OAUTH_PLAN = "generic"  # load-bearing — DO NOT remove
+
+_XAI_REDIRECT_HOST = "127.0.0.1"
+_XAI_TOKEN_ENDPOINT = f"{XAI_OAUTH_ISSUER}/oauth/token"
+_XAI_AUTHORIZE_ENDPOINT = f"{XAI_OAUTH_ISSUER}/oauth/authorize"
+
+
+# ---------------------------------------------------------------------------
+# PKCE helpers
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PkceVerifier:
+    """PKCE parameters for one OAuth session."""
+
+    code_verifier: str
+    code_challenge: str
+    state: str
+    nonce: str
+
+
+def _generate_pkce_verifier() -> PkceVerifier:
+    """Generate a fresh PKCE verifier using S256 challenge method."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    state = secrets.token_hex(16)
+    nonce = secrets.token_hex(16)
+    return PkceVerifier(
+        code_verifier=verifier,
+        code_challenge=challenge,
+        state=state,
+        nonce=nonce,
+    )
+
+
+def _build_authorize_url(challenge: str, state: str, nonce: str) -> str:
+    """Build the xAI OAuth authorization URL.
+
+    MUST include plan=generic — without it auth.x.ai rejects loopback OAuth
+    from non-allowlisted clients (ref: Hermes auth.py line 6393).
+    """
+    redirect_uri = (
+        f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
+    )
+    params = {
+        "response_type": "code",
+        "client_id": XAI_OAUTH_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": XAI_OAUTH_SCOPE,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "nonce": nonce,
+        "plan": XAI_OAUTH_PLAN,
+    }
+    return f"{_XAI_AUTHORIZE_ENDPOINT}?{urlencode(params)}"
+
+
+# ---------------------------------------------------------------------------
+# Loopback callback server
+# ---------------------------------------------------------------------------
+
+def _loopback_server(timeout: float = 120.0) -> tuple[str, str]:
+    """Run a single-request HTTP server on 127.0.0.1:56121.
+
+    Blocks until the /callback request arrives (or timeout).
+    Returns (code, state) extracted from the redirect URL.
+    Raises RuntimeError on timeout or OAuth error.
+    """
+    result: dict = {"code": None, "state": None, "error": None}
+    result_lock = threading.Lock()
+    expected_path = XAI_OAUTH_REDIRECT_PATH
+
+    class _CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlparse(self.path)
+            if parsed.path != expected_path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            params = parse_qs(parsed.query)
+            incoming = {
+                "code": params.get("code", [None])[0],
+                "state": params.get("state", [None])[0],
+                "error": params.get("error", [None])[0],
+            }
+            with result_lock:
+                if not (result["code"] or result["error"]):
+                    result.update(incoming)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            if incoming.get("error"):
+                body = b"<html><body><h1>xAI authorization failed.</h1>Close this tab.</body></html>"
+            else:
+                body = b"<html><body><h1>xAI authorization received.</h1>Close this tab.</body></html>"
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A002 — match BaseHTTPRequestHandler signature
+            pass  # silence request logs
+
+    class _ReuseHTTPServer(HTTPServer):
+        allow_reuse_address = True
+
+    server = _ReuseHTTPServer((_XAI_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT), _CallbackHandler)
+    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + timeout
+    try:
+        while time.monotonic() < deadline:
+            if result["code"] or result["error"]:
+                break
+            time.sleep(0.1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+    if result.get("error"):
+        raise RuntimeError(f"xAI authorization failed: {result['error']}")
+    if not result["code"]:
+        raise RuntimeError("xAI authorization timed out waiting for callback.")
+
+    return str(result["code"]), str(result["state"] or "")
+
+
+# ---------------------------------------------------------------------------
+# Token exchange and refresh
+# ---------------------------------------------------------------------------
+
+def exchange_code(code: str, verifier: str) -> XaiCredentials:
+    """Exchange an authorization code for tokens via POST to auth.x.ai/oauth/token.
+
+    Also sends code_challenge + code_challenge_method as defense-in-depth
+    (xAI validates challenge at token step, not only at authorize step).
+    """
+    if not verifier:
+        raise ValueError("PKCE code_verifier is required for token exchange.")
+
+    redirect_uri = (
+        f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
+    )
+    # Recompute challenge from verifier for the defense-in-depth parameter
+    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": XAI_OAUTH_CLIENT_ID,
+        "code_verifier": verifier,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    response = httpx.post(
+        _XAI_TOKEN_ENDPOINT,
+        data=data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"xAI token exchange failed (HTTP {response.status_code}): {response.text.strip()}"
+        )
+    payload = response.json()
+    expires_in = int(payload.get("expires_in") or 3600)
+    return XaiCredentials(
+        access_token=str(payload.get("access_token", "")).strip(),
+        refresh_token=str(payload.get("refresh_token", "")).strip(),
+        id_token=str(payload.get("id_token", "") or "").strip(),
+        expires_at=int(time.time()) + expires_in,
+        token_type=str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        scope=str(payload.get("scope", "") or "").strip(),
+    )
+
+
+def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
+    """Refresh an expired access_token using the stored refresh_token.
+
+    Returns a new XaiCredentials with updated tokens.
+    Raises RuntimeError on 4xx (e.g. refresh_token expired after >30d offline).
+    """
+    response = httpx.post(
+        _XAI_TOKEN_ENDPOINT,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": XAI_OAUTH_CLIENT_ID,
+            "refresh_token": creds.refresh_token,
+        },
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"xAI token refresh failed (HTTP {response.status_code}): {response.text.strip()}"
+        )
+    payload = response.json()
+    expires_in = int(payload.get("expires_in") or 3600)
+    return XaiCredentials(
+        access_token=str(payload.get("access_token", "")).strip(),
+        refresh_token=str(payload.get("refresh_token") or creds.refresh_token).strip(),
+        id_token=str(payload.get("id_token", "") or "").strip(),
+        expires_at=int(time.time()) + expires_in,
+        token_type=str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        scope=str(payload.get("scope", "") or creds.scope).strip(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Login flow orchestrator
+# ---------------------------------------------------------------------------
+
+def login_flow() -> XaiCredentials:
+    """Run the full xAI OAuth PKCE login flow.
+
+    1. Generate PKCE verifier + challenge
+    2. Spawn loopback listener on :56121
+    3. Open browser at auth.x.ai/oauth/authorize?plan=generic&...
+    4. Wait for /callback?code=...&state=...
+    5. Verify state, exchange code for tokens
+    6. Persist credentials to XAI_CREDENTIALS_PATH (0600)
+    7. Return XaiCredentials
+    """
+    pkce = _generate_pkce_verifier()
+    authorize_url = _build_authorize_url(pkce.code_challenge, pkce.state, pkce.nonce)
+
+    print(f"Opening browser at:\n  {authorize_url}")
+    print(f"(loopback listener on {_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT})")
+    print()
+
+    try:
+        webbrowser.open(authorize_url)
+    except Exception:
+        print("Could not open browser automatically — open the URL above manually.")
+
+    print("Waiting for authorization callback (timeout 120s)…")
+    code, received_state = _loopback_server(timeout=120.0)
+
+    if received_state != pkce.state:
+        raise RuntimeError("xAI authorization failed: state mismatch (possible CSRF).")
+
+    print("Authorization code received, exchanging for tokens…")
+    creds = exchange_code(code, pkce.code_verifier)
+
+    save(creds, XAI_CREDENTIALS_PATH)
+
+    print(f"Logged in. Credentials stored at {XAI_CREDENTIALS_PATH}")
+    print(f"  expires_at: {creds.expires_at}")
+    print("  refresh_token: stored (long-lived)")
+
+    return creds

--- a/src/llmcli/auth/xai_oauth.py
+++ b/src/llmcli/auth/xai_oauth.py
@@ -5,6 +5,8 @@ credential_pool — single-account only.
 """
 import base64
 import hashlib
+import hmac
+import logging
 import secrets
 import threading
 import time
@@ -16,6 +18,8 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import httpx
 
 from llmcli.auth.store import XaiCredentials, XAI_CREDENTIALS_PATH, save
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants — load-bearing values, do NOT modify without testing against xAI
@@ -36,6 +40,11 @@ _XAI_AUTHORIZE_ENDPOINT = f"{XAI_OAUTH_ISSUER}/oauth/authorize"
 # PKCE helpers
 # ---------------------------------------------------------------------------
 
+def _s256_challenge(verifier: str) -> str:
+    """Compute the S256 PKCE code_challenge from a verifier string."""
+    return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+
+
 @dataclass(frozen=True)
 class PkceVerifier:
     """PKCE parameters for one OAuth session."""
@@ -49,13 +58,11 @@ class PkceVerifier:
 def _generate_pkce_verifier() -> PkceVerifier:
     """Generate a fresh PKCE verifier using S256 challenge method."""
     verifier = secrets.token_urlsafe(64)
-    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
-    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
     state = secrets.token_hex(16)
     nonce = secrets.token_hex(16)
     return PkceVerifier(
         code_verifier=verifier,
-        code_challenge=challenge,
+        code_challenge=_s256_challenge(verifier),
         state=state,
         nonce=nonce,
     )
@@ -170,8 +177,7 @@ def exchange_code(code: str, verifier: str) -> XaiCredentials:
         f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
     )
     # Recompute challenge from verifier for the defense-in-depth parameter
-    digest = hashlib.sha256(verifier.encode("utf-8")).digest()
-    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    challenge = _s256_challenge(verifier)
 
     data = {
         "grant_type": "authorization_code",
@@ -192,9 +198,8 @@ def exchange_code(code: str, verifier: str) -> XaiCredentials:
         timeout=30.0,
     )
     if response.status_code != 200:
-        raise RuntimeError(
-            f"xAI token exchange failed (HTTP {response.status_code}): {response.text.strip()}"
-        )
+        logger.debug("xai token endpoint error body: %s", response.text)
+        raise RuntimeError(f"xAI token exchange failed (HTTP {response.status_code})")
     payload = response.json()
     expires_in = int(payload.get("expires_in") or 3600)
     return XaiCredentials(
@@ -227,9 +232,8 @@ def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
         timeout=30.0,
     )
     if response.status_code != 200:
-        raise RuntimeError(
-            f"xAI token refresh failed (HTTP {response.status_code}): {response.text.strip()}"
-        )
+        logger.debug("xai token endpoint error body: %s", response.text)
+        raise RuntimeError(f"xAI token refresh failed (HTTP {response.status_code})")
     payload = response.json()
     expires_in = int(payload.get("expires_in") or 3600)
     return XaiCredentials(
@@ -272,8 +276,8 @@ def login_flow() -> XaiCredentials:
     print("Waiting for authorization callback (timeout 120s)…")
     code, received_state = _loopback_server(timeout=120.0)
 
-    if received_state != pkce.state:
-        raise RuntimeError("xAI authorization failed: state mismatch (possible CSRF).")
+    if not hmac.compare_digest(received_state, pkce.state):
+        raise RuntimeError("OAuth state mismatch — possible CSRF")
 
     print("Authorization code received, exchanging for tokens…")
     creds = exchange_code(code, pkce.code_verifier)

--- a/src/llmcli/cli/_app.py
+++ b/src/llmcli/cli/_app.py
@@ -6,3 +6,6 @@ from rich.console import Console
 app = typer.Typer(add_completion=False, help="llmCLI — local LLM serving")
 console = Console()
 err_console = Console(stderr=True)
+
+from llmcli.cli.xai import xai_app  # noqa: E402
+app.add_typer(xai_app, name="xai")

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -14,7 +14,12 @@ import yaml
 
 from llmcli.cli._app import app, console, err_console
 from llmcli.config import Catalog
-from llmcli.support.litellm_config import build_model_list, load_proxy_base, merge_proxy_config
+from llmcli.support.litellm_config import (
+    build_model_list,
+    emit_xai_oauth_warning_if_absent,
+    load_proxy_base,
+    merge_proxy_config,
+)
 from llmcli.support.providers import PROVIDERS
 
 # ---------------------------------------------------------------------------
@@ -66,6 +71,9 @@ def register_proxy(
         raise typer.Exit(code=1)
 
     model_count = len(catalog.models)
+
+    # 5a. Warn if xAI credentials are absent (discoverability hint)
+    emit_xai_oauth_warning_if_absent(err_console)
 
     # 6. Reload proxy — warn on failure, don't fail the command
     try:

--- a/src/llmcli/cli/xai.py
+++ b/src/llmcli/cli/xai.py
@@ -1,0 +1,39 @@
+"""xAI / SuperGrok OAuth credentials CLI subcommands."""
+from __future__ import annotations
+
+import typer
+
+from llmcli.auth import login_flow, store
+from llmcli.auth.store import CredentialsCorruptError
+from llmcli.cli._app import console, err_console
+
+xai_app = typer.Typer(help="xAI / SuperGrok OAuth credentials")
+
+
+@xai_app.command("login")
+def login_cmd() -> None:
+    """Run PKCE OAuth flow against auth.x.ai; stores credentials at xai.json."""
+    creds = login_flow()
+    console.print(f"[green]✓[/green] Logged in. expires_at={creds.expires_at}")
+
+
+@xai_app.command("logout")
+def logout_cmd() -> None:
+    """Delete cached xai.json credentials (silent no-op if absent)."""
+    store.XAI_CREDENTIALS_PATH.unlink(missing_ok=True)
+    console.print("[green]✓[/green] Credentials removed.")
+
+
+@xai_app.command("status")
+def status_cmd() -> None:
+    """Report logged_in + expires_at + scope. Never prints token material."""
+    try:
+        creds = store.load()
+    except CredentialsCorruptError as exc:
+        err_console.print(f"[red]error:[/red] {exc}")
+        raise typer.Exit(2)
+    if creds is None:
+        console.print({"logged_in": False})
+        raise typer.Exit(1)
+    # AC3: stdout must NOT contain eyJ (JWT prefix) or xai- substring
+    console.print({"logged_in": True, "expires_at": creds.expires_at, "scope": creds.scope})

--- a/src/llmcli/cli/xai.py
+++ b/src/llmcli/cli/xai.py
@@ -1,6 +1,8 @@
 """xAI / SuperGrok OAuth credentials CLI subcommands."""
 from __future__ import annotations
 
+import json
+
 import typer
 
 from llmcli.auth import login_flow, store
@@ -33,7 +35,7 @@ def status_cmd() -> None:
         err_console.print(f"[red]error:[/red] {exc}")
         raise typer.Exit(2)
     if creds is None:
-        console.print({"logged_in": False})
+        console.print(json.dumps({"logged_in": False}))
         raise typer.Exit(1)
     # AC3: stdout must NOT contain eyJ (JWT prefix) or xai- substring
-    console.print({"logged_in": True, "expires_at": creds.expires_at, "scope": creds.scope})
+    console.print(json.dumps({"logged_in": True, "expires_at": creds.expires_at, "scope": creds.scope}))

--- a/src/llmcli/nats/_lifecycle.py
+++ b/src/llmcli/nats/_lifecycle.py
@@ -19,7 +19,9 @@ from pydantic import ValidationError
 from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse
 from roxabi_contracts.errors import WorkerError
 
+from llmcli.auth.store import XAI_CREDENTIALS_PATH
 from llmcli.config import check_vram_budget, load as load_catalog
+from llmcli.support.litellm_config import _XAI_OAUTH_MODELS
 
 log = logging.getLogger(__name__)
 
@@ -247,6 +249,14 @@ class LifecycleMixin:
             }
             for name, spec in catalog.models.items()
         ]
+        if XAI_CREDENTIALS_PATH.exists():
+            for model_name in _XAI_OAUTH_MODELS:
+                models.append({
+                    "name": model_name,
+                    "running": False,  # forwarder liveness checked via /health, not surfaced here
+                    "engine": "oauth-forwarder",
+                    "vram_gib": 0,
+                })
         await self._reply_ok(msg, req, data={"models": models})
 
     async def _do_stop(self, msg, req: LifecycleRequest) -> None:

--- a/src/llmcli/proxy_forwarder/__init__.py
+++ b/src/llmcli/proxy_forwarder/__init__.py
@@ -1,0 +1,14 @@
+"""Provider-agnostic OAuth-managed forwarder for LiteLLM upstream calls."""
+
+from ._common import ALLOWED_PATHS, OAuthAdapter, lazy_retry_on_401
+from ._server import create_app, main
+from .xai_adapter import XaiAdapter
+
+__all__ = [
+    "OAuthAdapter",
+    "lazy_retry_on_401",
+    "ALLOWED_PATHS",
+    "create_app",
+    "main",
+    "XaiAdapter",
+]

--- a/src/llmcli/proxy_forwarder/_common.py
+++ b/src/llmcli/proxy_forwarder/_common.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
 
@@ -36,7 +37,10 @@ ALLOWED_PATHS: frozenset[str] = frozenset(
 # across all concurrent request handlers in the same process.
 # ---------------------------------------------------------------------------
 
-_REFRESH_LOCK = asyncio.Lock()
+# _REFRESH_LOCK is module-level — exactly ONE in-flight refresh per process.
+# Python 3.10+: asyncio.Lock is loop-agnostic (bpo-39529); safe to instantiate at import.
+# Requires Python ≥ 3.10 (project targets 3.12).
+_REFRESH_LOCK: asyncio.Lock = asyncio.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -126,20 +130,21 @@ async def lazy_retry_on_401(
         # already written fresh tokens to disk while we waited.
         fresh_creds = store_load()
 
-        if fresh_creds is not None and fresh_creds.access_token != creds.access_token:
-            # Token was already refreshed by a concurrent handler — use it.
+        if fresh_creds is None:
+            # Credentials disappeared mid-flight; propagate 401.
+            return _Resp401()
+
+        # Spec-mandated: if another handler already refreshed and the new token
+        # is not expired, skip the POST and retry with the already-refreshed token.
+        if fresh_creds.expires_at > int(time.time()) + 5:  # 5s skew tolerance
             logger.debug("lazy_retry_on_401: token refreshed by another handler, skipping POST")
-            new_creds = fresh_creds
+            resp = await request_fn(fresh_creds.access_token)
         else:
-            # Token is still the stale one — we are responsible for refreshing.
+            # Token is still expired — we are responsible for refreshing.
             logger.info("lazy_retry_on_401: refreshing token via refresh_fn")
-            if fresh_creds is None:
-                # Credentials disappeared mid-flight; propagate 401.
-                return _Resp401()
             new_creds = await refresh_fn(fresh_creds)
             store_save(new_creds)
-
-        resp = await request_fn(new_creds.access_token)
+            resp = await request_fn(new_creds.access_token)
 
     return resp
 

--- a/src/llmcli/proxy_forwarder/_common.py
+++ b/src/llmcli/proxy_forwarder/_common.py
@@ -1,0 +1,155 @@
+"""Provider-agnostic OAuth machinery for the llmCLI forwarder.
+
+Contains:
+- ALLOWED_PATHS: frozenset of forwarded endpoint paths.
+- _REFRESH_LOCK: module-level asyncio.Lock for single-flight token refresh.
+- OAuthAdapter: Protocol defining the adapter contract.
+- lazy_retry_on_401: Async helper that retries once after refreshing the token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Path allowlist — unknown paths are rejected with 404.
+# ---------------------------------------------------------------------------
+
+ALLOWED_PATHS: frozenset[str] = frozenset(
+    {
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/v1/responses",
+        "/v1/embeddings",
+        "/v1/models",
+        "/health",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Module-level refresh lock — ensures exactly one token refresh in-flight
+# across all concurrent request handlers in the same process.
+# ---------------------------------------------------------------------------
+
+_REFRESH_LOCK = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# OAuthAdapter Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class OAuthAdapter(Protocol):
+    """Contract every provider adapter must satisfy.
+
+    Attributes
+    ----------
+    api_base:
+        Upstream base URL (no trailing slash), e.g. ``https://api.x.ai/v1``.
+    credential_path:
+        Filesystem path to the JSON credentials file for this provider.
+    """
+
+    api_base: str
+    credential_path: Path
+
+    async def refresh(self, creds: Any) -> Any:
+        """Exchange the stored refresh_token for a new credentials object.
+
+        Implementations should delegate to the synchronous auth module via
+        ``loop.run_in_executor`` to avoid blocking the event loop.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# lazy_retry_on_401 — single-flight 401 retry
+# ---------------------------------------------------------------------------
+
+
+async def lazy_retry_on_401(
+    request_fn: Callable[[str], Awaitable[Any]],
+    refresh_fn: Callable[[Any], Awaitable[Any]],
+    store_load: Callable[[], Any],
+    store_save: Callable[[Any], None],
+) -> Any:
+    """Call *request_fn* with the current access_token; refresh once on 401.
+
+    Algorithm
+    ---------
+    1. Load credentials from store; call request_fn(access_token).
+    2. If response is not 401, return immediately.
+    3. Acquire _REFRESH_LOCK (only one coroutine refreshes at a time):
+       a. Re-read credentials from store — another handler may have already
+          refreshed the token while we waited for the lock.
+       b. If the access_token changed (another handler refreshed), skip the
+          POST and retry with the already-refreshed token.
+       c. Otherwise call refresh_fn(creds), persist via store_save, and
+          retry with the new token.
+    4. Return the retry response; the caller maps a still-401 to
+       ``X-Llmcli-Reauth: required``.
+
+    Parameters
+    ----------
+    request_fn:
+        Async callable that accepts a bearer token string and returns an
+        aiohttp-like response (must expose ``.status``).
+    refresh_fn:
+        Async callable that accepts the credentials object and returns
+        a refreshed credentials object.
+    store_load:
+        Sync callable (no args) that returns the current credentials or None.
+    store_save:
+        Sync callable that persists a credentials object.
+    """
+    creds = store_load()
+    if creds is None:
+        # No credentials at all — propagate as 401 so caller can add header.
+        # We build a minimal stand-in response object.
+        return _Resp401()
+
+    resp = await request_fn(creds.access_token)
+    if resp.status != 401:
+        return resp
+
+    # 401 received — enter the single-flight refresh path.
+    logger.info("lazy_retry_on_401: received 401, acquiring refresh lock")
+
+    async with _REFRESH_LOCK:
+        # Re-read creds after acquiring the lock; another handler may have
+        # already written fresh tokens to disk while we waited.
+        fresh_creds = store_load()
+
+        if fresh_creds is not None and fresh_creds.access_token != creds.access_token:
+            # Token was already refreshed by a concurrent handler — use it.
+            logger.debug("lazy_retry_on_401: token refreshed by another handler, skipping POST")
+            new_creds = fresh_creds
+        else:
+            # Token is still the stale one — we are responsible for refreshing.
+            logger.info("lazy_retry_on_401: refreshing token via refresh_fn")
+            if fresh_creds is None:
+                # Credentials disappeared mid-flight; propagate 401.
+                return _Resp401()
+            new_creds = await refresh_fn(fresh_creds)
+            store_save(new_creds)
+
+        resp = await request_fn(new_creds.access_token)
+
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Minimal stand-in for a 401 response when credentials are absent.
+# ---------------------------------------------------------------------------
+
+
+class _Resp401:
+    """Minimal response stand-in for the no-credentials-found case."""
+
+    status: int = 401

--- a/src/llmcli/proxy_forwarder/_server.py
+++ b/src/llmcli/proxy_forwarder/_server.py
@@ -1,0 +1,258 @@
+"""Provider-agnostic aiohttp forwarder server for llmCLI OAuth upstreams.
+
+Listens on ``http://0.0.0.0:<port>`` and forwards allowed paths to the
+upstream defined by the injected OAuthAdapter. Authorization header is
+replaced with the real OAuth bearer on every request.
+
+Supports SSE streaming on ``/v1/chat/completions`` via aiohttp StreamResponse.
+
+Usage (as __main__)::
+
+    LLMCLI_FORWARDER_PROVIDER=xai LLMCLI_FORWARDER_PORT=18645 \\
+        python -m llmcli.proxy_forwarder._server
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import aiohttp
+from aiohttp import web
+from multidict import CIMultiDictProxy
+
+from llmcli.auth import store
+from llmcli.auth.store import CredentialsCorruptError
+
+from ._common import ALLOWED_PATHS, OAuthAdapter, lazy_retry_on_401
+
+logger = logging.getLogger(__name__)
+
+# Headers that must not be forwarded verbatim — aiohttp recomputes
+# content-length; authorization is replaced with the real bearer token.
+_DROP_REQUEST_HEADERS: frozenset[str] = frozenset(
+    {
+        "host",
+        "content-length",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "authorization",
+    }
+)
+
+# Response headers that aiohttp manages itself or that are unreliable to
+# forward across a hop — strip them from the upstream response.
+_DROP_RESPONSE_HEADERS: frozenset[str] = frozenset(
+    {
+        "host",
+        "content-length",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "content-encoding",
+    }
+)
+
+DEFAULT_PORT = 18645
+DEFAULT_HOST = "0.0.0.0"
+
+
+def _filter_request_headers(headers: CIMultiDictProxy[str]) -> dict[str, str]:
+    """Return inbound headers with hop-by-hop + Authorization stripped."""
+    return {k: v for k, v in headers.items() if k.lower() not in _DROP_REQUEST_HEADERS}
+
+
+def _filter_response_headers(headers: CIMultiDictProxy[str]) -> dict[str, str]:
+    """Return upstream response headers with hop-by-hop stripped."""
+    return {k: v for k, v in headers.items() if k.lower() not in _DROP_RESPONSE_HEADERS}
+
+
+# ---------------------------------------------------------------------------
+# Handler factories — closures that capture the adapter via DI.
+# ---------------------------------------------------------------------------
+
+
+def _health(adapter: OAuthAdapter):
+    """Return a GET /health handler bound to *adapter*."""
+
+    async def handler(request: web.Request) -> web.Response:  # noqa: ARG001 — handler signature
+        try:
+            creds = store.load(adapter.credential_path)
+            return web.json_response(
+                {
+                    "status": "ok",
+                    "logged_in": creds is not None,
+                    "expires_at": creds.expires_at if creds else None,
+                }
+            )
+        except CredentialsCorruptError:
+            # Corrupt credentials file — operator must re-run `llmcli xai login`.
+            # Return 200 with logged_in:false so systemd HealthCmd still succeeds
+            # and the operator can observe the state via `llmcli xai status`.
+            return web.json_response(
+                {"status": "ok", "logged_in": False, "expires_at": None},
+                status=200,
+            )
+
+    return handler
+
+
+def _proxy(adapter: OAuthAdapter):
+    """Return a catch-all proxy handler bound to *adapter*."""
+
+    async def handler(request: web.Request) -> web.StreamResponse | web.Response:
+        path = request.path
+
+        if path not in ALLOWED_PATHS:
+            return web.Response(status=404)
+
+        # Fail fast if credentials are corrupt — don't forward the request.
+        try:
+            _pre_check = store.load(adapter.credential_path)
+        except CredentialsCorruptError:
+            return web.Response(
+                status=503,
+                headers={"X-Llmcli-Reauth": "required"},
+                text="credentials corrupted — re-run llmcli xai login",
+            )
+        if _pre_check is None:
+            return web.Response(
+                status=401,
+                headers={"X-Llmcli-Reauth": "required"},
+                text="not logged in — run llmcli xai login",
+            )
+
+        body = await request.read()
+        fwd_headers = _filter_request_headers(request.headers)
+
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
+
+        async def request_fn(token: str) -> aiohttp.ClientResponse:
+            upstream_url = f"{adapter.api_base.rstrip('/')}{path}"
+            if request.query_string:
+                upstream_url = f"{upstream_url}?{request.query_string}"
+            headers = {**fwd_headers, "Authorization": f"Bearer {token}"}
+            session = aiohttp.ClientSession(timeout=timeout)
+            try:
+                upstream_resp = await session.request(
+                    request.method,
+                    upstream_url,
+                    data=body if body else None,
+                    headers=headers,
+                    allow_redirects=False,
+                )
+            except Exception:
+                await session.close()
+                raise
+            # Attach session to response so caller can close it.
+            upstream_resp._llmcli_session = session  # type: ignore[attr-defined]
+            return upstream_resp
+
+        try:
+            upstream_resp = await lazy_retry_on_401(
+                request_fn,
+                adapter.refresh,
+                lambda: store.load(adapter.credential_path),
+                lambda c: store.save(c, adapter.credential_path),
+            )
+        except aiohttp.ClientError as exc:
+            logger.warning("proxy: upstream connection failed: %s", exc)
+            return web.Response(status=502, text=f"upstream connection failed: {exc}")
+        except asyncio.TimeoutError:
+            return web.Response(status=504, text="upstream request timed out")
+
+        # Still 401 after retry — operator must re-authenticate.
+        if upstream_resp.status == 401:
+            session = getattr(upstream_resp, "_llmcli_session", None)
+            if session:
+                await session.close()
+            return web.Response(status=401, headers={"X-Llmcli-Reauth": "required"})
+
+        # Stream response back (supports SSE on /v1/chat/completions).
+        session = getattr(upstream_resp, "_llmcli_session", None)
+        resp_headers = _filter_response_headers(upstream_resp.headers)
+        stream = web.StreamResponse(status=upstream_resp.status, headers=resp_headers)
+        await stream.prepare(request)
+        try:
+            async for chunk in upstream_resp.content.iter_any():
+                if chunk:
+                    await stream.write(chunk)
+        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
+            logger.warning("proxy: streaming interrupted: %s", exc)
+        finally:
+            upstream_resp.release()
+            if session:
+                await session.close()
+
+        await stream.write_eof()
+        return stream
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app(adapter: OAuthAdapter) -> web.Application:
+    """Build the aiohttp Application for *adapter*.
+
+    Routes:
+    - GET /health  → credential presence check (always 200).
+    - *   /{path}  → proxy to upstream (404 if path not in ALLOWED_PATHS).
+    """
+    app = web.Application()
+    app.router.add_get("/health", _health(adapter))
+    app.router.add_route("*", "/{path:.*}", _proxy(adapter))
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Start the forwarder.
+
+    Environment variables
+    ---------------------
+    LLMCLI_FORWARDER_PROVIDER : str, default "xai"
+        Which OAuth adapter to use. Currently only "xai" is supported.
+    LLMCLI_FORWARDER_PORT : int, default 18645
+        TCP port to bind on 0.0.0.0.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+    provider = os.environ.get("LLMCLI_FORWARDER_PROVIDER", "xai")
+    port = int(os.environ.get("LLMCLI_FORWARDER_PORT", DEFAULT_PORT))
+
+    if provider == "xai":
+        from .xai_adapter import XaiAdapter
+
+        adapter: OAuthAdapter = XaiAdapter()
+    else:
+        raise ValueError(
+            f"Unknown LLMCLI_FORWARDER_PROVIDER={provider!r}. "
+            "Supported: 'xai'."
+        )
+
+    logger.info("llmcli-forwarder: provider=%s port=%d", provider, port)
+    web.run_app(create_app(adapter), host=DEFAULT_HOST, port=port, access_log=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llmcli/proxy_forwarder/_server.py
+++ b/src/llmcli/proxy_forwarder/_server.py
@@ -118,86 +118,72 @@ def _proxy(adapter: OAuthAdapter):
         if path not in ALLOWED_PATHS:
             return web.Response(status=404)
 
-        # Fail fast if credentials are corrupt — don't forward the request.
-        try:
-            _pre_check = store.load(adapter.credential_path)
-        except CredentialsCorruptError:
-            return web.Response(
-                status=503,
-                headers={"X-Llmcli-Reauth": "required"},
-                text="credentials corrupted — re-run llmcli xai login",
-            )
-        if _pre_check is None:
-            return web.Response(
-                status=401,
-                headers={"X-Llmcli-Reauth": "required"},
-                text="not logged in — run llmcli xai login",
-            )
-
         body = await request.read()
         fwd_headers = _filter_request_headers(request.headers)
 
-        timeout = aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=None, sock_connect=15, sock_read=300)
+        ) as session:
 
-        async def request_fn(token: str) -> aiohttp.ClientResponse:
-            upstream_url = f"{adapter.api_base.rstrip('/')}{path}"
-            if request.query_string:
-                upstream_url = f"{upstream_url}?{request.query_string}"
-            headers = {**fwd_headers, "Authorization": f"Bearer {token}"}
-            session = aiohttp.ClientSession(timeout=timeout)
-            try:
-                upstream_resp = await session.request(
+            async def request_fn(token: str) -> aiohttp.ClientResponse:
+                upstream_url = f"{adapter.api_base.rstrip('/')}{path}"
+                if request.query_string:
+                    upstream_url = f"{upstream_url}?{request.query_string}"
+                headers = {**fwd_headers, "Authorization": f"Bearer {token}"}
+                return await session.request(
                     request.method,
                     upstream_url,
                     data=body if body else None,
                     headers=headers,
                     allow_redirects=False,
                 )
-            except Exception:
-                await session.close()
-                raise
-            # Attach session to response so caller can close it.
-            upstream_resp._llmcli_session = session  # type: ignore[attr-defined]
-            return upstream_resp
 
-        try:
-            upstream_resp = await lazy_retry_on_401(
-                request_fn,
-                adapter.refresh,
-                lambda: store.load(adapter.credential_path),
-                lambda c: store.save(c, adapter.credential_path),
-            )
-        except aiohttp.ClientError as exc:
-            logger.warning("proxy: upstream connection failed: %s", exc)
-            return web.Response(status=502, text=f"upstream connection failed: {exc}")
-        except asyncio.TimeoutError:
-            return web.Response(status=504, text="upstream request timed out")
+            try:
+                upstream_resp = await lazy_retry_on_401(
+                    request_fn,
+                    adapter.refresh,
+                    lambda: store.load(adapter.credential_path),
+                    lambda c: store.save(c, adapter.credential_path),
+                )
+            except CredentialsCorruptError:
+                return web.Response(
+                    status=503,
+                    headers={"X-Llmcli-Reauth": "required"},
+                    text="credentials corrupted — re-run llmcli xai login",
+                )
+            except RuntimeError:
+                logger.warning("proxy: token refresh failed for %s — re-auth required", request.path)
+                # ¬log the exc — its message may contain response.text from auth.x.ai
+                return web.Response(
+                    status=401,
+                    headers={"X-Llmcli-Reauth": "required"},
+                    text="token refresh failed — re-run `llmcli xai login`",
+                )
+            except aiohttp.ClientError as exc:
+                logger.warning("proxy: upstream connection failed: %s", exc)
+                return web.Response(status=502, text=f"upstream connection failed: {exc}")
+            except asyncio.TimeoutError:
+                return web.Response(status=504, text="upstream request timed out")
 
-        # Still 401 after retry — operator must re-authenticate.
-        if upstream_resp.status == 401:
-            session = getattr(upstream_resp, "_llmcli_session", None)
-            if session:
-                await session.close()
-            return web.Response(status=401, headers={"X-Llmcli-Reauth": "required"})
+            # Still 401 after retry — operator must re-authenticate.
+            if upstream_resp.status == 401:
+                return web.Response(status=401, headers={"X-Llmcli-Reauth": "required"})
 
-        # Stream response back (supports SSE on /v1/chat/completions).
-        session = getattr(upstream_resp, "_llmcli_session", None)
-        resp_headers = _filter_response_headers(upstream_resp.headers)
-        stream = web.StreamResponse(status=upstream_resp.status, headers=resp_headers)
-        await stream.prepare(request)
-        try:
-            async for chunk in upstream_resp.content.iter_any():
-                if chunk:
-                    await stream.write(chunk)
-        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
-            logger.warning("proxy: streaming interrupted: %s", exc)
-        finally:
-            upstream_resp.release()
-            if session:
-                await session.close()
+            # Stream response back (supports SSE on /v1/chat/completions).
+            resp_headers = _filter_response_headers(upstream_resp.headers)
+            stream = web.StreamResponse(status=upstream_resp.status, headers=resp_headers)
+            await stream.prepare(request)
+            try:
+                async for chunk in upstream_resp.content.iter_any():
+                    if chunk:
+                        await stream.write(chunk)
+            except (aiohttp.ClientError, asyncio.CancelledError) as exc:
+                logger.warning("proxy: streaming interrupted: %s", exc)
+            finally:
+                upstream_resp.release()
 
-        await stream.write_eof()
-        return stream
+            await stream.write_eof()
+            return stream
 
     return handler
 

--- a/src/llmcli/proxy_forwarder/xai_adapter.py
+++ b/src/llmcli/proxy_forwarder/xai_adapter.py
@@ -1,0 +1,50 @@
+"""xAI provider adapter for the llmCLI OAuth forwarder.
+
+Implements OAuthAdapter for a single-account SuperGrok credential.
+The adapter is intentionally thin: it holds only provider-specific
+configuration (api_base, credential_path) and delegates to the auth
+module for token refresh.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from llmcli.auth.store import XAI_CREDENTIALS_PATH, XaiCredentials
+from llmcli.auth.xai_oauth import refresh_credentials
+
+
+class XaiAdapter:
+    """OAuthAdapter implementation for xAI / SuperGrok OAuth credentials.
+
+    Attributes
+    ----------
+    api_base:
+        xAI public OpenAI-compatible API base URL.
+    credential_path:
+        Path to the JSON file written by ``llmcli xai login``.
+    """
+
+    api_base: str = "https://api.x.ai/v1"
+    credential_path = XAI_CREDENTIALS_PATH
+
+    async def refresh(self, creds: XaiCredentials) -> XaiCredentials:
+        """Refresh *creds* via the xAI token endpoint.
+
+        Delegates to the synchronous ``refresh_credentials`` function via
+        ``run_in_executor`` to avoid blocking the event loop during the
+        HTTPS POST to auth.x.ai.
+
+        Parameters
+        ----------
+        creds:
+            Credentials whose ``refresh_token`` will be exchanged for a new
+            ``access_token``.
+
+        Returns
+        -------
+        XaiCredentials
+            Fresh credentials with updated ``access_token`` and ``expires_at``.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, refresh_credentials, creds)

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -15,6 +15,10 @@ from llmcli.support.providers import PROVIDERS
 log = logging.getLogger(__name__)
 
 LITELLM_CONFIG = Path.home() / ".litellm" / "config.yaml"
+
+# xAI OAuth — hardcoded model list (forwarder-routed; NOT in per-host TOML catalog)
+_XAI_OAUTH_MODELS: list[str] = ["grok-4", "grok-4-fast"]
+_XAI_CREDENTIALS_PATH = Path.home() / ".roxabi" / "llmcli" / "credentials" / "xai.json"
 BLOCK_START = "# --- llmCLI managed block start ---"
 BLOCK_END = "# --- llmCLI managed block end ---"
 
@@ -129,6 +133,25 @@ def build_model_list(
                 },
             }
         model_list.append(entry)
+
+    # Inject OAuth-managed models (not in catalog — forwarder-routed)
+    # Gate on credentials presence; silently skip when absent.
+    from llmcli.support.providers import PROVIDERS as _PROVIDERS  # local import avoids circularity
+
+    xai_provider = _PROVIDERS.get("xai-oauth")
+    if xai_provider is not None and xai_provider.key_env == "_OAUTH_MANAGED":
+        if _XAI_CREDENTIALS_PATH.exists():
+            for model_name in _XAI_OAUTH_MODELS:
+                model_list.append(
+                    {
+                        "model_name": model_name,
+                        "litellm_params": {
+                            "model": f"openai/{model_name}",
+                            "api_base": xai_provider.api_base,
+                            "api_key": "dummy",  # LiteLLM requires non-empty; forwarder ignores
+                        },
+                    }
+                )
 
     return model_list
 
@@ -248,6 +271,19 @@ def write_block(block: str, path: Path = LITELLM_CONFIG) -> None:
         new_content = before + block + after
 
     path.write_text(new_content)
+
+
+def emit_xai_oauth_warning_if_absent(err_console: Any) -> None:
+    """Print a stderr warning when xAI credentials are absent.
+
+    Called from cli/proxy.py:register_proxy after the LiteLLM config write.
+    No-op when credentials exist.
+    """
+    if not _XAI_CREDENTIALS_PATH.exists():
+        err_console.print(
+            "[yellow]WARNING:[/yellow] xAI credentials not found — "
+            "run `llmcli xai login` to enable Grok models"
+        )
 
 
 def reload_proxy() -> None:

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import yaml
 
+from llmcli.auth.store import XAI_CREDENTIALS_PATH as _XAI_CREDENTIALS_PATH
 from llmcli.config import Catalog
 from llmcli.support.providers import PROVIDERS
 
@@ -18,7 +19,6 @@ LITELLM_CONFIG = Path.home() / ".litellm" / "config.yaml"
 
 # xAI OAuth — hardcoded model list (forwarder-routed; NOT in per-host TOML catalog)
 _XAI_OAUTH_MODELS: list[str] = ["grok-4", "grok-4-fast"]
-_XAI_CREDENTIALS_PATH = Path.home() / ".roxabi" / "llmcli" / "credentials" / "xai.json"
 BLOCK_START = "# --- llmCLI managed block start ---"
 BLOCK_END = "# --- llmCLI managed block end ---"
 
@@ -136,9 +136,7 @@ def build_model_list(
 
     # Inject OAuth-managed models (not in catalog — forwarder-routed)
     # Gate on credentials presence; silently skip when absent.
-    from llmcli.support.providers import PROVIDERS as _PROVIDERS  # local import avoids circularity
-
-    xai_provider = _PROVIDERS.get("xai-oauth")
+    xai_provider = PROVIDERS.get("xai-oauth")
     if xai_provider is not None and xai_provider.key_env == "_OAUTH_MANAGED":
         if _XAI_CREDENTIALS_PATH.exists():
             for model_name in _XAI_OAUTH_MODELS:

--- a/src/llmcli/support/providers.py
+++ b/src/llmcli/support/providers.py
@@ -19,4 +19,5 @@ PROVIDERS: dict[str, Provider] = {
     "anthropic": Provider("https://api.anthropic.com", "ANTHROPIC_API_KEY"),
     "openai": Provider("https://api.openai.com/v1", "OPENAI_API_KEY"),
     "nvidia-nim": Provider("https://integrate.api.nvidia.com/v1", "NVIDIA_API_KEY"),
+    "xai-oauth": Provider("http://llmcli-xai-forwarder:18645/v1", "_OAUTH_MANAGED"),
 }

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -1,0 +1,313 @@
+"""RED-phase tests for xAI OAuth PKCE flow and credential store.
+
+Tests 1 and 4 (test_pkce_code_exchange, test_credentials_corrupted) exercise
+auth/xai_oauth.py + auth/store.py from Wave 1 and are expected to PASS after
+backend-dev-A completes T2 + T3.
+
+Tests 2 and 3 (test_lazy_refresh_on_401, test_concurrent_refresh_dedup) exercise
+proxy_forwarder/_common.py from Wave 2 and are SKIPPED until that module lands
+(import-guarded via importlib.util.find_spec at module level).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Wave 1 import guard — auth modules (required for T1/T4 at RG1)
+# findspec on a submodule of a non-existent parent raises ModuleNotFoundError,
+# so we guard with a try/except rather than find_spec directly.
+# ---------------------------------------------------------------------------
+
+try:
+    from llmcli.auth.store import CredentialsCorruptError, XaiCredentials
+    from llmcli.auth import store as auth_store
+
+    _AUTH_STORE_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    _AUTH_STORE_AVAILABLE = False
+
+try:
+    from llmcli.auth.xai_oauth import (
+        XAI_OAUTH_CLIENT_ID,
+        XAI_OAUTH_PLAN,
+        _build_authorize_url,
+        exchange_code,
+    )
+
+    _AUTH_OAUTH_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    _AUTH_OAUTH_AVAILABLE = False
+
+_AUTH_AVAILABLE = _AUTH_STORE_AVAILABLE and _AUTH_OAUTH_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# Wave 2 import guard — proxy_forwarder._common (required for T2/T3 at RG2)
+# ---------------------------------------------------------------------------
+
+try:
+    from llmcli.proxy_forwarder._common import _REFRESH_LOCK, lazy_retry_on_401  # noqa: F401
+
+    _FORWARDER_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    _FORWARDER_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def creds_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Monkeypatch XAI_CREDENTIALS_PATH to a temp file; return the path."""
+    xai_creds = tmp_path / "xai.json"
+    if _AUTH_STORE_AVAILABLE:
+        monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", xai_creds)
+    return xai_creds
+
+
+def _make_fake_creds(
+    access_token: str = "ATK",
+    refresh_token: str = "RTK",
+    id_token: str = "ITK",
+    expires_delta: int = 3600,
+) -> "XaiCredentials":
+    """Build an XaiCredentials for test usage."""
+    return XaiCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        id_token=id_token,
+        expires_at=int(time.time()) + expires_delta,
+        token_type="Bearer",
+        scope="openid",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — PKCE code exchange
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _AUTH_AVAILABLE, reason="auth modules not yet implemented (Wave 1)")
+def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """exchange_code POSTs to auth.x.ai/oauth/token with correct body; returns XaiCredentials."""
+    # Arrange
+    fake_response_json = {
+        "access_token": "ATK",
+        "refresh_token": "RTK",
+        "id_token": "ITK",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+    }
+    fake_verifier = "s" * 43  # minimum PKCE verifier length
+
+    captured_kwargs: dict = {}
+
+    def _fake_post(url: str, **kwargs):  # type: ignore[return]
+        captured_kwargs["url"] = url
+        captured_kwargs.update(kwargs)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = fake_response_json
+        return mock_resp
+
+    # Act — patch httpx.post used by exchange_code
+    with patch("httpx.post", side_effect=_fake_post):
+        before = int(time.time())
+        result = exchange_code(code="test_code", verifier=fake_verifier)
+        after = int(time.time())
+
+    # Assert — POST was made to auth.x.ai/oauth/token
+    assert captured_kwargs["url"] == "https://auth.x.ai/oauth/token"
+
+    # Assert — request body contains required fields (httpx uses data= as dict)
+    body = captured_kwargs.get("data") or {}
+    if isinstance(body, bytes):
+        body = dict(item.split("=") for item in body.decode().split("&"))
+    assert body.get("grant_type") == "authorization_code", f"body={body}"
+    assert body.get("code") == "test_code", f"body={body}"
+    assert body.get("code_verifier") == fake_verifier, f"body={body}"
+    assert body.get("client_id") == XAI_OAUTH_CLIENT_ID, f"body={body}"
+
+    # Assert — returned XaiCredentials matches mock response
+    assert result.access_token == "ATK"
+    assert result.refresh_token == "RTK"
+    assert result.id_token == "ITK"
+    # expires_at must be roughly time.time() + 3600 (±5 s tolerance)
+    assert before + 3595 <= result.expires_at <= after + 3605, (
+        f"expires_at={result.expires_at} not in expected range"
+    )
+
+    # Assert — authorize URL contains plan=generic (build helper)
+    assert XAI_OAUTH_PLAN == "generic"
+    auth_url = _build_authorize_url(
+        challenge="challenge_abc",
+        state="state_xyz",
+        nonce="nonce_123",
+    )
+    assert "plan=generic" in auth_url, f"plan=generic missing from URL: {auth_url}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — lazy 401 retry (Wave 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _FORWARDER_AVAILABLE, reason="proxy_forwarder not yet implemented (Wave 2)")
+@pytest.mark.asyncio
+async def test_lazy_refresh_on_401(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """lazy_retry_on_401 retries once on 401; new credentials persisted to disk."""
+    # Arrange — initial (expired) credentials on disk
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+
+    old_creds = _make_fake_creds(access_token="OLD_ATK", expires_delta=-60)
+    auth_store.save(old_creds, path=creds_file)
+
+    new_token_resp = {
+        "access_token": "NEW_ATK",
+        "refresh_token": "NEW_RTK",
+        "id_token": "NEW_ITK",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+    }
+    chat_ok_resp = {"choices": [{"message": {"content": "pong"}}]}
+
+    api_call_count = 0
+    auth_call_count = 0
+
+    async def request_fn(token: str) -> MagicMock:
+        nonlocal api_call_count
+        api_call_count += 1
+        resp = MagicMock()
+        if api_call_count == 1:
+            resp.status = 401
+        else:
+            resp.status = 200
+            resp.json = asyncio.coroutine(lambda: chat_ok_resp)  # type: ignore[attr-defined]
+        return resp
+
+    async def refresh_fn(creds: "XaiCredentials") -> "XaiCredentials":
+        nonlocal auth_call_count
+        auth_call_count += 1
+        return XaiCredentials(
+            access_token=new_token_resp["access_token"],
+            refresh_token=new_token_resp["refresh_token"],
+            id_token=new_token_resp["id_token"],
+            expires_at=int(time.time()) + new_token_resp["expires_in"],
+            token_type=new_token_resp["token_type"],
+            scope=new_token_resp["scope"],
+        )
+
+    # Act
+    store_load = lambda: auth_store.load(path=creds_file)  # noqa: E731
+    store_save = lambda c: auth_store.save(c, path=creds_file)  # noqa: E731
+    await lazy_retry_on_401(request_fn, refresh_fn, store_load, store_save)
+
+    # Assert — 2 calls to api.x.ai (1 initial 401 + 1 retry), 1 refresh POST
+    assert api_call_count == 2, f"expected 2 api calls, got {api_call_count}"
+    assert auth_call_count == 1, f"expected 1 refresh call, got {auth_call_count}"
+
+    # Assert — new credentials persisted to disk
+    persisted = auth_store.load(path=creds_file)
+    assert persisted is not None
+    assert persisted.access_token == "NEW_ATK"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — concurrent 401 dedup (Wave 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _FORWARDER_AVAILABLE, reason="proxy_forwarder not yet implemented (Wave 2)")
+@pytest.mark.asyncio
+async def test_concurrent_refresh_dedup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """5 concurrent 401s result in exactly ONE refresh POST (asyncio.Lock dedup)."""
+    # Arrange — expired credentials on disk
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+
+    old_creds = _make_fake_creds(access_token="OLD_ATK", expires_delta=-60)
+    auth_store.save(old_creds, path=creds_file)
+
+    api_call_count = 0
+    refresh_call_count = 0
+    lock = asyncio.Lock()
+
+    async def request_fn(token: str) -> MagicMock:
+        nonlocal api_call_count
+        async with lock:
+            api_call_count += 1
+            current_count = api_call_count
+        resp = MagicMock()
+        # First 5 calls return 401; subsequent calls (retries with new token) return 200
+        if current_count <= 5:
+            resp.status = 401
+        else:
+            resp.status = 200
+        return resp
+
+    async def refresh_fn(creds: "XaiCredentials") -> "XaiCredentials":
+        nonlocal refresh_call_count
+        refresh_call_count += 1
+        # Small delay to make race condition visible
+        await asyncio.sleep(0.01)
+        return XaiCredentials(
+            access_token="REFRESHED_ATK",
+            refresh_token="REFRESHED_RTK",
+            id_token="REFRESHED_ITK",
+            expires_at=int(time.time()) + 3600,
+            token_type="Bearer",
+            scope="openid",
+        )
+
+    store_load = lambda: auth_store.load(path=creds_file)  # noqa: E731
+    store_save = lambda c: auth_store.save(c, path=creds_file)  # noqa: E731
+
+    # Act — 5 concurrent callers all hit 401 simultaneously
+    await asyncio.gather(
+        *[lazy_retry_on_401(request_fn, refresh_fn, store_load, store_save) for _ in range(5)]
+    )
+
+    # Assert — EXACTLY ONE refresh POST (the _REFRESH_LOCK dedup property)
+    assert refresh_call_count == 1, (
+        f"expected exactly 1 refresh, got {refresh_call_count} — _REFRESH_LOCK dedup broken"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — corrupted credentials
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _AUTH_STORE_AVAILABLE, reason="auth.store not yet implemented (Wave 1)")
+def test_credentials_corrupted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """store.load() raises CredentialsCorruptError when xai.json contains partial JSON."""
+    # Arrange — write malformed JSON to the credentials file
+    xai_creds = tmp_path / "xai.json"
+    xai_creds.write_text('{"access_token": "abc"')  # truncated — no closing brace
+    monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", xai_creds)
+
+    # Act + Assert — CredentialsCorruptError raised
+    with pytest.raises(CredentialsCorruptError) as exc_info:
+        auth_store.load(path=xai_creds)
+
+    # Assert — error message contains "corrupted" and "re-run"
+    message = str(exc_info.value).lower()
+    assert "corrupted" in message, f"expected 'corrupted' in error message, got: {message!r}"
+    assert "re-run" in message, f"expected 're-run' in error message, got: {message!r}"

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -1,13 +1,4 @@
-"""RED-phase tests for xAI OAuth PKCE flow and credential store.
-
-Tests 1 and 4 (test_pkce_code_exchange, test_credentials_corrupted) exercise
-auth/xai_oauth.py + auth/store.py from Wave 1 and are expected to PASS after
-backend-dev-A completes T2 + T3.
-
-Tests 2 and 3 (test_lazy_refresh_on_401, test_concurrent_refresh_dedup) exercise
-proxy_forwarder/_common.py from Wave 2 and are SKIPPED until that module lands
-(import-guarded via importlib.util.find_spec at module level).
-"""
+"""Tests for xAI OAuth PKCE flow and credential store."""
 
 from __future__ import annotations
 
@@ -18,44 +9,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Wave 1 import guard — auth modules (required for T1/T4 at RG1)
-# findspec on a submodule of a non-existent parent raises ModuleNotFoundError,
-# so we guard with a try/except rather than find_spec directly.
-# ---------------------------------------------------------------------------
-
-try:
-    from llmcli.auth.store import CredentialsCorruptError, XaiCredentials
-    from llmcli.auth import store as auth_store
-
-    _AUTH_STORE_AVAILABLE = True
-except (ImportError, ModuleNotFoundError):
-    _AUTH_STORE_AVAILABLE = False
-
-try:
-    from llmcli.auth.xai_oauth import (
-        XAI_OAUTH_CLIENT_ID,
-        XAI_OAUTH_PLAN,
-        _build_authorize_url,
-        exchange_code,
-    )
-
-    _AUTH_OAUTH_AVAILABLE = True
-except (ImportError, ModuleNotFoundError):
-    _AUTH_OAUTH_AVAILABLE = False
-
-_AUTH_AVAILABLE = _AUTH_STORE_AVAILABLE and _AUTH_OAUTH_AVAILABLE
-
-# ---------------------------------------------------------------------------
-# Wave 2 import guard — proxy_forwarder._common (required for T2/T3 at RG2)
-# ---------------------------------------------------------------------------
-
-try:
-    from llmcli.proxy_forwarder._common import _REFRESH_LOCK, lazy_retry_on_401  # noqa: F401
-
-    _FORWARDER_AVAILABLE = True
-except (ImportError, ModuleNotFoundError):
-    _FORWARDER_AVAILABLE = False
+# F1 — direct imports (no try/except guards)
+from llmcli.auth import store as auth_store
+from llmcli.auth.store import CredentialsCorruptError, XaiCredentials
+from llmcli.auth.xai_oauth import (
+    XAI_OAUTH_CLIENT_ID,
+    _build_authorize_url,
+    exchange_code,
+)
+from llmcli.proxy_forwarder._common import _REFRESH_LOCK, lazy_retry_on_401  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
@@ -63,21 +25,12 @@ except (ImportError, ModuleNotFoundError):
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def creds_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Monkeypatch XAI_CREDENTIALS_PATH to a temp file; return the path."""
-    xai_creds = tmp_path / "xai.json"
-    if _AUTH_STORE_AVAILABLE:
-        monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", xai_creds)
-    return xai_creds
-
-
 def _make_fake_creds(
     access_token: str = "ATK",
     refresh_token: str = "RTK",
     id_token: str = "ITK",
     expires_delta: int = 3600,
-) -> "XaiCredentials":
+) -> XaiCredentials:
     """Build an XaiCredentials for test usage."""
     return XaiCredentials(
         access_token=access_token,
@@ -94,7 +47,6 @@ def _make_fake_creds(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _AUTH_AVAILABLE, reason="auth modules not yet implemented (Wave 1)")
 def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """exchange_code POSTs to auth.x.ai/oauth/token with correct body; returns XaiCredentials."""
     # Arrange
@@ -136,6 +88,8 @@ def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert body.get("code") == "test_code", f"body={body}"
     assert body.get("code_verifier") == fake_verifier, f"body={body}"
     assert body.get("client_id") == XAI_OAUTH_CLIENT_ID, f"body={body}"
+    # F4 — assert code_challenge in POST body
+    assert body.get("code_challenge") is not None, f"code_challenge missing from body: {body}"
 
     # Assert — returned XaiCredentials matches mock response
     assert result.access_token == "ATK"
@@ -147,21 +101,27 @@ def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     )
 
     # Assert — authorize URL contains plan=generic (build helper)
-    assert XAI_OAUTH_PLAN == "generic"
+    # F3 — removed tautological assert XAI_OAUTH_PLAN == "generic"
     auth_url = _build_authorize_url(
         challenge="challenge_abc",
         state="state_xyz",
         nonce="nonce_123",
     )
     assert "plan=generic" in auth_url, f"plan=generic missing from URL: {auth_url}"
+    # F4 — assert state and nonce in URL
+    assert "state=state_xyz" in auth_url, f"state missing from URL: {auth_url}"
+    assert "nonce=nonce_123" in auth_url, f"nonce missing from URL: {auth_url}"
+    # F11 — assert client_id constant (not hardcoded literal)
+    assert f"client_id={XAI_OAUTH_CLIENT_ID}" in auth_url, (
+        f"client_id missing from URL: {auth_url}"
+    )
 
 
 # ---------------------------------------------------------------------------
-# Test 2 — lazy 401 retry (Wave 2)
+# Test 2 — lazy 401 retry
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _FORWARDER_AVAILABLE, reason="proxy_forwarder not yet implemented (Wave 2)")
 @pytest.mark.asyncio
 async def test_lazy_refresh_on_401(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -170,6 +130,8 @@ async def test_lazy_refresh_on_401(
     # Arrange — initial (expired) credentials on disk
     creds_file = tmp_path / "xai.json"
     monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+    # F8 — isolate _REFRESH_LOCK per test
+    monkeypatch.setattr("llmcli.proxy_forwarder._common._REFRESH_LOCK", asyncio.Lock())
 
     old_creds = _make_fake_creds(access_token="OLD_ATK", expires_delta=-60)
     auth_store.save(old_creds, path=creds_file)
@@ -186,6 +148,8 @@ async def test_lazy_refresh_on_401(
 
     api_call_count = 0
     auth_call_count = 0
+    # F9 — accumulate tokens received
+    tokens_received: list[str] = []
 
     async def _json_ok() -> dict:
         return chat_ok_resp
@@ -193,6 +157,7 @@ async def test_lazy_refresh_on_401(
     async def request_fn(token: str) -> MagicMock:
         nonlocal api_call_count
         api_call_count += 1
+        tokens_received.append(token)
         resp = MagicMock()
         if api_call_count == 1:
             resp.status = 401
@@ -201,7 +166,7 @@ async def test_lazy_refresh_on_401(
             resp.json = _json_ok
         return resp
 
-    async def refresh_fn(creds: "XaiCredentials") -> "XaiCredentials":
+    async def refresh_fn(creds: XaiCredentials) -> XaiCredentials:
         nonlocal auth_call_count
         auth_call_count += 1
         return XaiCredentials(
@@ -227,13 +192,20 @@ async def test_lazy_refresh_on_401(
     assert persisted is not None
     assert persisted.access_token == "NEW_ATK"
 
+    # F9 — assert token values used on each call
+    assert tokens_received[0] == "OLD_ATK", (
+        f"first call should use old token, got {tokens_received[0]!r}"
+    )
+    assert tokens_received[1] == "NEW_ATK", (
+        f"retry should use refreshed token, got {tokens_received[1]!r}"
+    )
+
 
 # ---------------------------------------------------------------------------
-# Test 3 — concurrent 401 dedup (Wave 2)
+# Test 3 — concurrent 401 dedup
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _FORWARDER_AVAILABLE, reason="proxy_forwarder not yet implemented (Wave 2)")
 @pytest.mark.asyncio
 async def test_concurrent_refresh_dedup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -242,6 +214,8 @@ async def test_concurrent_refresh_dedup(
     # Arrange — expired credentials on disk
     creds_file = tmp_path / "xai.json"
     monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+    # F8 — isolate _REFRESH_LOCK per test
+    monkeypatch.setattr("llmcli.proxy_forwarder._common._REFRESH_LOCK", asyncio.Lock())
 
     old_creds = _make_fake_creds(access_token="OLD_ATK", expires_delta=-60)
     auth_store.save(old_creds, path=creds_file)
@@ -263,7 +237,7 @@ async def test_concurrent_refresh_dedup(
             resp.status = 200
         return resp
 
-    async def refresh_fn(creds: "XaiCredentials") -> "XaiCredentials":
+    async def refresh_fn(creds: XaiCredentials) -> XaiCredentials:
         nonlocal refresh_call_count
         refresh_call_count += 1
         # Small delay to make race condition visible
@@ -290,13 +264,21 @@ async def test_concurrent_refresh_dedup(
         f"expected exactly 1 refresh, got {refresh_call_count} — _REFRESH_LOCK dedup broken"
     )
 
+    # F10 — assert disk persistence + final api count
+    persisted = auth_store.load(path=creds_file)
+    assert persisted is not None
+    assert persisted.access_token == "REFRESHED_ATK"
+
+    assert api_call_count >= 5, (
+        f"expected ≥5 api calls (initial 401s), got {api_call_count}"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Test 4 — corrupted credentials
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _AUTH_STORE_AVAILABLE, reason="auth.store not yet implemented (Wave 1)")
 def test_credentials_corrupted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -314,3 +296,121 @@ def test_credentials_corrupted(
     message = str(exc_info.value).lower()
     assert "corrupted" in message, f"expected 'corrupted' in error message, got: {message!r}"
     assert "re-run" in message, f"expected 're-run' in error message, got: {message!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — AC14: credentials repr redacts tokens  (F5)
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_repr_redacts_tokens() -> None:
+    """AC14: XaiCredentials.__repr__ MUST redact access/refresh/id tokens."""
+    creds = XaiCredentials(
+        access_token="eyJhbGciOiJIUzI1NiJ9.payload.sig",  # JWT-like prefix
+        refresh_token="xai-refresh-abc123",
+        id_token="eyJhbGciOiJIUzI1NiJ9.id.sig",
+        expires_at=9999999,
+        token_type="Bearer",
+        scope="openid",
+    )
+    r = repr(creds)
+    assert "eyJ" not in r, f"JWT prefix leaked in repr: {r}"
+    assert "xai-refresh" not in r, f"refresh token leaked in repr: {r}"
+    assert "access_token=***" in r
+    assert "refresh_token=***" in r
+    assert "id_token=***" in r
+    assert "expires_at=9999999" in r  # non-secret int is fine
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — empty verifier guard  (F6)
+# ---------------------------------------------------------------------------
+
+
+def test_exchange_code_empty_verifier_raises() -> None:
+    """`exchange_code` MUST reject empty verifier — guard at xai_oauth.py."""
+    with pytest.raises(ValueError, match="PKCE code_verifier"):
+        exchange_code(code="some_code", verifier="")
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — AC4 second half: /health returns logged_in:false on corrupt creds  (F7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_credentials_corrupted_health_endpoint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test-AC4 second half: forwarder /health reports logged_in:false when xai.json is corrupted."""
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    creds_file = tmp_path / "xai.json"
+    creds_file.write_text('{"access_token": "abc"')  # partial JSON
+
+    adapter = XaiAdapter()
+    monkeypatch.setattr(adapter, "credential_path", creds_file)
+
+    app = create_app(adapter)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/health")
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["logged_in"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — lazy_retry still 401 propagates  (F8)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lazy_refresh_still_401_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the retry is ALSO 401, lazy_retry_on_401 returns the 401 (caller handles X-Llmcli-Reauth)."""
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+    monkeypatch.setattr("llmcli.proxy_forwarder._common._REFRESH_LOCK", asyncio.Lock())
+
+    old = XaiCredentials(
+        access_token="OLD_ATK",
+        refresh_token="OLD_RTK",
+        id_token="OLD_ITK",
+        expires_at=int(time.time()) - 60,  # expired
+        token_type="Bearer",
+        scope="openid",
+    )
+    auth_store.save(old, path=creds_file)
+
+    api_calls = 0
+
+    async def request_fn(token: str) -> MagicMock:
+        nonlocal api_calls
+        api_calls += 1
+        resp = MagicMock()
+        resp.status = 401
+        return resp
+
+    async def refresh_fn(creds: XaiCredentials) -> XaiCredentials:
+        # Returns NEW creds — but the api will STILL return 401
+        return XaiCredentials(
+            access_token="NEW_BUT_STILL_REJECTED",
+            refresh_token="NEW_RTK",
+            id_token="NEW_ITK",
+            expires_at=int(time.time()) + 3600,
+            token_type="Bearer",
+            scope="openid",
+        )
+
+    resp = await lazy_retry_on_401(
+        request_fn,
+        refresh_fn,
+        lambda: auth_store.load(path=creds_file),
+        lambda c: auth_store.save(c, path=creds_file),
+    )
+    assert resp.status == 401, f"expected final 401, got {resp.status}"
+    assert api_calls == 2, f"expected 2 api calls (initial + retry), got {api_calls}"

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -187,6 +187,9 @@ async def test_lazy_refresh_on_401(
     api_call_count = 0
     auth_call_count = 0
 
+    async def _json_ok() -> dict:
+        return chat_ok_resp
+
     async def request_fn(token: str) -> MagicMock:
         nonlocal api_call_count
         api_call_count += 1
@@ -195,7 +198,7 @@ async def test_lazy_refresh_on_401(
             resp.status = 401
         else:
             resp.status = 200
-            resp.json = asyncio.coroutine(lambda: chat_ok_resp)  # type: ignore[attr-defined]
+            resp.json = _json_ok
         return resp
 
     async def refresh_fn(creds: "XaiCredentials") -> "XaiCredentials":

--- a/uv.lock
+++ b/uv.lock
@@ -1219,6 +1219,7 @@ name = "llmcli"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "aiohttp" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "nvidia-ml-py" },
@@ -1259,6 +1260,7 @@ vllm = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "huggingface-hub", specifier = ">=1.0" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aioresponses"
+version = "0.7.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,7 +1216,7 @@ wheels = [
 
 [[package]]
 name = "llmcli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -1229,6 +1242,7 @@ proxy = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aioresponses" },
     { name = "import-linter" },
     { name = "pip-licenses" },
     { name = "pre-commit" },
@@ -1264,6 +1278,7 @@ provides-extras = ["nats", "proxy"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aioresponses", specifier = ">=0.7.8" },
     { name = "import-linter", specifier = ">=2.1" },
     { name = "pip-licenses", specifier = ">=5.5.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },


### PR DESCRIPTION
## Summary

- Add Grok-4 / Grok-4-fast to llmCLI's LiteLLM mesh via **OAuth (SuperGrok)** — no paid xAI API key required.
- New `auth/` package (PKCE login, atomic 0600 credential store, lazy refresh) + new `proxy_forwarder/` aiohttp sibling service that swaps `Authorization` per request and dedup-refreshes on 401.
- Provider-agnostic `OAuthAdapter` Protocol + generic `lazy_retry_on_401` keep stage logic reusable for future OAuth providers (Gemini, Anthropic Console, Qwen) — the substrate is the point.
- M₁ deploy: new Quadlet on `roxabi.network` with `:18645` internal-only, `keep-id:uid=1502,gid=1502`, rw credentials mount; image reuses `ghcr.io/roxabi/llmcli:staging`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #99 feat(auth): xAI OAuth proxy à la Hermes | OPEN |
| Frame | [99-xai-oauth-proxy-frame.mdx](artifacts/frames/99-xai-oauth-proxy-frame.mdx) | Present |
| Spec | [99-xai-oauth-proxy-spec.mdx](artifacts/specs/99-xai-oauth-proxy-spec.mdx) | Present (19 AC, 13 affordances) |
| Plan | [99-xai-oauth-proxy-plan.mdx](artifacts/plans/99-xai-oauth-proxy-plan.mdx) | Present (16 micro + 3 RED-GATEs) |
| Implementation | 6 commits on `feat/99-xai-oauth-proxy` (3 docs + 3 waves) | Complete (19/19 tasks) |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (418 pass, 11 skip; 4 new) | Passed |

## Architecture

```
host roxabituwer (M₁)
  ~/.roxabi/llmcli/credentials/xai.json   (refresh_token + cached access, 0600)
                              ↑ rw (refresh writes new access_token)
  roxabi.network ─────┐
  ┌─ llmcli :18091 ─→ │ Bearer dummy ─→ llmcli-xai-forwarder :18645 ─→ api.x.ai/v1/
  │  (LiteLLM proxy)  │                 (aiohttp, lazy refresh on 401)
  └─ container        └─ sibling Quadlet
```

Single-flight refresh: module-level `asyncio.Lock` + re-read-on-entry → exactly **one** POST to `auth.x.ai/oauth/token` per expired-token cluster (covered by `test_concurrent_refresh_dedup`).

## Test Plan

### Automated (passes in CI)

- [x] `uv run pytest tests/test_xai_oauth_pkce.py -v` → 4 PASS (pkce_code_exchange, lazy_refresh_on_401, concurrent_refresh_dedup, credentials_corrupted)
- [x] `uv run pytest` → 418 pass, 11 skip
- [x] `uv run ruff check . && uv run ruff check --select=PYI .` → clean
- [x] Forwarder local smoke: `python -m llmcli.proxy_forwarder._server` → `/health` 200, `/wrong-path` 404
- [x] All new files within 300-LOC budget (largest: `xai_oauth.py` at 287)

### Operator-side (post-merge on M₁ — RG3 deferred steps)

- [ ] \`./deploy/install.sh\` then \`systemctl --user start llmcli-xai-forwarder\` → active (running), Health: healthy
- [ ] \`llmcli xai login\` with real SuperGrok account → \`~/.roxabi/llmcli/credentials/xai.json\` mode 0600
- [ ] From llmcli container: \`podman exec llmcli curl -f http://llmcli-xai-forwarder:18645/health\` → 200 \`logged_in: true\`
- [ ] \`ss -tlnp | grep 18645\` on host → empty (¬PublishPort verified)
- [ ] End-to-end Grok-4: \`curl :18091/v1/chat/completions -H \"Authorization: Bearer dummy\" -d '{\"model\":\"grok-4\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}'\` → 200
- [ ] \`journalctl --user -u llmcli-xai-forwarder | grep -cE 'eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+'\` → 0 (no JWT material logged)

## Out of Scope

- M₂ deployment (deferred; tailnet routing if needed later)
- Multi-account credential pool (Hermes feature, overkill for single-operator)
- Eager timer-based refresh (lazy on-401 only)
- Other OAuth providers — separate issues; this PR establishes the reusable substrate
- CLAUDE.md path-drift update (\`src/llmcli/cli.py\` → \`src/llmcli/cli/\`) — follow-up sibling issue

## Revisit Triggers

When a 2nd OAuth provider arrives → extract \`auth/_common.py\` with 5 OAuth primitives parameterized by ProviderConfig (xai_oauth.py shrinks to ≤30 LOC); consider collapsing per-provider Quadlets into one \`llmcli-oauth-forwarder\` mounting adapters on path prefixes. The DI'd \`OAuthAdapter\` Protocol already keeps stage logic provider-agnostic — second provider only adds its adapter file.

Closes #99

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`