### PR TITLE
fix(quadlet): add ReadOnly=true + tmpfs to non-GPU llmcli units (D-6)

### DIFF
--- a/deploy/quadlet/llmcli-fw-forwarder.container
+++ b/deploy/quadlet/llmcli-fw-forwarder.container
@@ -24,6 +24,14 @@ HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true
 DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit). Thin relay; runtime
+# writes (lib caches, /tmp) land on the tmpfs set below — 0 EROFS at boot. Uniform
+# with the proxy. mode=1777: a root-owned 0755 tmpfs EACCESes for non-root uid 1502.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
 
 [Service]
 Restart=on-failure

--- a/deploy/quadlet/llmcli-xai-forwarder.container
+++ b/deploy/quadlet/llmcli-xai-forwarder.container
@@ -29,6 +29,15 @@ HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true
 DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit). The credentials
+# Volume above is explicit :rw,Z → stays writable under ReadOnly, so xAI OAuth
+# token refresh is unaffected. Other runtime writes land on the tmpfs set below.
+# mode=1777: a root-owned 0755 tmpfs EACCESes for the non-root uid 1502.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
 
 [Service]
 Restart=on-failure

--- a/deploy/quadlet/llmcli.container
+++ b/deploy/quadlet/llmcli.container
@@ -24,6 +24,17 @@ HealthInterval=30s
 HealthStartPeriod=15s
 NoNewPrivileges=true
 DropCapability=all
+# ReadOnly rootfs — host-validated 2026-06-16 (D-6 ops-audit, M₂). LiteLLM writes
+# the merged proxy config to ~/.local/state/llmcli/proxy.config.yaml; all runtime
+# writes (incl. a completion under load) land on the tmpfs set below — 0 EROFS.
+# mode=1777: a root-owned 0755 tmpfs EACCESes for the non-root uid 1502. The :ro
+# config mount above is unaffected. GPU units (llmcli-nats-worker) are EXCLUDED —
+# nvidia CDI hooks (create-symlinks/update-ldcache) mutate the rootfs → EROFS.
+ReadOnly=true
+Tmpfs=/tmp:mode=1777
+Tmpfs=/home/llmcli/.local:mode=1777
+Tmpfs=/home/llmcli/.cache:mode=1777
+Tmpfs=/home/llmcli/.config:mode=1777
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
## D-6 — `ReadOnly=true` on non-GPU llmcli units

Host-validated 2026-06-16 (M₂ RTX 5070 Ti, throwaway `--rm` replicas, live units undisturbed).

### Change
`ReadOnly=true` + 4 tmpfs (`/tmp`, `~/.local`, `~/.cache`, `~/.config` @ `mode=1777`) on **proxy + fw-forwarder + xai-forwarder**.

| Unit | Validation |
|---|---|
| `llmcli` (proxy) | **load-tested** — real deepseek-v4-pro completion → HTTP **200**, **0 fatal EROFS**. Merged LiteLLM config writes to `~/.local/state/llmcli/proxy.config.yaml` (tmpfs ✓). 1 benign warning (admin-UI restructure in read-only site-packages — proxy is headless → moot). |
| `llmcli-fw-forwarder` | boot-validated, 0 EROFS (same image). |
| `llmcli-xai-forwarder` | boot-validated; credentials `Volume` is explicit `:rw,Z` → stays writable → **xAI OAuth token refresh unaffected**. |

### Scope — GPU unit excluded
`llmcli-nats-worker` is **NOT** included. `ReadOnly=true` is incompatible with nvidia CDI device injection: the `create-symlinks` + `update-ldcache` hooks mutate the rootfs (`/usr/lib/x86_64-linux-gnu`, `/etc/ld.so.cache`) → EROFS → container exit 126. Host-level + image-agnostic; A/B-isolated on M₁ (identical config without ReadOnly = warmup OK exit 0). GPU hardening stays DropCap+NoNewPriv+keep-id+Tmpfs.

### Notes
- `mode=1777` required: a root-owned 0755 tmpfs EACCESes for the non-root uid 1502.
- The proxy is the **HA relay** (M₁ 24/7 cloud passthrough) — load-validated incl. a real request, not just boot.
- Verified locally: `quadlet --dryrun` (network-stub) parses all 3 + inline-comment gate clean.

Closes part of D-6 (`ops-consistency-audit-2026-06-15`).