### PR TITLE
feat(proxy): add /xai pass_through for live Grok catalogue

### DIFF
--- a/deploy/proxy-base.yaml.example
+++ b/deploy/proxy-base.yaml.example
@@ -61,6 +61,15 @@ general_settings:
         # NOTE: this block MAY be removed when MODE ON (forwarder injects the key; inbound Authorization is stripped regardless).
         Authorization: "Bearer os.environ/FIREWORKS_API_KEY"
 
+    # xAI Grok — live catalogue via OAuth forwarder (no LiteLLM reload).
+    # Consumers point at http://<host>:18091/xai/v1 (OpenAI-compatible).
+    # The forwarder injects/refreshes SuperGrok OAuth server-side; no client key needed.
+    # Container DNS `llmcli-xai-forwarder` resolves on roxabi.network (M₁).
+    - path: "/xai"
+      target: "http://llmcli-xai-forwarder:18645"
+      include_subpath: true
+      forward_headers: false
+
 litellm_settings:
   # Drop unsupported provider-specific kwargs instead of erroring.
   drop_params: true

--- a/docs/QUADLET-DEPLOYMENT.md
+++ b/docs/QUADLET-DEPLOYMENT.md
@@ -339,6 +339,27 @@ Expected:
 {"status": "ok", "logged_in": true, "expires_at": 1748454131}
 ```
 
+**4. Live Grok via proxy pass-through** (verifies `/xai` route in `proxy-base.yaml`):
+
+```bash
+curl -sS -H "Authorization: Bearer $LLMCLI_API_KEY" \
+  http://127.0.0.1:18091/xai/v1/models | jq '.data[].id'
+```
+
+Expected: the same model ids as `curl http://llmcli-xai-forwarder:18645/v1/models` from
+inside the `llmcli` container (e.g. `grok-4.3`, `grok-4.20-*`). The `/xai` path is a
+raw pass-through to `llmcli-xai-forwarder:18645` — the forwarder owns OAuth injection;
+the proxy only validates `LLMCLI_API_KEY` at the edge.
+
+Smoke a completion:
+
+```bash
+curl -sS -H "Authorization: Bearer $LLMCLI_API_KEY" \
+  -H 'content-type: application/json' \
+  -d '{"model":"grok-4.3","max_tokens":16,"messages":[{"role":"user","content":"ok"}]}' \
+  http://127.0.0.1:18091/xai/v1/chat/completions
+```
+
 ---
 
 ### Refresh expiry behavior

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -700,6 +700,15 @@ pattern to the Quadlet-managed `llmcli proxy`:
    Use `127.0.0.1` explicitly — rootless Podman on M₁ does not resolve IPv6 `::1` for
    `localhost`.
 
+7b. **Smoke (xAI Grok pass-through)** — requires `llmcli-xai-forwarder` running and
+   `llmcli xai login` complete (M₁ only):
+   ```bash
+   curl -sS -H "Authorization: Bearer $LLMCLI_API_KEY" \
+     http://127.0.0.1:18091/xai/v1/models | jq '.data[].id'
+   ```
+   The `/xai` path forwards to `llmcli-xai-forwarder:18645` with live model discovery —
+   no proxy restart needed when xAI ships new Grok versions.
+
 8. **Migrate Claude Code aliases** — point `~/.bash_aliases` `_cc_fireworks()` /
    `_cc_nvidia()` / `cccc` / `cnd` to `127.0.0.1:18091` (and `/fw-anthropic` for the
    Fireworks pass-through if you use it). See issue #52 for the full alias migration.

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -830,6 +830,16 @@ class TestMergeProxyConfig:
         assert result["router_settings"] == {"timeout": 600}
         assert result["environment_variables"] == {"FOO": "bar"}
 
+    def test_proxy_base_example_includes_xai_pass_through(self) -> None:
+        """deploy/proxy-base.yaml.example exposes /xai → xAI OAuth forwarder."""
+        example = Path(__file__).parent.parent / "deploy" / "proxy-base.yaml.example"
+        data = yaml.safe_load(example.read_text())
+        endpoints = data["general_settings"]["pass_through_endpoints"]
+        xai = next(ep for ep in endpoints if ep["path"] == "/xai")
+        assert xai["target"] == "http://llmcli-xai-forwarder:18645"
+        assert xai["include_subpath"] is True
+        assert xai["forward_headers"] is False
+
 
 # ---------------------------------------------------------------------------
 # TestProxyEnvPortMalformed


### PR DESCRIPTION
## Summary

- Add `/xai` pass-through endpoint to `deploy/proxy-base.yaml.example`, routing to `llmcli-xai-forwarder:18645`
- Document smoke checks in `docs/QUADLET-DEPLOYMENT.md` and `docs/guides/deployment.md`
- Add unit test validating the example config shape

Exposes live Grok model discovery through `:18091/xai/v1` without LiteLLM reload — same pattern as `/fw-anthropic`.

## Test plan

- [x] `uv run pytest tests/test_proxy_cmd.py::TestMergeProxyConfig::test_proxy_base_example_includes_xai_pass_through`
- [x] Full suite: 464 passed
- [ ] M₁ smoke: `curl :18091/xai/v1/models` returns same ids as forwarder
- [ ] M₁ smoke: `curl :18091/xai/v1/chat/completions` with `grok-4.3` → HTTP 200

Closes #129