### PR TITLE
fix(forwarder): publish xai-forwarder on 127.0.0.1:18645 for host consumers

### DIFF
--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -20,7 +20,11 @@ Environment=LLMCLI_FORWARDER_PROVIDER=xai
 Environment=LLMCLI_FORWARDER_PORT=18645
 UserNS=keep-id:uid=1502,gid=1502
 Exec=forwarder
-HealthCmd=python -c "import urllib.request; urllib.request.urlopen('http://localhost:18645/health', timeout=5)"
+# Single-quote outer / double-quote inner: podman 5.7.0 (quadlet, M₁ Ubuntu)
+# truncates a HealthCmd value that ENDS in an escaped double-quote, producing
+# `sh: Unterminated quoted string` -> permanent unhealthy. Ending in the outer
+# single quote sidesteps the bug; verified via `quadlet -dryrun` on 5.7.0 + 5.8.2.
+HealthCmd=python -c 'import urllib.request; urllib.request.urlopen("http://localhost:18645/health", timeout=5)'
 HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -7,8 +7,13 @@ StartLimitBurst=5
 Image=ghcr.io/roxabi/llmcli:staging
 Label=io.containers.autoupdate=registry
 ContainerName=llmcli-xai-forwarder
-# No PublishPort — internal to roxabi.network only (reachable as
-# http://llmcli-xai-forwarder:18645 from other containers on roxabi.network)
+# Reachable two ways:
+#  - container-to-container via roxabi.network DNS (http://llmcli-xai-forwarder:18645)
+#    — used by the LiteLLM proxy container.
+#  - host loopback via PublishPort below — used by host processes such as the
+#    xai-research skill (xai_research.py -> http://127.0.0.1:18645). Bound to
+#    127.0.0.1 only: no LAN exposure of the OAuth-injecting relay.
+PublishPort=127.0.0.1:18645:18645
 Network=roxabi.network
 Volume=%h/.roxabi/llmcli/credentials:/home/llmcli/.roxabi/llmcli/credentials:rw,Z
 Environment=LLMCLI_FORWARDER_PROVIDER=xai


### PR DESCRIPTION
Two related fixes to the xAI OAuth forwarder Quadlet unit. **Both already live-deployed on M₁ + M₂** (config-only, no image rebuild); this PR is the durable record so the next `install.sh` keeps them.

## 1. Publish on 127.0.0.1:18645 for host consumers
`xai-research` skill (`xai_research.py`) runs as a **host process** and calls `http://127.0.0.1:18645`, but the unit had **no `PublishPort`** — reachable only container-to-container via `roxabi.network` DNS (the LiteLLM proxy path). Host processes → connection refused; the skill was blocked.

Add `PublishPort=127.0.0.1:18645:18645` — **loopback only**, no LAN exposure of the OAuth-injecting relay. Container-net DNS path unchanged; both consumers now work.

## 2. Quote HealthCmd so podman 5.7.0 doesn't truncate it
podman **5.7.0** (quadlet, M₁ Ubuntu) drops the trailing escaped `"` of a `HealthCmd` ending in one → generates `python -c "...timeout=5)` (unterminated) → `sh: Unterminated quoted string` → forwarder permanently **`unhealthy`** despite serving fine. podman **5.8.2** (M₂) unaffected, which masked it. Found while restarting M₁ for fix #1.

Swap to single-quote outer / double-quote inner so the value ends in the outer `'`. Verified identical correct generation on **5.7.0 and 5.8.2** via `quadlet -dryrun`.

## Verification (live, both hosts)
| Check | M₂ (5.8.2) | M₁ (5.7.0) |
|---|---|---|
| `podman port` → `127.0.0.1:18645` | ✅ | ✅ |
| host `curl /health` → `logged_in:true` | ✅ | ✅ |
| container health status | `healthy` | `healthy` |
| `xai_research.py` end-to-end → Grok | ✅ | — |

No `llmcli xai login` needed (already authenticated; one forwarder per host, no #114 clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)