### PR TITLE
fix(proxy): custom auth intercept for misleading 'No connected db' error

### DIFF
--- a/deploy/proxy-base.yaml.example
+++ b/deploy/proxy-base.yaml.example
@@ -12,6 +12,12 @@
 general_settings:
   master_key: os.environ/LLMCLI_API_KEY
 
+  # Custom auth intercept: replaces LiteLLM's default DB key lookup with a
+  # master_key-only check. Fixes the misleading 400 "No connected db" error
+  # that LiteLLM returns for invalid keys when no database is configured.
+  # `llmcli proxy` auto-wires this; add it manually for `register-proxy` setups.
+  custom_auth: proxy_custom_auth.custom_auth
+
   # Fireworks /v1/messages → forward as-is to Fireworks Anthropic-compatible
   # endpoint. Used by Claude Code aliases (ccfg/ccfk) that speak Anthropic
   # protocol and route to Fireworks via this proxy.

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -75,6 +75,15 @@ def register_proxy(
     # 5a. Warn if xAI credentials are absent (discoverability hint)
     emit_xai_oauth_warning_if_absent(err_console)
 
+    # 5b. Write custom auth module so LiteLLM can resolve it
+    _write_custom_auth_module(resolved_path.parent)
+    # 5c. Warn if custom_auth is not yet in the persistent config
+    if resolved_path.exists() and "custom_auth" not in resolved_path.read_text():
+        err_console.print(
+            "[yellow]Note: add `custom_auth: proxy_custom_auth.custom_auth` to "
+            "general_settings in your config to fix the 'No connected db' error.[/yellow]"
+        )
+
     # 6. Reload proxy — warn on failure, don't fail the command
     try:
         _cli.reload_proxy()
@@ -183,6 +192,9 @@ def proxy(
     with os.fdopen(fd, "w") as f:
         f.write(yaml_text)
     target.chmod(0o600)  # defense-in-depth: enforce exact mode regardless of process umask
+
+    # 5b. Write custom auth module so LiteLLM can resolve it
+    _write_custom_auth_module(target.parent)
 
     # 6. If --config-out, dry-run exit
     if config_out is not None:
@@ -304,3 +316,15 @@ def _install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.
 
     signal.signal(signal.SIGTERM, handler)
     signal.signal(signal.SIGINT, handler)
+
+
+def _write_custom_auth_module(target_dir: Path) -> None:
+    """Copy the LiteLLM custom auth module to the config directory.
+
+    LiteLLM's get_instance_fn resolves custom_auth modules relative to the
+    config file path. Writing proxy_custom_auth.py next to the config ensures
+    it is importable regardless of which venv runs litellm.
+    """
+    auth_module_src = Path(__file__).parent.parent / "proxy_custom_auth.py"
+    if auth_module_src.exists():
+        shutil.copy2(auth_module_src, target_dir / "proxy_custom_auth.py")

--- a/src/llmcli/proxy_custom_auth.py
+++ b/src/llmcli/proxy_custom_auth.py
@@ -1,0 +1,46 @@
+"""LiteLLM custom auth for llmCLI master_key-only proxy.
+
+Intercepts invalid API keys and returns 401 instead of the misleading
+400 "No connected db" error that LiteLLM emits when no DB is configured.
+
+Wired into the LiteLLM proxy config via `general_settings.custom_auth`.
+"""
+
+import secrets
+from fastapi import HTTPException  # type: ignore[import-untyped]
+
+
+async def custom_auth(request, api_key: str | None) -> dict:  # noqa: ARG001
+    """Validate API key against LiteLLM master_key.
+
+    - Key matches master_key → return admin auth object.
+    - Key missing or invalid → raise 401.
+
+    Args:
+        request: FastAPI request (unused).
+        api_key: The API key from the request.
+
+    Returns:
+        Minimal UserAPIKeyAuth dict for admin access.
+
+    Raises:
+        HTTPException: 401 when key is missing or invalid.
+    """
+    from litellm.proxy.proxy_server import master_key  # type: ignore[import-untyped]
+
+    if not api_key:
+        raise HTTPException(status_code=401, detail="No API key provided")
+
+    try:
+        is_master_key = secrets.compare_digest(api_key, master_key)
+    except Exception:
+        is_master_key = False
+
+    if is_master_key:
+        return {
+            "api_key": api_key,
+            "user_role": "proxy_admin",
+            "user_id": "proxy_admin",
+        }
+
+    raise HTTPException(status_code=401, detail="Invalid API key")

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -68,6 +68,7 @@ def merge_proxy_config(
     result = copy.deepcopy(base)  # B3 — deep copy to prevent mutation of caller's base
     gs = result.setdefault("general_settings", {})
     gs.setdefault("master_key", f"os.environ/{api_key_env}")
+    gs.setdefault("custom_auth", "proxy_custom_auth.custom_auth")
     ls = result.setdefault("litellm_settings", {})
     ls.setdefault("drop_params", _DEFAULT_PROXY_BASE["litellm_settings"]["drop_params"])
     result["model_list"] = model_list


### PR DESCRIPTION
## Summary

Fixes #101 — when the LiteLLM proxy receives an invalid API key and no database is configured, it returns HTTP 400 "No connected db." instead of a proper 401 auth error. This masked a real production issue where Hermes was configured with the wrong key for ~6 days.

## Changes

- **src/llmcli/proxy_custom_auth.py** — new LiteLLM custom_auth module that validates keys against `master_key` and returns 401 for invalid keys, intercepting the misleading 400 before LiteLLM reaches the DB check.
- **src/llmcli/support/litellm_config.py** — wire `custom_auth: proxy_custom_auth.custom_auth` into generated proxy configs.
- **src/llmcli/cli/proxy.py** — copy the custom auth module to the config directory alongside the generated YAML; warn `register-proxy` users if `custom_auth` is not yet in their persistent config.
- **deploy/proxy-base.yaml.example** — document the `custom_auth` setting.

## Test plan

- [ ] Run `llmcli proxy` locally and verify `proxy_custom_auth.py` is written next to `proxy.config.yaml`
- [ ] Verify invalid key returns 401 instead of 400 "No connected db"
- [ ] Verify valid `master_key` still works correctly
- [ ] Run `llmcli register-proxy` and verify the warning is shown when `custom_auth` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)