### PR TITLE
feat(deploy): bidirectional manifest↔install gate (#1901)

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -76,3 +76,8 @@ quality_gates:
     enabled: true
     stage: pre-push
     script: tools/check_healthcmd_quoting.sh
+  quadlet_manifest_install:
+    enabled: true
+    stage: pre-push
+    script: tools/check_quadlet_manifest_install.sh
+    description: bidirectional manifest↔install — every [component.*] container in deploy/quadlet.toml has a source file installed by the deploy/quadlet/*.container glob (Makefile + install.sh), and every on-disk *.container is declared (orphan-install guard, #1901). Also enforced in CI via quadlet-lint.yml.

--- a/.github/workflows/quadlet-lint.yml
+++ b/.github/workflows/quadlet-lint.yml
@@ -8,6 +8,10 @@ on:
     branches: [main, staging]
     paths:
       - "deploy/quadlet/**"
+      - "deploy/quadlet.toml"
+      - "deploy/install.sh"
+      - "Makefile"
+      - "tools/check_quadlet_manifest_install.sh"
   workflow_dispatch: {}
 
 concurrency:
@@ -109,3 +113,11 @@ jobs:
             exit 1
           fi
           echo "No inline comments on value lines — OK"
+
+      - name: Manifest↔install gate (#1901)
+        # Bidirectional: every declared [component.*] container has a source file
+        # installed by the deploy/quadlet/*.container glob, and every on-disk
+        # *.container is declared in quadlet.toml (orphan-install guard). Mirrors
+        # the pre-push hook so the gate also blocks in CI. Needs python3+tomllib
+        # (ubuntu-latest ships 3.12) and git (checkout above) — no Podman.
+        run: bash tools/check_quadlet_manifest_install.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,9 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-push]
+      - id: quadlet-manifest-install
+        name: quadlet manifest↔install gate
+        entry: tools/check_quadlet_manifest_install.sh
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tools/check_quadlet_manifest_install.sh — bidirectional manifest↔install gate (llmCLI).
+#
+# deploy/quadlet.toml is the authoritative component manifest. This gate asserts
+# BOTH directions so a declared component is always installed AND no installed
+# unit file is undeclared (the orphan-install class — e.g. the xai/fw forwarders
+# that ran on M₁ while `make install-quadlet` shipped only 2 of 4 declared units,
+# fixed in #1900).
+#
+#   Forward:  every [component.*] container in quadlet.toml has its source file in
+#             deploy/quadlet/ AND the install paths (Makefile install-quadlet +
+#             deploy/install.sh) install via a deploy/quadlet/*.container glob, so
+#             any declared unit's file is necessarily installed.
+#   Reverse:  every deploy/quadlet/*.container file is declared in quadlet.toml.
+#
+# llmCLI has no [volume.*]/[network.*]/[pod.*], no converge.sh, and no
+# quadlet-install-verify UNITS array, so this gate is container-only — cf. the
+# fuller roxabi-factory variant.
+#
+# EXIT-CODE CONTRACT (roxabi container-deployment-standard): 0 = clean,
+# 1 = violations found (merge-blocking), 2 = script setup error.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" \
+    || { echo "ERROR: not a git repository" >&2; exit 2; }
+
+# Paths are env-overridable for testing; defaults are the repo-root locations.
+QUADLET_TOML="${QUADLET_TOML:-deploy/quadlet.toml}"
+QUADLET_DIR="${QUADLET_DIR:-deploy/quadlet}"
+MAKEFILE="${MAKEFILE:-Makefile}"
+INSTALL_SH="${INSTALL_SH:-deploy/install.sh}"
+
+for req in "$QUADLET_TOML" "$MAKEFILE" "$INSTALL_SH"; do
+    if [[ ! -f "$req" ]]; then
+        echo "ERROR: required file not found: $req" >&2
+        exit 2
+    fi
+done
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import tomllib' >/dev/null 2>&1; then
+    echo "ERROR: python3 with tomllib (Python 3.11+) required" >&2
+    exit 2
+fi
+
+fail=0
+
+# Declared container basenames, one per line.
+mapfile -t DECLARED < <(python3 - "$QUADLET_TOML" <<'PYEOF'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+for comp in data.get("component", {}).values():
+    container = comp.get("container")
+    if container:
+        print(container)
+PYEOF
+)
+
+if [[ ${#DECLARED[@]} -eq 0 ]]; then
+    echo "FAIL: no [component.*] containers parsed from $QUADLET_TOML — gate validated nothing" >&2
+    exit 1
+fi
+
+# Install paths must use a dir-glob so any declared unit's file is installed.
+if ! grep -qF 'deploy/quadlet/*.container' "$MAKEFILE"; then
+    echo "FAIL: $MAKEFILE install-quadlet does not glob deploy/quadlet/*.container — install is not manifest-driven" >&2
+    fail=1
+fi
+if ! grep -qF 'quadlet/*.container' "$INSTALL_SH"; then
+    echo "FAIL: $INSTALL_SH does not glob quadlet/*.container — install is not manifest-driven" >&2
+    fail=1
+fi
+
+# Forward: every declared container has its source file on disk (the glob installs it).
+for container in "${DECLARED[@]}"; do
+    if [[ ! -f "$QUADLET_DIR/$container" ]]; then
+        echo "FAIL: $container declared in $QUADLET_TOML but $QUADLET_DIR/$container does not exist (glob cannot install it)" >&2
+        echo "::error file=$QUADLET_TOML::declared container $container has no source file in $QUADLET_DIR/"
+        fail=1
+    fi
+done
+
+# Reverse: every on-disk *.container file is declared in the manifest.
+declared_set=" ${DECLARED[*]} "
+for fpath in "$QUADLET_DIR"/*.container; do
+    [[ -e "$fpath" ]] || continue   # no-match glob guard
+    fname="$(basename "$fpath")"
+    if [[ "$declared_set" != *" $fname "* ]]; then
+        echo "FAIL: $QUADLET_DIR/$fname is installed by the quadlet glob but NOT declared in $QUADLET_TOML (orphan install)" >&2
+        echo "::error file=$QUADLET_DIR/$fname::orphan unit — declare it in $QUADLET_TOML [component.*] or remove the file"
+        fail=1
+    fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "" >&2
+    echo "Every [component.*] container in $QUADLET_TOML must have a source file installed by the" >&2
+    echo "deploy/quadlet/*.container glob in $MAKEFILE + $INSTALL_SH, and every on-disk *.container" >&2
+    echo "must be declared in the manifest (#1901)." >&2
+    exit 1
+fi
+
+echo "quadlet manifest install check passed (bidirectional, container-only)"
+exit 0


### PR DESCRIPTION
Refs #1901 (llmCLI gate — wave 4; protects the #1900 manifest-driven install shipped in #127).

Ports roxabi-factory's orphan-install guard to llmCLI.

## What
- **`tools/check_quadlet_manifest_install.sh`** (new): bidirectional —
  - *Forward*: every `[component.*]` container in `quadlet.toml` has a source file installed by the `deploy/quadlet/*.container` glob (Makefile + install.sh, from #1900); also asserts the glob is present in both install paths.
  - *Reverse*: every on-disk `deploy/quadlet/*.container` is declared in `quadlet.toml` (the orphan-install class — the 2/4 forwarder gap #1900 fixed).
  - Container-only (llmCLI has no volumes/networks/pods, no converge fan-out / verify array).
- Wired three ways: `.pre-commit-config.yaml` pre-push hook (matches `axial-drift`/`license` convention), `.claude/stack.yml`, and **CI via `quadlet-lint.yml`** (+ extended path triggers to `quadlet.toml`, `Makefile`, `deploy/install.sh`, the gate script).

## Verify (positive + negative, lead-run)
- positive → **0** (`check passed (bidirectional)`); `bash -n` clean; 3 YAML files valid; pre-push hook ran green on push.
- reverse neg: orphan `*.container` → **1**, recovers to **0** on removal.
- forward neg: declared container with no source file → **1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)