### PR TITLE
feat(contracts): echo job_id on response models + contracts-bump caller (factory#1840)

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -1,0 +1,16 @@
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/llmCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats"
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/src/llmcli/nats/_generation.py
+++ b/src/llmcli/nats/_generation.py
@@ -19,7 +19,6 @@ import httpx
 
 from roxabi_contracts.envelope import CONTRACT_VERSION
 from roxabi_contracts.errors import WorkerError
-from roxabi_contracts.llm.builders import build_llm_chunk, build_llm_response
 from roxabi_contracts.llm.models import LlmChunkEvent, LlmResponse
 
 if TYPE_CHECKING:
@@ -69,6 +68,11 @@ class GenerationMixin:
         safe_id = rid if _REQUEST_ID_RE.match(rid) else "unknown"
         trace_id = payload.get("trace_id") or safe_id
         # builders.py does not accept worker_error= — build envelope manually.
+        # Conditional kwarg exclusion: omit job_id entirely when absent so
+        # default_factory fires instead of passing None to _validate_job_id.
+        job_id_kwargs: dict = {}
+        if job_id := payload.get("job_id"):
+            job_id_kwargs["job_id"] = job_id
         if stream:
             return (
                 LlmChunkEvent(
@@ -80,6 +84,7 @@ class GenerationMixin:
                     is_error=True,
                     error=we.message,
                     worker_error=we,
+                    **job_id_kwargs,
                 )
                 .model_dump_json(exclude_none=True)
                 .encode()
@@ -93,6 +98,7 @@ class GenerationMixin:
                 ok=False,
                 error=we.message,
                 worker_error=we,
+                **job_id_kwargs,
             )
             .model_dump_json(exclude_none=True)
             .encode()
@@ -196,9 +202,23 @@ class GenerationMixin:
                     continue
                 delta = chunk_data.get("choices", [{}])[0].get("delta", {}).get("content")
                 if delta and msg.reply:
+                    # Conditional kwarg exclusion: omit job_id when absent so
+                    # default_factory fires instead of passing None to _validate_job_id.
+                    _jid: dict = {}
+                    if _v := payload.get("job_id"):
+                        _jid["job_id"] = _v
                     await nc.publish(
                         msg.reply,
-                        build_llm_chunk(payload, delta=delta).encode(),
+                        LlmChunkEvent(
+                            contract_version=CONTRACT_VERSION,
+                            trace_id=payload.get("trace_id") or str(payload.get("request_id", "")),
+                            issued_at=datetime.now(timezone.utc),
+                            request_id=str(payload.get("request_id", "")),
+                            delta=delta,
+                            **_jid,
+                        )
+                        .model_dump_json(exclude_none=True)
+                        .encode(),
                     )
                     chunk_count += 1
 
@@ -212,9 +232,22 @@ class GenerationMixin:
 
         duration_ms = int((time.monotonic() - t0) * 1000)
         if msg.reply:
+            _jid2: dict = {}
+            if _v2 := payload.get("job_id"):
+                _jid2["job_id"] = _v2
             await nc.publish(
                 msg.reply,
-                build_llm_chunk(payload, done=True, duration_ms=duration_ms).encode(),
+                LlmChunkEvent(
+                    contract_version=CONTRACT_VERSION,
+                    trace_id=payload.get("trace_id") or str(payload.get("request_id", "")),
+                    issued_at=datetime.now(timezone.utc),
+                    request_id=str(payload.get("request_id", "")),
+                    done=True,
+                    duration_ms=duration_ms,
+                    **_jid2,
+                )
+                .model_dump_json(exclude_none=True)
+                .encode(),
             )
 
     async def _blocking_response(self, msg, payload: dict, body: dict, t0: float) -> None:
@@ -225,7 +258,23 @@ class GenerationMixin:
         text: str = data["choices"][0]["message"]["content"]
 
         duration_ms = int((time.monotonic() - t0) * 1000)
+        # Conditional kwarg exclusion: omit job_id when absent so
+        # default_factory fires instead of passing None to _validate_job_id.
+        _jid3: dict = {}
+        if _v3 := payload.get("job_id"):
+            _jid3["job_id"] = _v3
         await self.reply(
             msg,
-            build_llm_response(payload, ok=True, text=text, duration_ms=duration_ms).encode(),
+            LlmResponse(
+                contract_version=CONTRACT_VERSION,
+                trace_id=payload.get("trace_id") or str(payload.get("request_id", "")),
+                issued_at=datetime.now(timezone.utc),
+                request_id=str(payload.get("request_id", "")),
+                ok=True,
+                text=text,
+                duration_ms=duration_ms,
+                **_jid3,
+            )
+            .model_dump_json(exclude_none=True)
+            .encode(),
         )

--- a/tests/nats/test_adapter.py
+++ b/tests/nats/test_adapter.py
@@ -351,3 +351,111 @@ async def test_stream_only_done_emits_empty_response_warning(
     assert any("empty response" in m for m in warning_msgs), (
         f"Expected 'empty response' warning, got: {warning_msgs}"
     )
+
+
+# ---------- Issue #1840 — job_id echo on response models ----------
+
+
+@pytest.mark.asyncio
+async def test_blocking_response_echoes_job_id(adapter, fake_msg_factory, make_request_payload):
+    """LlmResponse carries job_id when the request payload includes one."""
+    payload = make_request_payload(stream=False, job_id="job-abc-123")
+    msg = fake_msg_factory(payload)
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.json = MagicMock(return_value={"choices": [{"message": {"content": "hi"}}]})
+    adapter._client.post.return_value = fake_resp
+
+    await adapter.handle(msg, payload)
+
+    assert adapter._nc.publish.await_count == 1
+    body = _decode_publish(adapter._nc.publish.await_args_list[0])
+    assert body["ok"] is True
+    assert body["job_id"] == "job-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_blocking_response_no_crash_without_job_id(
+    adapter, fake_msg_factory, make_request_payload
+):
+    """LlmResponse must not crash when job_id is absent (default_factory fires)."""
+    payload = make_request_payload(stream=False)
+    msg = fake_msg_factory(payload)
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.json = MagicMock(return_value={"choices": [{"message": {"content": "hi"}}]})
+    adapter._client.post.return_value = fake_resp
+
+    await adapter.handle(msg, payload)
+
+    assert adapter._nc.publish.await_count == 1
+    body = _decode_publish(adapter._nc.publish.await_args_list[0])
+    assert body["ok"] is True
+    # job_id must be present (default_factory generates one) and non-empty
+    assert body.get("job_id")
+
+
+@pytest.mark.asyncio
+async def test_stream_chunks_echo_job_id(
+    adapter, fake_msg_factory, make_request_payload, stream_lines
+):
+    """LlmChunkEvent (delta + done terminator) both carry job_id from the request."""
+    payload = make_request_payload(stream=True, job_id="job-stream-xyz")
+    msg = fake_msg_factory(payload)
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.aiter_lines = lambda: stream_lines(["hello", " world"])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    adapter._client.stream.return_value = cm
+
+    await adapter.handle(msg, payload)
+
+    # 2 delta chunks + 1 done terminator = 3 publishes
+    assert adapter._nc.publish.await_count == 3
+    bodies = [_decode_publish(c) for c in adapter._nc.publish.await_args_list]
+    for body in bodies:
+        assert body["job_id"] == "job-stream-xyz", f"job_id missing or wrong in: {body}"
+
+
+@pytest.mark.asyncio
+async def test_stream_chunks_no_crash_without_job_id(
+    adapter, fake_msg_factory, make_request_payload, stream_lines
+):
+    """Streaming path must not crash when job_id is absent (default_factory fires)."""
+    payload = make_request_payload(stream=True)
+    msg = fake_msg_factory(payload)
+
+    fake_resp = MagicMock()
+    fake_resp.raise_for_status = MagicMock()
+    fake_resp.aiter_lines = lambda: stream_lines(["hi"])
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    adapter._client.stream.return_value = cm
+
+    await adapter.handle(msg, payload)
+
+    assert adapter._nc.publish.await_count == 2  # 1 delta + 1 terminator
+    bodies = [_decode_publish(c) for c in adapter._nc.publish.await_args_list]
+    for body in bodies:
+        # default_factory generates a job_id; must be non-empty
+        assert body.get("job_id"), f"job_id must be non-empty, got: {body}"
+
+
+@pytest.mark.asyncio
+async def test_error_response_echoes_job_id(adapter, fake_msg_factory, make_request_payload):
+    """Error path (LlmResponse ok=False) also echoes job_id when present."""
+    payload = make_request_payload(stream=False, job_id="job-err-456")
+    msg = fake_msg_factory(payload)
+    adapter._client.post.side_effect = httpx.TimeoutException("upstream timeout")
+
+    await adapter.handle(msg, payload)
+
+    body = _decode_publish(adapter._nc.publish.await_args_list[-1])
+    assert body["ok"] is False
+    assert body["job_id"] == "job-err-456"

--- a/uv.lock
+++ b/uv.lock
@@ -2737,8 +2737,8 @@ wheels = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.7.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
+version = "0.9.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary

- Bumps `roxabi-contracts` 0.7.0→0.9.0 and `roxabi-nats` to factory staging SHA `da2ebebd` — picks up `WorkEnvelope.job_id` (ADR/issue #1619)
- Rewrites 5 direct-construction sites in `_generation.py` to echo `job_id` from request payload onto `LlmResponse` / `LlmChunkEvent`, using conditional kwarg exclusion so `default_factory` fires when `job_id` is absent (avoids `_validate_job_id` TypeError on None)
- Adds `.github/workflows/contracts-bump-caller.yml` — weekly Monday 06:00 UTC cron + manual dispatch, calls `contracts-bump.yml` reusable workflow in `roxabi-factory`
- Replaces deprecated `build_llm_chunk` / `build_llm_response` call-sites with direct model construction (builders do not accept `job_id`)

## Test plan

- [ ] `pytest tests/nats/test_adapter.py` — 21 tests pass (5 new: blocking echo, blocking no-crash, stream echo, stream no-crash, error echo)
- [ ] Full suite: 463 passed, 11 skipped, 0 failures
- [ ] `ruff check` and `ruff format --check` pass on changed files
- [ ] File length gate: `_generation.py` = 280 lines (under 300-line limit)
- [ ] `tools/check_file_length.sh`, `check_folder_size.sh`, `check_axial_drift.sh` — all clean

Closes Roxabi/roxabi-factory#1840 (llmCLI lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)