### PR TITLE
fix(nats): re-pin llmCLI to factory.* wire (#105)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ proxy = [
 ]
 
 [tool.uv.sources]
-roxabi-nats      = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats",      branch = "staging" }
-roxabi-contracts = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
+roxabi-nats      = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-nats",      branch = "staging" }
+roxabi-contracts = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
 
 [tool.pyright]
 venvPath = "."

--- a/src/llmcli/nats/_lifecycle.py
+++ b/src/llmcli/nats/_lifecycle.py
@@ -16,7 +16,7 @@ import tomllib
 from datetime import datetime, timezone
 
 from pydantic import ValidationError
-from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse
+from roxabi_contracts.llm import LifecycleRequest, LifecycleResponse, SUBJECTS as LLM_SUBJECTS
 from roxabi_contracts.errors import WorkerError
 
 from llmcli.auth.store import XAI_CREDENTIALS_PATH
@@ -39,11 +39,11 @@ _CRASH_MESSAGES: dict[str, str] = {
 _CRASH_FALLBACK = "engine start failed"
 
 LIFECYCLE_SUBJECTS = (
-    "lyra.llm.lifecycle.swap",
-    "lyra.llm.lifecycle.stop",
-    "lyra.llm.lifecycle.status",
-    "lyra.llm.lifecycle.list",
-    "lyra.llm.lifecycle.reload-catalog",
+    LLM_SUBJECTS.lifecycle_swap,
+    LLM_SUBJECTS.lifecycle_stop,
+    LLM_SUBJECTS.lifecycle_status,
+    LLM_SUBJECTS.lifecycle_list,
+    LLM_SUBJECTS.lifecycle_reload_catalog,
 )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1272,8 +1272,8 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
-    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
+    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
+    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.12" },
@@ -1290,8 +1290,8 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout", specifier = ">=0.5" },
     { name = "radon", specifier = ">=6.0.1" },
-    { name = "roxabi-contracts", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
-    { name = "roxabi-nats", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
+    { name = "roxabi-contracts", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
+    { name = "roxabi-nats", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "ruff" },
 ]
 vllm = [{ name = "vllm", specifier = ">=0.6.0" }]
@@ -2737,16 +2737,16 @@ wheels = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.4.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#0f8f5021e8c855c486cd4667efce14736f81e9c6" }
+version = "0.7.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
 dependencies = [
     { name = "pydantic" },
 ]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.4.1"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#0f8f5021e8c855c486cd4667efce14736f81e9c6" }
+version = "0.4.2"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary

- Replace hardcoded `lyra.llm.lifecycle.*` subject literals in `_lifecycle.py` with `SUBJECTS.lifecycle_*` from `roxabi_contracts.llm` — single source of truth, no more literal drift.
- Update `[tool.uv.sources]` git URLs from `Roxabi/lyra.git` → `Roxabi/roxabi-factory.git` (repo rename; old URL was GitHub redirect only).
- Re-lock: `roxabi-contracts` 0.4.0 → **0.7.0** (factory.* wire), `roxabi-nats` 0.4.1 → 0.4.2.

Fixes #105 — part of #1670 satellite lockstep. Stops `lyra.llm.*` Publish Violations on factory-nats ACL enforcer.

## Test plan

- [ ] `uv run python -c "from roxabi_contracts.llm import SUBJECTS; print(SUBJECTS)"` → all subjects `factory.llm.*`
- [ ] `grep -rnE '"lyra\.(llm|voice)' src/` → 0 matches
- [ ] CI green (lint + tests)
- [ ] Image rebuild on staging push → `ghcr.io/roxabi/llmcli:staging`
- [ ] Worker redeploy on M₂ — `systemctl --user is-active llmcli-nats-worker` = active, NRestarts=0
- [ ] M₁ violation count for `lyra.llm.*` = 0 after 2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)