### PR TITLE
fix(deploy): install all 4 declared containers — derive install from quadlet dir (#1900)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ install-quadlet:
 	@mkdir -p $(QUADLET_DIR)
 	@mkdir -p $(QUADLET_ENV_DIR)
 	@mkdir -p $(HOME)/.cache/huggingface
-	@install -m 644 deploy/quadlet/llmcli.container $(QUADLET_DIR)/llmcli.container
-	@install -m 644 deploy/quadlet/llmcli-nats-worker.container $(QUADLET_DIR)/llmcli-nats-worker.container
+	@for f in deploy/quadlet/*.container; do \
+		install -m 644 "$$f" "$(QUADLET_DIR)/"; \
+	done
 	@if [ ! -f "$(QUADLET_ENV_PROXY)" ]; then \
 	  install -m 600 /dev/null "$(QUADLET_ENV_PROXY)" ; \
 	  printf '# proxy.env — chmod 600. Populate with provider keys before starting.\nLLMCLI_API_KEY=\nFIREWORKS_API_KEY=\nANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nNVIDIA_API_KEY=\n' >> "$(QUADLET_ENV_PROXY)" ; \

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -122,11 +122,12 @@ fi
 # --- Quadlet units ---
 echo ""
 echo "--- Quadlet units ---"
-for unit in llmcli.container llmcli-nats-worker.container llmcli-xai-forwarder.container llmcli-fw-forwarder.container; do
-  src="${SCRIPT_DIR}/quadlet/${unit}"
+for src in "${SCRIPT_DIR}"/quadlet/*.container; do
+  unit="$(basename "$src")"
   dst="${QUADLET_DIR}/${unit}"
   if [ ! -f "$src" ]; then
-    echo "  [skip]  $unit (source not found: $src)"
+    # glob matched nothing → literal pattern; nothing to install
+    echo "  [skip]  no .container units found in ${SCRIPT_DIR}/quadlet/"
     continue
   fi
   if [ -f "$dst" ] && ! "$FORCE"; then


### PR DESCRIPTION
Refs #1900 (llmCLI slice — wave 3 of the cross-repo manifest-driven install program; factory shipped in roxabi-factory#1902).

## Problem
`make install-quadlet` hand-enumerated only `llmcli.container` + `llmcli-nats-worker.container` — **2 of the 4** containers declared in `deploy/quadlet.toml`. The `xai-forwarder` + `fw-forwarder` were installed out-of-band on M₁, so a fresh `make install-quadlet` could **not** reproduce the live host.

## Fix
Both install paths now glob `deploy/quadlet/*.container` (dir-driven, no hand list — llmCLI has no `.tmpl` templates):
- `Makefile install-quadlet`: 2 hardcoded `install` lines → glob loop (now installs all 4).
- `deploy/install.sh`: the hand-enumerated `for unit in …` list → `for src in quadlet/*.container` (was already complete at 4, now drift-proof).

## Verify
- `make -n install-quadlet` → glob loop installs all 4 (`llmcli`, `llmcli-nats-worker`, `llmcli-xai-forwarder`, `llmcli-fw-forwarder`).
- `bash -n deploy/install.sh` clean; glob yields all 4.
- Unit **files unchanged** — only which get installed; the 4 are the same units already running on M₁ → install-mechanism change, no runtime/unit change.

## Notes / follow-ups
- M₁ verification (operator): `./deploy/install.sh --dry-run` should now list all 4 units.
- The `[component.proxy] required_secrets = ["llmcli-litellm-key"]` vs env_file question is deferred to the #1901 gate-port wave (where it becomes load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)