### PR TITLE
fix(forwarder): fail loud on dead xAI refresh token + headless re-auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,11 @@ llmCLI does **not** own the proxy. `llmcli register-proxy` emits/maintains a nam
 - M₂ is on-demand — local inference can disappear at any time.
 - New engine = +1 file composing `engines/_common.py` — never re-implement stage logic.
 - `llmcli register-proxy` only touches the `# --- llmCLI managed block` in `~/.litellm/config.yaml`.
+- xAI OAuth: each host holds its **own** grant family — never copy/sync `xai.json` between hosts (shared family → rotation clobber, #114).
 
 ## Gotchas
 
 - `llmcli serve` is removed — use `systemctl --user start llmcli-nats-worker` instead.
 - `vllm` engine requires `uv sync --group vllm` and is dev-only (M₂).
 - TQ3_4S models require the `llamacpp_tq3` engine (TurboQuant fork), not vanilla llama.cpp.
+- xAI forwarder `unhealthy` / grok 401 / `auth.x.ai/oauth2/token 400` → dead refresh token; re-auth (headless M₁: `llmcli xai login --manual`). Runbook: [docs/runbooks/xai-oauth-reauth.md](docs/runbooks/xai-oauth-reauth.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,13 @@ llmcli status [--host <hostname>]        # engines, ports, VRAM, uptime (local o
 llmcli reload-catalog [--host <hostname>] # reload llmcli.toml catalog on worker (local or remote via NATS)
 llmcli chat <name> "..."                 # one-shot OpenAI call (bypasses proxy)
 llmcli register-proxy                    # refresh llmCLI block in ~/.litellm/config.yaml
+
+llmcli xai login                         # PKCE OAuth → xai.json (loopback listener on 127.0.0.1:56121)
+llmcli xai login --manual                # headless: print URL, paste the redirected code (no listener/tunnel)
+llmcli xai status                        # logged_in + expires_at + scope (never prints token material)
+llmcli xai logout                        # delete cached xai.json
 ```
 
 The 5 lifecycle commands (`swap`, `stop`, `status`, `list`, `reload-catalog`) accept `--host <hostname>` to target a remote GPU host. Omitting `--host` defaults to the local hostname.
+
+`llmcli xai login` authenticates the **xAI forwarder** (`llmcli-xai-forwarder`), which injects/refreshes the SuperGrok OAuth bearer for the LiteLLM proxy. On a **headless host** (e.g. M₁ `roxabituwer`) use `--manual` — or SSH-tunnel the loopback port. Each host keeps its **own** independent grant; never copy `xai.json` between hosts. See [runbooks/xai-oauth-reauth.md](runbooks/xai-oauth-reauth.md).

--- a/docs/runbooks/xai-oauth-reauth.md
+++ b/docs/runbooks/xai-oauth-reauth.md
@@ -1,0 +1,72 @@
+# Runbook — xAI OAuth re-auth (forwarder)
+
+**When:** the `llmcli-xai-forwarder` is `unhealthy`, grok models 401/`upstream authentication failed`, or logs show `POST https://auth.x.ai/oauth2/token "HTTP/1.1 400"` / `RE-AUTH REQUIRED`.
+
+**Root cause class:** the SuperGrok OAuth **refresh token is dead** — rotated out of its family (see [Per-host grant model](#per-host-grant-model)) or expired after >30 d offline. A restart does **not** fix it; the token must be re-minted interactively.
+
+## Symptom check
+
+```bash
+# on the affected host
+podman ps --filter name=llmcli-xai-forwarder --format '{{.Names}}\t{{.Status}}'   # → unhealthy
+podman logs --tail 20 llmcli-xai-forwarder | grep -E 'RE-AUTH|oauth2/token'
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:18645/health            # → 503 when re-auth required
+uv run llmcli xai status                                                          # logged_in / expires_at
+```
+
+The forwarder fails **loud**: a dead refresh token logs `ERROR RE-AUTH REQUIRED` once, flips `/health` to **503** (container → `unhealthy`), serves `503 X-Llmcli-Reauth: required`, and **backs off** (stops re-POSTing to auth.x.ai every request). It self-heals once a fresh `xai.json` lands.
+
+## Re-auth
+
+### Headless host (M₁ `roxabituwer`) — preferred: `--manual`
+
+No browser, no SSH tunnel:
+
+```bash
+ssh roxabituwer
+cd ~/projects/llmCLI && uv run llmcli xai login --manual
+#   → prints an authorize URL. Open it in ANY browser (your laptop).
+#   → after authorizing you are redirected to http://127.0.0.1:56121/callback?code=...
+#     the page fails to load (expected) — copy the FULL URL (or just the code) from the address bar.
+#   → paste it at the prompt.
+systemctl --user restart llmcli-xai-forwarder
+uv run llmcli xai status            # expect logged_in=true + fresh expires_at
+```
+
+### Alternative — SSH-tunnelled loopback
+
+The default `llmcli xai login` runs a one-shot listener on the **fixed** port `127.0.0.1:56121` (the registered redirect URI). To reach it from a laptop browser, tunnel the port:
+
+```bash
+ssh -L 56121:127.0.0.1:56121 roxabituwer
+# in that session, on M₁:
+cd ~/projects/llmCLI && uv run llmcli xai login
+#   open the printed URL in the laptop browser → redirect tunnels back to M₁'s listener.
+systemctl --user restart llmcli-xai-forwarder
+```
+
+### Workstation with a browser (M₂ `roxabitower`)
+
+Plain `uv run llmcli xai login` — the listener and browser are on the same machine.
+
+## Per-host grant model
+
+> ⚠️ **Each host runs its own independent `llmcli xai login`. Never copy or sync `xai.json` between hosts.**
+
+xAI rotates refresh tokens with **reuse-detection**: two hosts sharing one token *family* (i.e. one was seeded by copying the other's `xai.json`) invalidate each other on rotation — the first host to refresh kills the other's stale member (`400` on next refresh). M₁ runs 24/7 so its token never idle-expires; the only way it dies is cross-host clobber.
+
+- M₁ and M₂ each hold a **separate grant family** (one independent `login` per host).
+- `~/.roxabi/llmcli/credentials/` is **excluded from Syncthing** — keep it that way.
+- After a fresh independent re-auth, confirm M₁ **survives the next M₂ refresh**. If M₁ dies again, xAI is enforcing one-grant-per-client → switch to a single-holder topology (M₁ only; M₂ routes xai → M₁ over the tailnet).
+
+## Architecture (why a forwarder, not just LiteLLM)
+
+```
+agents → llmcli (LiteLLM proxy :18091)        # catalog + routing + bearer auth
+            └─ grok-*  → llmcli-xai-forwarder:18645   # OAuth refresh (this runbook)
+            └─ kimi-*  → llmcli-fw-forwarder:18646    # static FIREWORKS_API_KEY (NOT OAuth)
+```
+
+LiteLLM only speaks static-API-key auth; the xAI forwarder exists to hold the OAuth credential and refresh the rotating bearer per request. The Fireworks forwarder is a **static-key** sidecar — its failures (kimi `Unauthorized`, deepseek `400`) are a separate, non-OAuth concern.
+
+— Origin: issue #114 (2026-06-10).

--- a/src/llmcli/auth/__init__.py
+++ b/src/llmcli/auth/__init__.py
@@ -1,6 +1,14 @@
 """OAuth credential management for llmCLI providers."""
-from .store import XaiCredentials, CredentialsCorruptError, load, save
+
+from .store import XaiCredentials, CredentialsCorruptError, ReauthRequired, load, save
 from .xai_oauth import login_flow, refresh_credentials
 
-__all__ = ["XaiCredentials", "CredentialsCorruptError", "load", "save",
-           "login_flow", "refresh_credentials"]
+__all__ = [
+    "XaiCredentials",
+    "CredentialsCorruptError",
+    "ReauthRequired",
+    "load",
+    "save",
+    "login_flow",
+    "refresh_credentials",
+]

--- a/src/llmcli/auth/store.py
+++ b/src/llmcli/auth/store.py
@@ -2,6 +2,7 @@
 
 Atomic-write with fcntl flock. Credentials dir mode 0700, file mode 0600.
 """
+
 import fcntl
 import json
 import os
@@ -14,6 +15,16 @@ XAI_CREDENTIALS_PATH = CREDENTIALS_DIR / "xai.json"
 
 class CredentialsCorruptError(RuntimeError):
     """Raised when credentials JSON cannot be parsed."""
+
+
+class ReauthRequired(RuntimeError):
+    """Raised when the refresh token is rejected (4xx) — interactive re-auth needed.
+
+    Distinct from a generic ``RuntimeError`` (transient 5xx / network) so the
+    forwarder can fail *loud* (ERROR log + 503 health) and back off instead of
+    hammering the token endpoint on every request. Subclasses ``RuntimeError``
+    for back-compat with existing ``except RuntimeError`` handlers.
+    """
 
 
 @dataclass(frozen=True)

--- a/src/llmcli/auth/xai_oauth.py
+++ b/src/llmcli/auth/xai_oauth.py
@@ -204,7 +204,7 @@ def exchange_code(code: str, verifier: str) -> XaiCredentials:
         timeout=30.0,
     )
     if response.status_code != 200:
-        logger.debug("xai token endpoint error body: %s", response.text)
+        logger.debug("xai token endpoint non-200: status=%d", response.status_code)
         raise RuntimeError(f"xAI token exchange failed (HTTP {response.status_code})")
     payload = response.json()
     expires_in = int(payload.get("expires_in") or 3600)
@@ -241,7 +241,7 @@ def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
         timeout=30.0,
     )
     if response.status_code != 200:
-        logger.debug("xai token endpoint error body: %s", response.text)
+        logger.debug("xai token endpoint non-200: status=%d", response.status_code)
         if 400 <= response.status_code < 500:
             raise ReauthRequired(
                 f"xAI rejected the refresh token (HTTP {response.status_code}) — "
@@ -269,11 +269,26 @@ def _parse_manual_input(raw: str) -> tuple[str, str]:
     """Extract ``(code, state)`` from a pasted redirect URL or a bare code value.
 
     Accepts either the full ``http://127.0.0.1:56121/callback?code=...&state=...``
-    URL copied from the browser address bar, or just the ``code`` value.
+    URL copied from the browser address bar, or just the ``code`` value. A pasted
+    URL must match the registered loopback redirect (scheme/host/port/path); a
+    foreign origin is rejected. Empty input raises.
     """
     raw = raw.strip()
+    if not raw:
+        raise RuntimeError("no code or redirect URL provided")
     if "code=" in raw or raw.lower().startswith("http"):
-        params = parse_qs(urlparse(raw).query)
+        parsed = urlparse(raw)
+        if parsed.scheme and (
+            parsed.scheme != "http"
+            or parsed.hostname != _XAI_REDIRECT_HOST
+            or parsed.port != XAI_OAUTH_REDIRECT_PORT
+            or parsed.path != XAI_OAUTH_REDIRECT_PATH
+        ):
+            raise RuntimeError(
+                "unexpected redirect origin — expected "
+                f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
+            )
+        params = parse_qs(parsed.query)
         code = (params.get("code") or [""])[0]
         if not code:
             raise RuntimeError("no `code=` parameter found in the pasted URL")
@@ -295,8 +310,16 @@ def _login_manual(pkce: PkceVerifier, authorize_url: str) -> XaiCredentials:
     print("(that page fails to load on a headless host — expected; the code is in the URL).")
     print("Paste the FULL redirected URL (or just the code value) below.\n")
     code, received_state = _parse_manual_input(input("code or redirect URL: "))
-    if received_state and not hmac.compare_digest(received_state, pkce.state):
-        raise RuntimeError("OAuth state mismatch — possible CSRF")
+    if received_state:
+        if not hmac.compare_digest(received_state, pkce.state):
+            raise RuntimeError("OAuth state mismatch — possible CSRF")
+    else:
+        # Bare-code paste (no state in the input) — PKCE still binds the code, but
+        # the CSRF state check cannot run. Log it so the omission is auditable.
+        logger.warning(
+            "xai login --manual: no OAuth state in pasted input — "
+            "CSRF state check skipped (PKCE still binds the code)"
+        )
     creds = exchange_code(code, pkce.code_verifier)
     save(creds, XAI_CREDENTIALS_PATH)
     print(f"Logged in. Credentials stored at {XAI_CREDENTIALS_PATH}")

--- a/src/llmcli/auth/xai_oauth.py
+++ b/src/llmcli/auth/xai_oauth.py
@@ -3,6 +3,7 @@
 Ported from hermes_cli/auth.py (Hermes Agent). Omits multi-account
 credential_pool — single-account only.
 """
+
 import base64
 import hashlib
 import hmac
@@ -17,7 +18,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 
-from llmcli.auth.store import XaiCredentials, XAI_CREDENTIALS_PATH, save
+from llmcli.auth.store import ReauthRequired, XaiCredentials, XAI_CREDENTIALS_PATH, save
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ _XAI_AUTHORIZE_ENDPOINT = f"{XAI_OAUTH_ISSUER}/oauth2/authorize"
 # ---------------------------------------------------------------------------
 # PKCE helpers
 # ---------------------------------------------------------------------------
+
 
 def _s256_challenge(verifier: str) -> str:
     """Compute the S256 PKCE code_challenge from a verifier string."""
@@ -74,9 +76,7 @@ def _build_authorize_url(challenge: str, state: str, nonce: str) -> str:
     MUST include plan=generic — without it auth.x.ai rejects loopback OAuth
     from non-allowlisted clients (ref: Hermes auth.py line 6393).
     """
-    redirect_uri = (
-        f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
-    )
+    redirect_uri = f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
     params = {
         "response_type": "code",
         "client_id": XAI_OAUTH_CLIENT_ID,
@@ -94,6 +94,7 @@ def _build_authorize_url(challenge: str, state: str, nonce: str) -> str:
 # ---------------------------------------------------------------------------
 # Loopback callback server
 # ---------------------------------------------------------------------------
+
 
 def _loopback_server(timeout: float = 120.0) -> tuple[str, str]:
     """Run a single-request HTTP server on 127.0.0.1:56121.
@@ -126,9 +127,13 @@ def _loopback_server(timeout: float = 120.0) -> tuple[str, str]:
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             if incoming.get("error"):
-                body = b"<html><body><h1>xAI authorization failed.</h1>Close this tab.</body></html>"
+                body = (
+                    b"<html><body><h1>xAI authorization failed.</h1>Close this tab.</body></html>"
+                )
             else:
-                body = b"<html><body><h1>xAI authorization received.</h1>Close this tab.</body></html>"
+                body = (
+                    b"<html><body><h1>xAI authorization received.</h1>Close this tab.</body></html>"
+                )
             self.wfile.write(body)
 
         def log_message(self, format: str, *args: object) -> None:  # noqa: A002 — match BaseHTTPRequestHandler signature
@@ -138,7 +143,9 @@ def _loopback_server(timeout: float = 120.0) -> tuple[str, str]:
         allow_reuse_address = True
 
     server = _ReuseHTTPServer((_XAI_REDIRECT_HOST, XAI_OAUTH_REDIRECT_PORT), _CallbackHandler)
-    thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True)
+    thread = threading.Thread(
+        target=server.serve_forever, kwargs={"poll_interval": 0.1}, daemon=True
+    )
     thread.start()
 
     deadline = time.monotonic() + timeout
@@ -164,6 +171,7 @@ def _loopback_server(timeout: float = 120.0) -> tuple[str, str]:
 # Token exchange and refresh
 # ---------------------------------------------------------------------------
 
+
 def exchange_code(code: str, verifier: str) -> XaiCredentials:
     """Exchange an authorization code for tokens via POST to auth.x.ai/oauth2/token.
 
@@ -173,9 +181,7 @@ def exchange_code(code: str, verifier: str) -> XaiCredentials:
     if not verifier:
         raise ValueError("PKCE code_verifier is required for token exchange.")
 
-    redirect_uri = (
-        f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
-    )
+    redirect_uri = f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
     # Recompute challenge from verifier for the defense-in-depth parameter
     challenge = _s256_challenge(verifier)
 
@@ -216,7 +222,10 @@ def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
     """Refresh an expired access_token using the stored refresh_token.
 
     Returns a new XaiCredentials with updated tokens.
-    Raises RuntimeError on 4xx (e.g. refresh_token expired after >30d offline).
+    Raises ReauthRequired on 4xx (refresh token rejected — e.g. rotated out of
+    its family, or expired after >30d offline) so the caller can fail loud and
+    require an interactive `llmcli xai login`. Raises a generic RuntimeError on
+    other non-200 (5xx / unexpected) which are transient and worth retrying.
     """
     response = httpx.post(
         _XAI_TOKEN_ENDPOINT,
@@ -233,6 +242,11 @@ def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
     )
     if response.status_code != 200:
         logger.debug("xai token endpoint error body: %s", response.text)
+        if 400 <= response.status_code < 500:
+            raise ReauthRequired(
+                f"xAI rejected the refresh token (HTTP {response.status_code}) — "
+                "run `llmcli xai login` to re-authenticate"
+            )
         raise RuntimeError(f"xAI token refresh failed (HTTP {response.status_code})")
     payload = response.json()
     expires_in = int(payload.get("expires_in") or 3600)
@@ -250,19 +264,65 @@ def refresh_credentials(creds: XaiCredentials) -> XaiCredentials:
 # Login flow orchestrator
 # ---------------------------------------------------------------------------
 
-def login_flow() -> XaiCredentials:
+
+def _parse_manual_input(raw: str) -> tuple[str, str]:
+    """Extract ``(code, state)`` from a pasted redirect URL or a bare code value.
+
+    Accepts either the full ``http://127.0.0.1:56121/callback?code=...&state=...``
+    URL copied from the browser address bar, or just the ``code`` value.
+    """
+    raw = raw.strip()
+    if "code=" in raw or raw.lower().startswith("http"):
+        params = parse_qs(urlparse(raw).query)
+        code = (params.get("code") or [""])[0]
+        if not code:
+            raise RuntimeError("no `code=` parameter found in the pasted URL")
+        return code, (params.get("state") or [""])[0]
+    return raw, ""
+
+
+def _login_manual(pkce: PkceVerifier, authorize_url: str) -> XaiCredentials:
+    """Headless login: print the URL, prompt for the pasted redirect code.
+
+    No loopback server is started, so a headless host needs **no SSH tunnel** —
+    the browser's redirect to ``127.0.0.1:56121`` fails to load, but its URL
+    (carrying the ``code``) is copied from the address bar and pasted here.
+    """
+    redirect = f"http://{_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT}{XAI_OAUTH_REDIRECT_PATH}"
+    print("Open this URL in any browser and authorize:\n")
+    print(f"  {authorize_url}\n")
+    print(f"You will be redirected to {redirect}?code=...&state=...")
+    print("(that page fails to load on a headless host — expected; the code is in the URL).")
+    print("Paste the FULL redirected URL (or just the code value) below.\n")
+    code, received_state = _parse_manual_input(input("code or redirect URL: "))
+    if received_state and not hmac.compare_digest(received_state, pkce.state):
+        raise RuntimeError("OAuth state mismatch — possible CSRF")
+    creds = exchange_code(code, pkce.code_verifier)
+    save(creds, XAI_CREDENTIALS_PATH)
+    print(f"Logged in. Credentials stored at {XAI_CREDENTIALS_PATH}")
+    print(f"  expires_at: {creds.expires_at}")
+    return creds
+
+
+def login_flow(manual: bool = False) -> XaiCredentials:
     """Run the full xAI OAuth PKCE login flow.
 
     1. Generate PKCE verifier + challenge
-    2. Spawn loopback listener on :56121
+    2. Spawn loopback listener on :56121 (skipped in ``manual`` mode)
     3. Open browser at auth.x.ai/oauth2/authorize?plan=generic&...
-    4. Wait for /callback?code=...&state=...
+    4. Wait for /callback?code=...&state=... (``manual`` mode: paste it instead)
     5. Verify state, exchange code for tokens
     6. Persist credentials to XAI_CREDENTIALS_PATH (0600)
     7. Return XaiCredentials
+
+    ``manual=True`` runs the loopback-free paste-the-code flow for headless hosts
+    (no listener, no SSH tunnel). See docs/runbooks/xai-oauth-reauth.md.
     """
     pkce = _generate_pkce_verifier()
     authorize_url = _build_authorize_url(pkce.code_challenge, pkce.state, pkce.nonce)
+
+    if manual:
+        return _login_manual(pkce, authorize_url)
 
     print(f"Opening browser at:\n  {authorize_url}")
     print(f"(loopback listener on {_XAI_REDIRECT_HOST}:{XAI_OAUTH_REDIRECT_PORT})")

--- a/src/llmcli/cli/xai.py
+++ b/src/llmcli/cli/xai.py
@@ -1,4 +1,5 @@
 """xAI / SuperGrok OAuth credentials CLI subcommands."""
+
 from __future__ import annotations
 
 import json
@@ -13,9 +14,16 @@ xai_app = typer.Typer(help="xAI / SuperGrok OAuth credentials")
 
 
 @xai_app.command("login")
-def login_cmd() -> None:
+def login_cmd(
+    manual: bool = typer.Option(
+        False,
+        "--manual",
+        help="Headless mode: print the auth URL and paste the redirected code "
+        "(no loopback listener / SSH tunnel needed).",
+    ),
+) -> None:
     """Run PKCE OAuth flow against auth.x.ai; stores credentials at xai.json."""
-    creds = login_flow()
+    creds = login_flow(manual=manual)
     console.print(f"[green]✓[/green] Logged in. expires_at={creds.expires_at}")
 
 
@@ -38,4 +46,6 @@ def status_cmd() -> None:
         console.print(json.dumps({"logged_in": False}))
         raise typer.Exit(1)
     # AC3: stdout must NOT contain eyJ (JWT prefix) or xai- substring
-    console.print(json.dumps({"logged_in": True, "expires_at": creds.expires_at, "scope": creds.scope}))
+    console.print(
+        json.dumps({"logged_in": True, "expires_at": creds.expires_at, "scope": creds.scope})
+    )

--- a/src/llmcli/proxy_forwarder/_server.py
+++ b/src/llmcli/proxy_forwarder/_server.py
@@ -88,10 +88,11 @@ def _health(adapter: ForwardAdapter):
 
     async def handler(request: web.Request) -> web.Response:  # noqa: ARG001 — handler signature
         payload = await adapter.health()
-        # 503 when the adapter needs re-auth — a flat 200 leaves the container
-        # HEALTHCHECK (HTTP-reachability only) green on dead credentials.
-        status = 503 if payload.get("reauth_required") else 200
-        return web.json_response(payload, status=status)
+        # 503 when the adapter needs re-auth OR creds are corrupted — a flat 200
+        # leaves the container HEALTHCHECK (HTTP-reachability only) green on dead
+        # or unreadable credentials.
+        unhealthy = payload.get("reauth_required") or payload.get("status") == "corrupted"
+        return web.json_response(payload, status=503 if unhealthy else 200)
 
     return handler
 
@@ -135,15 +136,14 @@ def _proxy(adapter: ForwardAdapter):
                     headers={"X-Llmcli-Reauth": "required"},
                     text="re-auth required — run `llmcli xai login` on this host",
                 )
-            except RuntimeError:
-                logger.warning(
-                    "proxy: upstream authentication failed for %s — re-auth required",
-                    request.path,
-                )
+            except RuntimeError as exc:
+                # Non-ReauthRequired refresh/upstream failure (e.g. auth.x.ai 5xx).
+                # Transient → 502 (bad gateway), NOT 401 + reauth header: the
+                # credentials are not known-bad, so do not tell the caller to re-auth.
+                logger.warning("proxy: transient upstream auth error for %s: %s", request.path, exc)
                 return web.Response(
-                    status=401,
-                    headers={"X-Llmcli-Reauth": "required"},
-                    text="upstream authentication failed — check provider credentials",
+                    status=502,
+                    text="upstream auth endpoint error — transient, retry",
                 )
             except aiohttp.ClientError as exc:
                 logger.warning("proxy: upstream connection failed: %s", exc)
@@ -185,7 +185,8 @@ def create_app(adapter: ForwardAdapter) -> web.Application:
     """Build the aiohttp Application for *adapter*.
 
     Routes:
-    - GET /health  → adapter health check (always 200).
+    - GET /health  → adapter health check (200, or 503 when re-auth required
+      or credentials are corrupted).
     - *   /{path}  → proxy to upstream (404 if path not in ALLOWED_PATHS).
     """
     app = web.Application()

--- a/src/llmcli/proxy_forwarder/_server.py
+++ b/src/llmcli/proxy_forwarder/_server.py
@@ -22,7 +22,7 @@ import aiohttp
 from aiohttp import web
 from multidict import CIMultiDictProxy
 
-from llmcli.auth.store import CredentialsCorruptError
+from llmcli.auth.store import CredentialsCorruptError, ReauthRequired
 
 from ._common import ALLOWED_PATHS, ForwardAdapter, _Resp401
 
@@ -87,7 +87,11 @@ def _health(adapter: ForwardAdapter):
     """Return a GET /health handler bound to *adapter*."""
 
     async def handler(request: web.Request) -> web.Response:  # noqa: ARG001 — handler signature
-        return web.json_response(await adapter.health())
+        payload = await adapter.health()
+        # 503 when the adapter needs re-auth — a flat 200 leaves the container
+        # HEALTHCHECK (HTTP-reachability only) green on dead credentials.
+        status = 503 if payload.get("reauth_required") else 200
+        return web.json_response(payload, status=status)
 
     return handler
 
@@ -121,6 +125,15 @@ def _proxy(adapter: ForwardAdapter):
                     status=503,
                     headers={"X-Llmcli-Reauth": "required"},
                     text="credentials corrupted — re-run the provider login command",
+                )
+            except ReauthRequired:
+                # Refresh token rejected (4xx). The adapter already logged ERROR
+                # once + set its flag; respond 503 (hard failure, not a soft 401
+                # to retry) so callers and monitoring see re-auth is required.
+                return web.Response(
+                    status=503,
+                    headers={"X-Llmcli-Reauth": "required"},
+                    text="re-auth required — run `llmcli xai login` on this host",
                 )
             except RuntimeError:
                 logger.warning(

--- a/src/llmcli/proxy_forwarder/xai_adapter.py
+++ b/src/llmcli/proxy_forwarder/xai_adapter.py
@@ -9,15 +9,23 @@ module for token refresh.
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import aiohttp
 
 from llmcli.auth import store
-from llmcli.auth.store import CredentialsCorruptError, XAI_CREDENTIALS_PATH, XaiCredentials
+from llmcli.auth.store import (
+    CredentialsCorruptError,
+    ReauthRequired,
+    XAI_CREDENTIALS_PATH,
+    XaiCredentials,
+)
 from llmcli.auth.xai_oauth import refresh_credentials
 
 from ._common import _Resp401, lazy_retry_on_401
+
+logger = logging.getLogger(__name__)
 
 
 class XaiAdapter:
@@ -35,6 +43,24 @@ class XaiAdapter:
 
     api_base: str = "https://api.x.ai"
     credential_path = XAI_CREDENTIALS_PATH
+
+    def __init__(self) -> None:
+        # Flipped once a 4xx refresh proves the refresh token is dead. While set,
+        # the adapter backs off (no re-POST to auth.x.ai) and /health reports 503.
+        # Cleared when the operator re-auths (refresh_token on disk changes).
+        self._reauth_required: bool = False
+        self._dead_refresh_token: str | None = None
+
+    def _sync_reauth_state(self, creds: XaiCredentials | None) -> None:
+        """Clear the re-auth flag once the operator has re-authed (token changed)."""
+        if (
+            self._reauth_required
+            and creds is not None
+            and creds.refresh_token != self._dead_refresh_token
+        ):
+            logger.info("xai forwarder: fresh credentials detected — re-auth flag cleared")
+            self._reauth_required = False
+            self._dead_refresh_token = None
 
     def transform_request(self, body: bytes, path: str) -> bytes:  # noqa: ARG002
         """Return body unchanged — xAI does not require request body mutation."""
@@ -89,31 +115,51 @@ class XaiAdapter:
         """
         try:
             creds = store.load(self.credential_path)
-            return {
-                "status": "ok",
-                "logged_in": creds is not None,
-                "expires_at": creds.expires_at if creds else None,
-            }
         except CredentialsCorruptError:
-            return {"status": "ok", "logged_in": False, "expires_at": None}
+            return {
+                "status": "corrupted",
+                "logged_in": False,
+                "expires_at": None,
+                "reauth_required": self._reauth_required,
+            }
+        self._sync_reauth_state(creds)
+        return {
+            "status": "reauth_required" if self._reauth_required else "ok",
+            "logged_in": creds is not None,
+            "expires_at": creds.expires_at if creds else None,
+            "reauth_required": self._reauth_required,
+        }
 
     async def refresh(self, creds: XaiCredentials) -> XaiCredentials:
-        """Refresh *creds* via the xAI token endpoint.
+        """Refresh *creds* via the xAI token endpoint (off-loop executor).
 
-        Delegates to the synchronous ``refresh_credentials`` function via
-        ``run_in_executor`` to avoid blocking the event loop during the
-        HTTPS POST to auth.x.ai.
+        Backs off when the refresh token is already known-dead: re-POSTing a
+        rejected token on every request hammers auth.x.ai and starves the event
+        loop — the silent 42 h failure mode of issue #114. On a fresh 4xx, logs
+        ERROR once and flips the re-auth flag; on success, clears it.
 
-        Parameters
-        ----------
-        creds:
-            Credentials whose ``refresh_token`` will be exchanged for a new
-            ``access_token``.
-
-        Returns
-        -------
-        XaiCredentials
-            Fresh credentials with updated ``access_token`` and ``expires_at``.
+        Raises
+        ------
+        ReauthRequired
+            When the refresh token is rejected (4xx), now or previously.
         """
+        # Back-off — refresh token already proven dead and unchanged on disk.
+        if self._reauth_required and creds.refresh_token == self._dead_refresh_token:
+            raise ReauthRequired(
+                "xAI re-auth required — run `llmcli xai login` (cached; not re-POSTing)"
+            )
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, refresh_credentials, creds)
+        try:
+            new = await loop.run_in_executor(None, refresh_credentials, creds)
+        except ReauthRequired:
+            if not self._reauth_required:
+                logger.error(
+                    "RE-AUTH REQUIRED: xAI rejected the refresh token (HTTP 4xx). "
+                    "Run `llmcli xai login` on this host — serving 503 until re-auth."
+                )
+            self._reauth_required = True
+            self._dead_refresh_token = creds.refresh_token
+            raise
+        self._reauth_required = False
+        self._dead_refresh_token = None
+        return new

--- a/src/llmcli/proxy_forwarder/xai_adapter.py
+++ b/src/llmcli/proxy_forwarder/xai_adapter.py
@@ -48,6 +48,14 @@ class XaiAdapter:
         # Flipped once a 4xx refresh proves the refresh token is dead. While set,
         # the adapter backs off (no re-POST to auth.x.ai) and /health reports 503.
         # Cleared when the operator re-auths (refresh_token on disk changes).
+        #
+        # Single-threaded asyncio (no data race), but the flag is read/written
+        # both inside _REFRESH_LOCK (refresh()) and outside it (health()'s
+        # _sync_reauth_state). Two bounded, benign windows, each ≤1 healthcheck
+        # interval: (a) a health poll may report ok while a 4xx is in-flight;
+        # (b) /health may stay 503 briefly after re-auth if traffic (fresh token,
+        # no refresh) arrives before the next poll. Neither wrongly clears the
+        # flag — _sync_reauth_state only clears on a *changed* refresh_token.
         self._reauth_required: bool = False
         self._dead_refresh_token: str | None = None
 

--- a/tests/test_proxy_forwarder.py
+++ b/tests/test_proxy_forwarder.py
@@ -6,10 +6,13 @@ Tests 5–7: XaiAdapter regression under the new contract (RED until T4/T7 land)
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from llmcli.auth.store import XaiCredentials
 from llmcli.proxy_forwarder._common import ALLOWED_PATHS, ForwardAdapter, OAuthAdapter
 
 
@@ -205,3 +208,163 @@ def test_xai_transform_is_identity() -> None:
 
     # Assert — no extra headers injected by xAI adapter (auth is handled in execute)
     assert headers == {}, f"XaiAdapter.extra_headers() expected {{}}, got {headers!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — fail-loud back-off: a known-dead refresh token is NOT re-POSTed (#114)
+# ---------------------------------------------------------------------------
+
+
+def _dead_creds(refresh_token: str = "DEAD_RTK") -> XaiCredentials:
+    """Expired credentials whose refresh token the token endpoint will 4xx."""
+    return XaiCredentials(
+        access_token="A",
+        refresh_token=refresh_token,
+        id_token="I",
+        expires_at=int(time.time()) - 60,  # expired → triggers proactive refresh
+        token_type="Bearer",
+        scope="openid",
+    )
+
+
+@pytest.mark.asyncio
+async def test_xai_adapter_backs_off_on_dead_refresh_token() -> None:
+    """After a 4xx proves the refresh token dead, refresh() backs off — no re-POST."""
+    # Arrange
+    from llmcli.auth.store import ReauthRequired
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    adapter = XaiAdapter()
+    dead = _dead_creds()
+
+    post_calls = 0
+
+    def _fake_post(url: str, **kwargs):  # noqa: ARG001 — signature match
+        nonlocal post_calls
+        post_calls += 1
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.text = "invalid_grant"
+        return resp
+
+    # Act — two refreshes of the same dead token
+    with patch("httpx.post", side_effect=_fake_post):
+        with pytest.raises(ReauthRequired):
+            await adapter.refresh(dead)  # real POST → 400 → flag set
+        with pytest.raises(ReauthRequired):
+            await adapter.refresh(dead)  # backed off → no POST
+
+    # Assert — exactly one upstream POST despite two refresh attempts
+    assert post_calls == 1, f"expected one POST (back-off), got {post_calls}"
+    assert adapter._reauth_required is True
+
+
+@pytest.mark.asyncio
+async def test_xai_adapter_clears_flag_after_reauth() -> None:
+    """A new refresh_token (operator re-authed) clears back-off and POSTs again."""
+    # Arrange — drive the adapter into the dead state first
+    from llmcli.auth.store import ReauthRequired
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    adapter = XaiAdapter()
+
+    def _post_400(url: str, **kwargs):  # noqa: ARG001
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.text = "invalid_grant"
+        return resp
+
+    with patch("httpx.post", side_effect=_post_400):
+        with pytest.raises(ReauthRequired):
+            await adapter.refresh(_dead_creds("DEAD_RTK"))
+    assert adapter._reauth_required is True
+
+    # Act — operator re-authed: a DIFFERENT refresh_token now succeeds
+    token_resp = {
+        "access_token": "NEW_ATK",
+        "refresh_token": "NEW_RTK",
+        "id_token": "NEW_ITK",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+    }
+
+    def _post_ok(url: str, **kwargs):  # noqa: ARG001
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = token_resp
+        return resp
+
+    with patch("httpx.post", side_effect=_post_ok):
+        new = await adapter.refresh(_dead_creds("NEW_RTK"))
+
+    # Assert — refreshed + flag cleared
+    assert new.access_token == "NEW_ATK"
+    assert adapter._reauth_required is False
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — /health returns 503 when re-auth required (deterministic unhealthy) (#114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_503_when_reauth_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /health → 503 (not 200) when the adapter flags reauth_required."""
+    # Arrange
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    adapter = XaiAdapter()
+    # Absent creds → _sync_reauth_state cannot clear the flag (no fresh token on disk).
+    monkeypatch.setattr(adapter, "credential_path", tmp_path / "absent.json")
+    adapter._reauth_required = True
+    adapter._dead_refresh_token = "DEAD_RTK"
+
+    app = create_app(adapter)
+
+    # Act
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/health")
+
+        # Assert — 503 so the container HEALTHCHECK flips unhealthy
+        assert resp.status == 503, f"expected 503, got {resp.status}"
+        body = await resp.json()
+    assert body["reauth_required"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — proxy maps ReauthRequired → 503 + X-Llmcli-Reauth header (#114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_503_on_reauth_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ReauthRequired from execute() surfaces as HTTP 503 + X-Llmcli-Reauth: required."""
+    # Arrange
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.auth.store import ReauthRequired
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    adapter = XaiAdapter()
+
+    async def _boom(*_args, **_kwargs):
+        raise ReauthRequired("refresh token dead")
+
+    monkeypatch.setattr(adapter, "execute", _boom)
+
+    app = create_app(adapter)
+
+    # Act
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/chat/completions", data=b"{}")
+
+        # Assert — hard 503 (not a soft 401) + the re-auth signal header
+        assert resp.status == 503, f"expected 503, got {resp.status}"
+        assert resp.headers.get("X-Llmcli-Reauth") == "required"

--- a/tests/test_proxy_forwarder.py
+++ b/tests/test_proxy_forwarder.py
@@ -368,3 +368,91 @@ async def test_proxy_503_on_reauth_required(monkeypatch: pytest.MonkeyPatch) -> 
         # Assert — hard 503 (not a soft 401) + the re-auth signal header
         assert resp.status == 503, f"expected 503, got {resp.status}"
         assert resp.headers.get("X-Llmcli-Reauth") == "required"
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — /health 503 on corrupted creds (review fix #114)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_503_on_corrupted_creds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Corrupted xai.json → /health 503 (was 200) so monitoring sees unhealthy."""
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    creds_file = tmp_path / "xai.json"
+    creds_file.write_text('{"access_token": "abc"')  # partial JSON → CredentialsCorruptError
+    adapter = XaiAdapter()
+    monkeypatch.setattr(adapter, "credential_path", creds_file)
+
+    app = create_app(adapter)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/health")
+        assert resp.status == 503, f"expected 503, got {resp.status}"
+        body = await resp.json()
+    assert body["status"] == "corrupted"
+    assert body["logged_in"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — transient (non-ReauthRequired) refresh failure → 502, no reauth header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_502_on_transient_refresh_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A plain RuntimeError (auth.x.ai 5xx) → 502, NOT 401+reauth (creds not known-bad)."""
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    adapter = XaiAdapter()
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("xAI token refresh failed (HTTP 503)")
+
+    monkeypatch.setattr(adapter, "execute", _boom)
+
+    app = create_app(adapter)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.post("/v1/chat/completions", data=b"{}")
+        assert resp.status == 502, f"expected 502, got {resp.status}"
+        assert resp.headers.get("X-Llmcli-Reauth") is None
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — /health self-heals once the operator re-auths (new refresh_token)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_selfheal_clears_flag_on_new_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After re-auth (new refresh_token on disk), /health flips 503 → 200."""
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from llmcli.auth import store
+    from llmcli.proxy_forwarder._server import create_app
+    from llmcli.proxy_forwarder.xai_adapter import XaiAdapter
+
+    creds_file = tmp_path / "xai.json"
+    adapter = XaiAdapter()
+    monkeypatch.setattr(adapter, "credential_path", creds_file)
+    # Simulate a prior dead-token episode, then the operator re-authing (new token).
+    store.save(_dead_creds("NEW_RTK"), path=creds_file)
+    adapter._reauth_required = True
+    adapter._dead_refresh_token = "OLD_DEAD_RTK"
+
+    app = create_app(adapter)
+    async with TestClient(TestServer(app)) as client:
+        resp = await client.get("/health")
+        assert resp.status == 200, f"expected self-heal to 200, got {resp.status}"
+        body = await resp.json()
+    assert body["reauth_required"] is False

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -14,8 +14,10 @@ from llmcli.auth import store as auth_store
 from llmcli.auth.store import CredentialsCorruptError, ReauthRequired, XaiCredentials
 from llmcli.auth.xai_oauth import (
     XAI_OAUTH_CLIENT_ID,
+    PkceVerifier,
     _build_authorize_url,
     _parse_manual_input,
+    _s256_challenge,
     exchange_code,
     login_flow,
     refresh_credentials,
@@ -91,8 +93,10 @@ def test_pkce_code_exchange(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert body.get("code") == "test_code", f"body={body}"
     assert body.get("code_verifier") == fake_verifier, f"body={body}"
     assert body.get("client_id") == XAI_OAUTH_CLIENT_ID, f"body={body}"
-    # F4 — assert code_challenge in POST body
-    assert body.get("code_challenge") is not None, f"code_challenge missing from body: {body}"
+    # F4 — assert code_challenge is the exact S256 of the verifier (not just present)
+    assert body.get("code_challenge") == _s256_challenge(fake_verifier), (
+        f"code_challenge is not the S256 of the verifier: {body}"
+    )
 
     # Assert — returned XaiCredentials matches mock response
     assert result.access_token == "ATK"
@@ -402,7 +406,7 @@ def test_exchange_code_empty_verifier_raises() -> None:
 async def test_credentials_corrupted_health_endpoint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test-AC4 second half: forwarder /health reports logged_in:false when xai.json is corrupted."""
+    """Forwarder /health reports logged_in:false + 503 when xai.json is corrupted (#114)."""
     from aiohttp.test_utils import TestClient, TestServer
 
     from llmcli.proxy_forwarder._server import create_app
@@ -417,9 +421,11 @@ async def test_credentials_corrupted_health_endpoint(
     app = create_app(adapter)
     async with TestClient(TestServer(app)) as client:
         resp = await client.get("/health")
-        assert resp.status == 200
+        # 503 (was 200): corrupted creds must flip the container HEALTHCHECK unhealthy.
+        assert resp.status == 503
         body = await resp.json()
         assert body["logged_in"] is False
+        assert body["status"] == "corrupted"
 
 
 # ---------------------------------------------------------------------------
@@ -594,3 +600,54 @@ def test_login_flow_manual_state_mismatch(tmp_path: Path, monkeypatch: pytest.Mo
     # Act + Assert — raises before any token exchange
     with pytest.raises(RuntimeError, match="state mismatch"):
         login_flow(manual=True)
+
+
+def test_parse_manual_input_empty_raises() -> None:
+    """Empty / whitespace-only input is rejected (no silent empty code) — #114 review."""
+    for raw in ("", "   ", "\n\t"):
+        with pytest.raises(RuntimeError):
+            _parse_manual_input(raw)
+
+
+def test_parse_manual_input_foreign_origin_raises() -> None:
+    """A pasted URL from a non-loopback origin is rejected — #114 review."""
+    with pytest.raises(RuntimeError, match="unexpected redirect origin"):
+        _parse_manual_input("https://evil.example.com/callback?code=ABC&state=XYZ")
+
+
+def test_login_flow_manual_matching_state_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """manual login with a pasted redirect URL whose state matches → success — #114 review."""
+    # Arrange — pin the PKCE verifier so the pasted state can match
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.xai_oauth.XAI_CREDENTIALS_PATH", creds_file)
+    fixed = PkceVerifier(
+        code_verifier="v" * 43, code_challenge="chal", state="KNOWN_STATE", nonce="n"
+    )
+    monkeypatch.setattr("llmcli.auth.xai_oauth._generate_pkce_verifier", lambda: fixed)
+    url = "http://127.0.0.1:56121/callback?code=GOODCODE&state=KNOWN_STATE"
+    monkeypatch.setattr("builtins.input", lambda _prompt="": url)
+
+    token_resp = {
+        "access_token": "SATK",
+        "refresh_token": "SRTK",
+        "id_token": "SITK",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+    }
+
+    def _fake_post(url: str, **kwargs):  # noqa: ARG001 — signature match
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = token_resp
+        return resp
+
+    # Act
+    with patch("httpx.post", side_effect=_fake_post):
+        creds = login_flow(manual=True)
+
+    # Assert — matching state passed the CSRF check, creds exchanged + persisted
+    assert creds.access_token == "SATK"
+    assert auth_store.load(path=creds_file) is not None

--- a/tests/test_xai_oauth_pkce.py
+++ b/tests/test_xai_oauth_pkce.py
@@ -11,11 +11,14 @@ import pytest
 
 # F1 — direct imports (no try/except guards)
 from llmcli.auth import store as auth_store
-from llmcli.auth.store import CredentialsCorruptError, XaiCredentials
+from llmcli.auth.store import CredentialsCorruptError, ReauthRequired, XaiCredentials
 from llmcli.auth.xai_oauth import (
     XAI_OAUTH_CLIENT_ID,
     _build_authorize_url,
+    _parse_manual_input,
     exchange_code,
+    login_flow,
+    refresh_credentials,
 )
 from llmcli.proxy_forwarder._common import _REFRESH_LOCK, lazy_retry_on_401  # noqa: F401
 
@@ -471,3 +474,123 @@ async def test_lazy_refresh_still_401_propagates(
     )
     assert resp.status == 401, f"expected final 401, got {resp.status}"
     assert api_calls == 2, f"expected 2 api calls (initial + retry), got {api_calls}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — refresh_credentials maps 4xx → ReauthRequired, 5xx → RuntimeError (#114)
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_4xx_raises_reauth_required() -> None:
+    """A 4xx from the token endpoint means the refresh token is dead → ReauthRequired."""
+    # Arrange
+    creds = _make_fake_creds(refresh_token="DEAD_RTK", expires_delta=-60)
+
+    def _fake_post(url: str, **kwargs):  # noqa: ARG001 — signature match
+        resp = MagicMock()
+        resp.status_code = 400
+        resp.text = "invalid_grant"
+        return resp
+
+    # Act + Assert
+    with patch("httpx.post", side_effect=_fake_post):
+        with pytest.raises(ReauthRequired):
+            refresh_credentials(creds)
+
+
+def test_refresh_5xx_raises_generic_runtimeerror() -> None:
+    """A 5xx is transient — generic RuntimeError, NOT ReauthRequired (no back-off)."""
+    # Arrange
+    creds = _make_fake_creds(refresh_token="RTK", expires_delta=-60)
+
+    def _fake_post(url: str, **kwargs):  # noqa: ARG001 — signature match
+        resp = MagicMock()
+        resp.status_code = 503
+        resp.text = "upstream busy"
+        return resp
+
+    # Act + Assert
+    with patch("httpx.post", side_effect=_fake_post):
+        with pytest.raises(RuntimeError) as exc_info:
+            refresh_credentials(creds)
+    assert not isinstance(exc_info.value, ReauthRequired), (
+        "a 5xx must surface as a transient RuntimeError, not ReauthRequired"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — _parse_manual_input (--manual paste flow, #114)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_manual_input_full_url() -> None:
+    """A pasted redirect URL yields (code, state)."""
+    code, state = _parse_manual_input("http://127.0.0.1:56121/callback?code=ABC123&state=XYZ")
+    assert code == "ABC123"
+    assert state == "XYZ"
+
+
+def test_parse_manual_input_bare_code() -> None:
+    """A bare code value yields (code, '')."""
+    code, state = _parse_manual_input("  ABC123  ")
+    assert code == "ABC123"
+    assert state == ""
+
+
+def test_parse_manual_input_url_without_code_raises() -> None:
+    """A redirect URL missing the code param is an error."""
+    with pytest.raises(RuntimeError):
+        _parse_manual_input("http://127.0.0.1:56121/callback?state=XYZ")
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — login_flow(manual=True): loopback-free paste flow (#114)
+# ---------------------------------------------------------------------------
+
+
+def test_login_flow_manual_bare_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """manual login: paste a bare code → exchange → persist (no loopback / SSH tunnel)."""
+    # Arrange
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.xai_oauth.XAI_CREDENTIALS_PATH", creds_file)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "PASTED_CODE")
+
+    token_resp = {
+        "access_token": "MATK",
+        "refresh_token": "MRTK",
+        "id_token": "MITK",
+        "expires_in": 3600,
+        "token_type": "Bearer",
+        "scope": "openid",
+    }
+
+    def _fake_post(url: str, **kwargs):  # noqa: ARG001 — signature match
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = token_resp
+        return resp
+
+    # Act
+    with patch("httpx.post", side_effect=_fake_post):
+        creds = login_flow(manual=True)
+
+    # Assert — credentials exchanged + persisted to the (patched) path
+    assert creds.access_token == "MATK"
+    assert creds_file.exists()
+    saved = auth_store.load(path=creds_file)
+    assert saved is not None and saved.refresh_token == "MRTK"
+
+
+def test_login_flow_manual_state_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """manual login rejects a pasted state that doesn't match the PKCE state (CSRF guard)."""
+    # Arrange — paste a URL whose state cannot match the random per-flow PKCE state
+    creds_file = tmp_path / "xai.json"
+    monkeypatch.setattr("llmcli.auth.xai_oauth.XAI_CREDENTIALS_PATH", creds_file)
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": "http://127.0.0.1:56121/callback?code=C&state=WRONG_STATE",
+    )
+
+    # Act + Assert — raises before any token exchange
+    with pytest.raises(RuntimeError, match="state mismatch"):
+        login_flow(manual=True)


### PR DESCRIPTION
## Summary
- M₁'s `xai-forwarder` silently looped on OAuth refresh-`4xx` for 42h — an HA-critical outage (M₁ must always relay cloud LLM). The forwarder now fails **loud** and **backs off** instead of re-POSTing a dead token to `auth.x.ai` on every request, and headless re-auth no longer needs an SSH tunnel.
- `refresh_credentials` raises `ReauthRequired` on 4xx (dead refresh token) vs a transient `RuntimeError` on 5xx. `XaiAdapter` logs `ERROR` once + flips a back-off flag; `/health` → **503** (container HEALTHCHECK now flips *unhealthy* deterministically — it was a flat 200) and the proxy maps `ReauthRequired` → 503 + `X-Llmcli-Reauth: required`. Self-heals when a fresh `xai.json` lands.
- `llmcli xai login --manual`: paste-the-code flow (no loopback listener / tunnel) for headless hosts.
- Root cause documented: two hosts sharing one xAI refresh-token **family** clobber each other on rotation → **per-host independent grant, never copy `xai.json`** (`docs/runbooks/xai-oauth-reauth.md` + CLAUDE.md).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #114: ops(M1) all proxy upstreams broken | OPEN |
| Implementation | 1 commit on `feat/114-proxy-upstreams-oauth-forwarders` | Complete |
| Verification | Lint ✅ Typecheck (ruff PYI) ✅ Tests ✅ (11 new) · file-length ✅ | Passed |

## Test Plan
- [ ] `uv run pytest tests/test_proxy_forwarder.py tests/test_xai_oauth_pkce.py` → 27 pass (full suite: 452 pass / 11 skip)
- [ ] Dead token: refresh 4xx → `ReauthRequired`; `/health` → 503; **one** upstream POST across repeated requests (back-off); flag clears when `refresh_token` changes
- [ ] `llmcli xai login --manual` on a headless host → paste redirect URL → creds persisted, no tunnel
- [ ] Out of scope (separate issue): kimi `Unauthorized` / deepseek `400` — static-key (`FIREWORKS_API_KEY`/`NVIDIA_API_KEY`), not OAuth

## Remediation already applied
M₁ was re-authed independently (fresh PKCE grant) during triage — this PR is the durable hardening so it doesn't recur silently.

Fixes #114

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`