### PR TITLE
chore(deploy): persist llmcli quadlet memory caps

### DIFF
--- a/deploy/quadlet/llmcli-fw-forwarder.container
+++ b/deploy/quadlet/llmcli-fw-forwarder.container
@@ -25,6 +25,10 @@ DropCapability=all
 Restart=on-failure
 RestartSec=10
 TimeoutStopSec=20s
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). Tiny relay; 1G/1.5G is generous.
+MemoryHigh=1G
+MemoryMax=1536M
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/llmcli-nats-worker.container
+++ b/deploy/quadlet/llmcli-nats-worker.container
@@ -33,6 +33,11 @@ DropCapability=all
 [Service]
 Restart=on-failure
 RestartSec=10
+# Memory caps — contain a runaway to its cgroup (OOM-kill + restart) instead of
+# a global OOM death-spiral that freezes the host (2026-06-01 M₂ freeze, RAM+swap exhausted).
+# Local inference (qwen3-4b) weights go to VRAM; host-side RAM stays modest, 12G is generous.
+MemoryHigh=12G
+MemoryMax=14G
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -25,6 +25,10 @@ DropCapability=all
 Restart=on-failure
 RestartSec=10
 TimeoutStopSec=20s
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). Tiny OAuth relay; 1G/1.5G is generous.
+MemoryHigh=1G
+MemoryMax=1536M
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -31,6 +31,10 @@ RestartSec=10
 TimeoutStopSec=20s
 # RestartForceExitStatus: skip restart on provider-key (1) and litellm-missing (127) errors
 RestartForceExitStatus=1 127
+# Memory caps — contain a runaway to its cgroup instead of a global OOM freeze
+# (2026-06-01 M₂ freeze). LiteLLM proxy is lightweight; 2G/3G is ample headroom.
+MemoryHigh=2G
+MemoryMax=3G
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Persist uncommitted MemoryHigh/MemoryMax caps on llmcli quadlets (added on M₂ 2026-06-01, would be lost on a hard reset). Deploy-config only — no code/image change. Follow-up to #107 (satellite re-pin).