### PR TITLE
fix(forwarder): refresh expired OAuth token proactively, not only on 401

### DIFF
--- a/src/llmcli/proxy_forwarder/_common.py
+++ b/src/llmcli/proxy_forwarder/_common.py
@@ -111,7 +111,63 @@ OAuthAdapter = ForwardAdapter
 
 
 # ---------------------------------------------------------------------------
-# lazy_retry_on_401 — single-flight 401 retry
+# Single-flight token refresh helpers
+# ---------------------------------------------------------------------------
+
+
+async def _refresh_if_expired(
+    store_load: Callable[[], Any],
+    store_save: Callable[[Any], None],
+    refresh_fn: Callable[[Any], Awaitable[Any]],
+) -> Any:
+    """Refresh under _REFRESH_LOCK iff the on-disk token is expired.
+
+    Dedup signal: ``expires_at``. A concurrent handler that refreshed while we
+    waited for the lock leaves a non-expired token on disk, so we skip the POST.
+    Returns fresh credentials, or None if credentials vanished mid-flight.
+    """
+    async with _REFRESH_LOCK:
+        creds = store_load()
+        if creds is None:
+            return None
+        if creds.expires_at > int(time.time()) + 5:  # someone else refreshed
+            logger.debug("_refresh_if_expired: token already fresh, skipping POST")
+            return creds
+        logger.info("_refresh_if_expired: refreshing expired token via refresh_fn")
+        new = await refresh_fn(creds)
+        store_save(new)
+        return new
+
+
+async def _refresh_after_rejection(
+    rejected_token: str,
+    store_load: Callable[[], Any],
+    store_save: Callable[[Any], None],
+    refresh_fn: Callable[[Any], Awaitable[Any]],
+) -> Any:
+    """Refresh under _REFRESH_LOCK after the upstream rejected *rejected_token*.
+
+    Dedup signal: the access_token value. A 401 can arrive for a token that is
+    NOT yet expired (revoked server-side, clock skew), so expiry is not a valid
+    signal here — we refresh unless the on-disk token already differs from the
+    one that was rejected (another handler refreshed it while we waited).
+    Returns fresh credentials, or None if credentials vanished mid-flight.
+    """
+    async with _REFRESH_LOCK:
+        creds = store_load()
+        if creds is None:
+            return None
+        if creds.access_token != rejected_token:  # another handler refreshed
+            logger.debug("_refresh_after_rejection: token already rotated, skipping POST")
+            return creds
+        logger.info("_refresh_after_rejection: refreshing rejected token via refresh_fn")
+        new = await refresh_fn(creds)
+        store_save(new)
+        return new
+
+
+# ---------------------------------------------------------------------------
+# lazy_retry_on_401 — proactive expiry refresh + reactive 401 retry
 # ---------------------------------------------------------------------------
 
 
@@ -121,20 +177,20 @@ async def lazy_retry_on_401(
     store_load: Callable[[], Any],
     store_save: Callable[[Any], None],
 ) -> Any:
-    """Call *request_fn* with the current access_token; refresh once on 401.
+    """Call *request_fn* with a valid access_token; refresh proactively + on 401.
 
     Algorithm
     ---------
-    1. Load credentials from store; call request_fn(access_token).
-    2. If response is not 401, return immediately.
-    3. Acquire _REFRESH_LOCK (only one coroutine refreshes at a time):
-       a. Re-read credentials from store — another handler may have already
-          refreshed the token while we waited for the lock.
-       b. If the access_token changed (another handler refreshed), skip the
-          POST and retry with the already-refreshed token.
-       c. Otherwise call refresh_fn(creds), persist via store_save, and
-          retry with the new token.
-    4. Return the retry response; the caller maps a still-401 to
+    1. Load credentials. None → return ``_Resp401`` (caller adds reauth header).
+    2. **Proactive**: if the access_token is already expired, refresh BEFORE
+       sending. Some providers (xAI) reject an expired token with **403**, never
+       401 — so a reactive-only retry would never fire and every request would
+       fail despite a valid ``refresh_token`` on disk. Single-flight via
+       ``_REFRESH_LOCK``, deduped on ``expires_at``.
+    3. Send the request. A non-401 response is returned as-is.
+    4. **Reactive**: a 401 on a non-expired token means it was rejected anyway
+       (revoked, clock skew). Refresh once (deduped on the rejected token value)
+       and retry. A still-401 is returned for the caller to map to
        ``X-Llmcli-Reauth: required``.
 
     Parameters
@@ -153,38 +209,26 @@ async def lazy_retry_on_401(
     creds = store_load()
     if creds is None:
         # No credentials at all — propagate as 401 so caller can add header.
-        # We build a minimal stand-in response object.
         return _Resp401()
+
+    # Proactive — never send a token we already know is expired (xAI → 403).
+    if creds.expires_at <= int(time.time()) + 5:  # 5s skew tolerance
+        creds = await _refresh_if_expired(store_load, store_save, refresh_fn)
+        if creds is None:
+            return _Resp401()
 
     resp = await request_fn(creds.access_token)
     if resp.status != 401:
         return resp
 
-    # 401 received — enter the single-flight refresh path.
-    logger.info("lazy_retry_on_401: received 401, acquiring refresh lock")
-
-    async with _REFRESH_LOCK:
-        # Re-read creds after acquiring the lock; another handler may have
-        # already written fresh tokens to disk while we waited.
-        fresh_creds = store_load()
-
-        if fresh_creds is None:
-            # Credentials disappeared mid-flight; propagate 401.
-            return _Resp401()
-
-        # Spec-mandated: if another handler already refreshed and the new token
-        # is not expired, skip the POST and retry with the already-refreshed token.
-        if fresh_creds.expires_at > int(time.time()) + 5:  # 5s skew tolerance
-            logger.debug("lazy_retry_on_401: token refreshed by another handler, skipping POST")
-            resp = await request_fn(fresh_creds.access_token)
-        else:
-            # Token is still expired — we are responsible for refreshing.
-            logger.info("lazy_retry_on_401: refreshing token via refresh_fn")
-            new_creds = await refresh_fn(fresh_creds)
-            store_save(new_creds)
-            resp = await request_fn(new_creds.access_token)
-
-    return resp
+    # Reactive — token rejected despite not being (clock-) expired.
+    logger.info("lazy_retry_on_401: received 401, refreshing and retrying once")
+    refreshed = await _refresh_after_rejection(
+        creds.access_token, store_load, store_save, refresh_fn
+    )
+    if refreshed is None:
+        return _Resp401()
+    return await request_fn(refreshed.access_token)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -112,9 +112,7 @@ def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert "state=state_xyz" in auth_url, f"state missing from URL: {auth_url}"
     assert "nonce=nonce_123" in auth_url, f"nonce missing from URL: {auth_url}"
     # F11 — assert client_id constant (not hardcoded literal)
-    assert f"client_id={XAI_OAUTH_CLIENT_ID}" in auth_url, (
-        f"client_id missing from URL: {auth_url}"
-    )
+    assert f"client_id={XAI_OAUTH_CLIENT_ID}" in auth_url, f"client_id missing from URL: {auth_url}"
 
 
 # ---------------------------------------------------------------------------
@@ -123,17 +121,19 @@ def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_lazy_refresh_on_401(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """lazy_retry_on_401 retries once on 401; new credentials persisted to disk."""
-    # Arrange — initial (expired) credentials on disk
+async def test_lazy_refresh_on_401(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """lazy_retry_on_401 retries once on a 401 for a non-expired token; new creds persisted.
+
+    The token is NOT clock-expired (so the proactive path is skipped) but the
+    upstream rejects it with 401 — exercising the reactive refresh path.
+    """
+    # Arrange — valid (non-expired) credentials that the upstream nonetheless 401s
     creds_file = tmp_path / "xai.json"
     monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
     # F8 — isolate _REFRESH_LOCK per test
     monkeypatch.setattr("llmcli.proxy_forwarder._common._REFRESH_LOCK", asyncio.Lock())
 
-    old_creds = _make_fake_creds(access_token="OLD_ATK", expires_delta=-60)
+    old_creds = _make_fake_creds(access_token="OLD_ATK")  # default expires_delta=+3600
     auth_store.save(old_creds, path=creds_file)
 
     new_token_resp = {
@@ -207,10 +207,13 @@ async def test_lazy_refresh_on_401(
 
 
 @pytest.mark.asyncio
-async def test_concurrent_refresh_dedup(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """5 concurrent 401s result in exactly ONE refresh POST (asyncio.Lock dedup)."""
+async def test_concurrent_refresh_dedup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """5 concurrent requests on an expired token result in exactly ONE refresh POST.
+
+    With proactive refresh, an expired token is refreshed BEFORE sending — so the
+    real-world dedup scenario is N concurrent callers finding the token expired
+    and racing on _REFRESH_LOCK. Exactly one wins the POST; the rest reuse it.
+    """
     # Arrange — expired credentials on disk
     creds_file = tmp_path / "xai.json"
     monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
@@ -223,24 +226,21 @@ async def test_concurrent_refresh_dedup(
     api_call_count = 0
     refresh_call_count = 0
     lock = asyncio.Lock()
+    tokens_sent: list[str] = []
 
     async def request_fn(token: str) -> MagicMock:
         nonlocal api_call_count
         async with lock:
             api_call_count += 1
-            current_count = api_call_count
+            tokens_sent.append(token)
         resp = MagicMock()
-        # First 5 calls return 401; subsequent calls (retries with new token) return 200
-        if current_count <= 5:
-            resp.status = 401
-        else:
-            resp.status = 200
+        resp.status = 200  # token is valid post-refresh — never 401/403
         return resp
 
     async def refresh_fn(creds: XaiCredentials) -> XaiCredentials:
         nonlocal refresh_call_count
         refresh_call_count += 1
-        # Small delay to make race condition visible
+        # Small delay to make the race condition visible
         await asyncio.sleep(0.01)
         return XaiCredentials(
             access_token="REFRESHED_ATK",
@@ -254,7 +254,7 @@ async def test_concurrent_refresh_dedup(
     store_load = lambda: auth_store.load(path=creds_file)  # noqa: E731
     store_save = lambda c: auth_store.save(c, path=creds_file)  # noqa: E731
 
-    # Act — 5 concurrent callers all hit 401 simultaneously
+    # Act — 5 concurrent callers all find the token expired simultaneously
     await asyncio.gather(
         *[lazy_retry_on_401(request_fn, refresh_fn, store_load, store_save) for _ in range(5)]
     )
@@ -269,9 +269,68 @@ async def test_concurrent_refresh_dedup(
     assert persisted is not None
     assert persisted.access_token == "REFRESHED_ATK"
 
-    assert api_call_count >= 5, (
-        f"expected ≥5 api calls (initial 401s), got {api_call_count}"
+    # Each caller sends exactly one request, all with the refreshed token —
+    # the expired OLD_ATK is NEVER sent upstream.
+    assert api_call_count == 5, f"expected 5 api calls, got {api_call_count}"
+    assert tokens_sent == ["REFRESHED_ATK"] * 5, f"expired token leaked upstream: {tokens_sent}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3b — proactive refresh: an expired token is refreshed BEFORE sending
+# (regression for xAI replying 403 — not 401 — to an expired access_token,
+#  which a reactive-only retry never catches)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proactive_refresh_never_sends_expired_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An expired token is refreshed up front; the stale token never reaches upstream.
+
+    Models the xAI behaviour: an expired access_token is rejected with 403 (not
+    401). request_fn therefore raises if it ever receives the expired token —
+    the test passes only because proactive refresh runs before the first send.
+    """
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.store.XAI_CREDENTIALS_PATH", creds_file)
+    monkeypatch.setattr("llmcli.proxy_forwarder._common._REFRESH_LOCK", asyncio.Lock())
+
+    expired = _make_fake_creds(access_token="EXPIRED_ATK", expires_delta=-60)
+    auth_store.save(expired, path=creds_file)
+
+    api_calls = 0
+    refresh_calls = 0
+    tokens_sent: list[str] = []
+
+    async def request_fn(token: str) -> MagicMock:
+        nonlocal api_calls
+        api_calls += 1
+        tokens_sent.append(token)
+        # xAI would 403 an expired token — assert we never send it.
+        assert token != "EXPIRED_ATK", "expired token was sent upstream (the bug)"
+        resp = MagicMock()
+        resp.status = 200
+        return resp
+
+    async def refresh_fn(creds: XaiCredentials) -> XaiCredentials:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return _make_fake_creds(access_token="FRESH_ATK", expires_delta=3600)
+
+    resp = await lazy_retry_on_401(
+        request_fn,
+        refresh_fn,
+        lambda: auth_store.load(path=creds_file),
+        lambda c: auth_store.save(c, path=creds_file),
     )
+
+    # Assert — exactly one proactive refresh, one request, no 401 round-trip
+    assert resp.status == 200, f"expected 200, got {resp.status}"
+    assert refresh_calls == 1, f"expected 1 proactive refresh, got {refresh_calls}"
+    assert api_calls == 1, f"expected 1 api call (no reactive retry), got {api_calls}"
+    assert tokens_sent == ["FRESH_ATK"], f"unexpected tokens sent: {tokens_sent}"
+    assert auth_store.load(path=creds_file).access_token == "FRESH_ATK"
 
 
 # ---------------------------------------------------------------------------
@@ -279,9 +338,7 @@ async def test_concurrent_refresh_dedup(
 # ---------------------------------------------------------------------------
 
 
-def test_credentials_corrupted(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_credentials_corrupted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """store.load() raises CredentialsCorruptError when xai.json contains partial JSON."""
     # Arrange — write malformed JSON to the credentials file
     xai_creds = tmp_path / "xai.json"


### PR DESCRIPTION
## Problem

The xAI forwarder refreshed credentials **reactively only on HTTP 401** (`lazy_retry_on_401`). But xAI rejects an **expired** `access_token` with **403** (`bad-credentials`), never 401 → the refresh path never fired. Every request failed despite a valid `refresh_token` on disk, and `/health` still reported `logged_in: true` (it only checks token *presence*, not expiry).

Observed live on M₂: token expired 2026-06-04, all `xai-research` calls returned `403 bad-credentials` 4 days later.

## Fix

- **Proactive refresh**: when `expires_at` is in the past, refresh *before* sending — never hand an expired token to a provider that 403s it.
- **Reactive 401 retained** as a safety net (token revoked server-side / clock skew).
- Two distinct single-flight dedup signals (both under `_REFRESH_LOCK`):
  - proactive → `expires_at` (skip if a concurrent handler already refreshed)
  - reactive → **rejected token value** (after a proactive refresh the token is never clock-expired, so the old `expires_at` heuristic could no longer detect a concurrent refresh)

## Tests

| Test | Change |
|---|---|
| `test_lazy_refresh_on_401` | now uses a non-expired-but-rejected token (exercises the reactive path proper) |
| `test_concurrent_refresh_dedup` | models the proactive race; asserts the expired token is never sent |
| `test_proactive_refresh_never_sends_expired_token` | **new** regression — request_fn raises if it ever receives the expired token (the 403 case) |

442 passed, 10 skipped. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)