### PR TITLE
ci(contracts-bump): stop passing secrets.PAT to factory reusable workflow

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -12,5 +12,3 @@ jobs:
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats"
-    secrets:
-      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary
- Drop the `secrets: PAT` pass-through in `contracts-bump-caller.yml` — the factory reusable workflow stopped using it (roxabi-factory#1850) and its interface is optional since roxabi-factory#1855.
- Step 2 of the contract cleanup gating the org PAT revocation (chantier secrets).

⚠️ **Merge order**: only after roxabi-factory#1855 (PAT `required: false`) is on factory `staging` — auto-merge deliberately not armed yet.

Fixes #119

---
Generated with [Claude Code](https://claude.com/claude-code)