### PR TITLE
feat(proxy): unified dynamic /v1/models catalogue

### DIFF
--- a/artifacts/frames/130-unified-dynamic-v1-models-frame.mdx
+++ b/artifacts/frames/130-unified-dynamic-v1-models-frame.mdx
@@ -1,0 +1,81 @@
+---
+title: "feat(proxy): unified dynamic /v1/models — merge TOML catalog + xAI forwarder discovery"
+issue: 130
+status: approved
+tier: F-lite
+date: 2026-06-17
+---
+
+## Problem
+
+`GET :18091/v1/models` today lists only **static** entries from `build_model_list()` — TOML `models/*.toml` filtered by `machines` (ADR-005) plus a hardcoded `_XAI_OAUTH_MODELS` pair (`grok-4`, `grok-4-fast`) when credentials exist. The xAI forwarder at `llmcli-xai-forwarder:18645` exposes a **live** catalogue (`grok-4.3`, `grok-4.20-*`, …) that never reaches the canonical proxy surface.
+
+#129 shipped an interim fix: `pass_through_endpoints` `/xai` exposes Grok on a **separate path** (`:18091/xai/v1/models`). Consumers that discover models via the standard OpenAI endpoint (`:18091/v1/models`) — omp factory `discovery: openai-models-list`, Claude Code, lyra — still see stale or incomplete catalogues. Operators must know two base URLs and manually reconcile model lists.
+
+The pain is operational and consumer-facing: new Grok models appear on the forwarder but not in the unified catalogue; unhealthy upstream models (e.g. `kimi-k2.6` → 401) remain listed until a full Podman restart regenerates config.
+
+## Who
+
+- **Primary:** Mickael and Roxabi agents (Claude Code, lyra, factory omp) that call `:18091/v1/models` for model discovery before routing completions.
+- **Secondary:** Operators maintaining per-host TOML catalogs — they expect ADR-005 `machines` parity and health-aware listings without restart churn.
+
+## Constraints
+
+- ADR-005 `machines` host filter must continue to apply to TOML-derived entries.
+- No Postgres / LiteLLM `/model/new` hot-add — rejected ops model (config-file generation only).
+- Refresh without `systemctl restart llmcli` — in-memory cache + periodic poll (~60s) and invalidation on `xai login` / `xai logout`.
+- Exclude `grok-imagine-*` from merged Grok entries (image models, not chat).
+- Health filter: omit (or mark unhealthy) models whose upstream probe fails.
+- Spike recommends **Option A** first: extend `build_model_list()` + background refresh — no upstream LiteLLM blocker (#20064). Option B (wildcard + `check_provider_endpoint`) is a future migration path.
+- F-lite ceiling: single domain (proxy config generation), ~3–5 files touched.
+
+## Out of Scope
+
+- Postgres-backed LiteLLM model registry or `/model/new` hot-add.
+- Replacing LiteLLM with OpenRouter/Bifrost.
+- Removing the `/xai` pass-through path (#129) — may deprecate later once unified catalogue is proven; not required for this issue.
+- Image-generation Grok models (`grok-imagine-*`).
+
+## Approach (high-level)
+
+```
+TOML catalog (machines filter)
+        │
+        ▼
+build_model_list() ──► merge ◄── GET forwarder:18645/v1/models
+        │                    │         (exclude grok-imagine-*)
+        │                    │
+        ▼                    ▼
+   health probes ──► unified model_list
+        │
+        ▼
+   in-memory cache (60s TTL + login/logout invalidation)
+        │
+        ▼
+   LiteLLM child config regen (no Podman restart)
+```
+
+Option A: fetch forwarder `/v1/models` inside config builder, inject entries alongside TOML models, background task refreshes cache and triggers config regen.
+
+## Premise Validity
+
+**Success in 6 months:** A single `curl :18091/v1/models` returns TOML cloud entries (e.g. `deepseek-v4-pro`) **and** live Grok models (e.g. `grok-4.3`) when the forwarder is healthy. New forwarder models appear within the refresh interval without `systemctl restart llmcli`. Factory omp `discovery: openai-models-list` on `:18091` works without a separate `/xai` base URL. Unhealthy upstreams (401 on `kimi-k2.6`) are absent from the catalogue.
+
+**Failure in 6 months (falsifiable):** Any one of:
+1. ≥2 consumer integrations still require `:18091/xai/v1/models` for Grok discovery 30 days post-merge.
+2. Operators filed ≥3 incidents where new Grok models required a full proxy restart to appear in `:18091/v1/models`.
+3. `machines` filter regression: a TOML model visible on host A incorrectly appears (or is absent) on host B per ADR-005 parity checks.
+
+**Simplest alternative:** Document that consumers must use `:18091/xai/v1/models` for Grok and `:18091/v1/models` for everything else — no code change beyond #129.
+
+**Why not simplest:** Factory omp, Claude Code, and lyra all use the standard OpenAI `GET /v1/models` discovery contract on a single base URL. A split-path model forces every consumer to special-case Grok routing and breaks the "one proxy, one catalogue" invariant the Roxabi stack is converging on.
+
+## Complexity
+
+**Tier: F-lite** — Clear scope, single domain (proxy config generation), known integration points (`build_model_list`, forwarder health, existing test module).
+
+Signals observed:
+- Issue label `size:F-lite`; ~3–5 files (`litellm_config.py`, `cli/proxy.py` or refresh hook, `tests/test_litellm_config.py`, possibly `cli/xai.py` for cache invalidation).
+- Single domain: catalog merge + cache refresh in existing proxy startup path.
+- Implementation spike already scoped in issue body (Options A/B/C); recommend A with no upstream blocker.
+- Blocker #129 closed — interim `/xai` path is live; unified merge can proceed.

--- a/artifacts/plans/130-unified-dynamic-v1-models-plan.mdx
+++ b/artifacts/plans/130-unified-dynamic-v1-models-plan.mdx
@@ -1,0 +1,261 @@
+---
+title: "Plan: feat(proxy): unified dynamic /v1/models"
+issue: 130
+spec: artifacts/specs/130-unified-dynamic-v1-models-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-06-17
+---
+
+## Summary
+
+Replace hardcoded `_XAI_OAUTH_MODELS` with live forwarder discovery in `build_model_list()`, add remote upstream health probes, thread-safe `ModelDiscoveryCache`, and a background refresh loop in `cli/proxy.py` that regen-writes `proxy.config.yaml` and reloads the litellm child — plus cache invalidation hooks on `xai login/logout`.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph litellm_config["support/litellm_config.py"]
+        CACHE["ModelDiscoveryCache<br/>ttl · invalidate · get_or_refresh"]
+        FETCH["fetch_xai_models()<br/>GET forwarder /v1/models"]
+        PROBE["probe_remote_model()<br/>2xx gate"]
+        BUILD["build_model_list()<br/>TOML + probe + xAI merge"]
+    end
+    subgraph proxy_cli["cli/proxy.py"]
+        LOOP["background refresh thread<br/>LLMCLI_MODEL_REFRESH_SECS"]
+        RELOAD["_reload_litellm_child()<br/>SIGHUP or respawn"]
+        WRITE["write proxy.config.yaml"]
+    end
+    subgraph xai_cli["cli/xai.py"]
+        INV["invalidate_model_cache()"]
+    end
+    CATALOG["TOML catalog"] --> BUILD
+    FWD["llmcli-xai-forwarder:18645"] --> FETCH
+    BUILD --> CACHE
+    FETCH --> BUILD
+    PROBE --> BUILD
+    LOOP --> BUILD
+    BUILD --> WRITE
+    WRITE --> RELOAD
+    LOGIN["xai login/logout"] --> INV
+    INV --> CACHE
+    INV -.->|trigger once| LOOP
+```
+
+```mermaid
+flowchart LR
+    subgraph src["src/llmcli/"]
+        LC["litellm_config.py<br/>CACHE · FETCH · PROBE · BUILD"]
+        PX["proxy.py<br/>LOOP · RELOAD · WRITE"]
+        XA["xai.py<br/>INV hook"]
+    end
+    subgraph tests["tests/"]
+        T1["test_litellm_config.py<br/>xai fetch · probe · cache"]
+        T2["test_proxy_cmd.py<br/>refresh loop"]
+    end
+    LC --> PX
+    XA --> LC
+    T1 -.verifies.-> LC
+    T2 -.verifies.-> PX
+```
+
+## Agents
+
+| Agent instance | Tasks | Files | Subjects |
+|---|---|---|---|
+| backend-dev-A | T2, T3, T4 | `litellm_config.py` | discovery, probe |
+| backend-dev-B | T7, T8 | `proxy.py` | refresh, reload |
+| backend-dev-C | T10, T11 | `xai.py`, `litellm_config.py` | cache-inval |
+| tester-A | T1, T5 | `test_litellm_config.py` | discovery-tests |
+| tester-B | T6, T9 | `test_proxy_cmd.py` | refresh-tests |
+| tester-C | T12 | `test_litellm_config.py` | integration |
+| doc-writer-A | T13 | `docs/guides/deployment.md` | docs |
+
+## Wave Structure
+
+4 waves, max 5 parallel agents. Critical path T2→T4→T7→T9.
+
+| Wave | Trigger | Agents | Tasks |
+|------|---------|--------|-------|
+| 1 | start | 4 ∥ | t-A: T1 · bd-A: T2 · t-B: T6 · dw-A: T13 |
+| 2 | T2 done | 2 ∥ | bd-A: T3→T4 · bd-B: T7 |
+| 3 | T4,T7 done | 3 ∥ | bd-B: T8 · bd-C: T10→T11 · t-C: T12 |
+| 4 | T4,T6,T8 done | 2 ∥ | t-A: T5 · t-B: T9 |
+
+### Budget — per task
+
+| Task | Class | Est. ops |
+|------|-------|----------|
+| T1, T6, T12 | judgmental | 5 |
+| T2, T3, T4, T7, T8, T10 | judgmental | 5–6 |
+| T5, T9, T11, T13 | bounded | 2–3 |
+
+**Total estimated ops: ~52 across 7 instances (≤12 per instance).**
+
+### Budget — per agent instance
+
+| Instance | Tasks | Σ ops | Subjects | Split? |
+|----------|-------|-------|----------|--------|
+| backend-dev-A | T2, T3, T4 | 17 | discovery, probe | — |
+| backend-dev-B | T7, T8 | 11 | refresh, reload | — |
+| backend-dev-C | T10, T11 | 8 | cache-inval | — |
+| tester-A | T1, T5 | 7 | discovery-tests | — |
+| tester-B | T6, T9 | 7 | refresh-tests | — |
+| tester-C | T12 | 5 | integration | — |
+| doc-writer-A | T13 | 3 | docs | — |
+
+No per-task (>50) or per-instance cap breached.
+
+## Consistency Report
+
+Spec success criteria → tasks (10/10 covered):
+
+| Spec criterion | Task |
+|---|---|
+| SC-1 merged TOML + live Grok | T4, T5 |
+| SC-2 grok-imagine-* excluded | T1, T2, T4 |
+| SC-3 unhealthy remote omitted | T1, T3, T4 |
+| SC-4 machines filter parity | T1, T4, T5 |
+| SC-5 no hardcoded list when ¬creds | T4, T5 |
+| SC-6 background refresh ≤60s | T6, T7, T8, T9 |
+| SC-7 login/logout invalidation | T10, T12 |
+| SC-8 forwarder down → no crash | T2, T4, T5 |
+| SC-9 register-proxy parity | T11 |
+| SC-10 tests in test_litellm_config.py | T1, T5, T12 |
+
+Untraced tasks: none.
+
+## Micro-Tasks
+
+### Slice 1 — discovery primitives (N1–N4)
+
+**T1 [RED] · tester-A · discovery-tests · diff 3 · SC: SC-2,3,4,10**
+Add failing tests: `fetch_xai_models` returns IDs and filters `grok-imagine-*`; `probe_remote_model` omits on 401; `build_model_list` respects `machines`; dedup TOML over forwarder ID; no `_XAI_OAUTH_MODELS` when creds absent.
+- File: `tests/test_litellm_config.py`
+- Verify: `uv run pytest tests/test_litellm_config.py -k "xai_models or probe_remote or machines" -q`
+- Expected: tests collected (RED until T2–T4)
+
+**T2 [GREEN] · backend-dev-A · discovery · diff 4 · SC: SC-2,8**
+Implement `fetch_xai_models(forwarder_base: str) -> list[str]`: `httpx.get(..., timeout=3)`, parse `data[].id`, exclude `grok-imagine-*` prefix; log warning + return `[]` on any error.
+- File: `src/llmcli/support/litellm_config.py`
+- Verify: `uv run python -c "from llmcli.support.litellm_config import fetch_xai_models; print('ok')"`
+- Expected: import ok
+
+**T3 [GREEN] · backend-dev-A · probe · diff 4 · dep T2 · SC: SC-3**
+Implement `probe_remote_model(spec, provider) -> bool`: skip `_OAUTH_MANAGED`; minimal probe (HEAD or GET) to provider `api_base`; healthy iff 2xx within 3s.
+- File: `src/llmcli/support/litellm_config.py`
+- Verify: `uv run ruff check src/llmcli/support/litellm_config.py`
+- Expected: lint clean
+
+**T4 [GREEN] · backend-dev-A · discovery · diff 5 · dep T2,T3 · SC: SC-1,4,5**
+Add `ModelDiscoveryCache` (thread-safe, `ttl_secs`, `invalidate()`, `get_or_refresh(fn)`). Extend `build_model_list(..., *, cache=None)`: TOML loop with N3 probe; when `xai.json` exists merge N2 models as `openai/responses/{id}` entries; remove `_XAI_OAUTH_MODELS` constant + hardcoded injection; dedup by `model_name` (TOML wins).
+- File: `src/llmcli/support/litellm_config.py`
+- Verify: `uv run pytest tests/test_litellm_config.py -k "xai_models or probe_remote or machines" -q`
+- Expected: green
+
+**T5 [RED-GATE] · tester-A · discovery-tests · diff 2 · dep T1,T4 · SC: SC-1–5,10**
+Full discovery slice gate.
+- Verify: `uv run pytest tests/test_litellm_config.py -q && uv run ruff check src/llmcli/support/litellm_config.py`
+- Expected: all green
+
+### Slice 2 — background refresh (N5–N6)
+
+**T6 [RED] · tester-B · refresh-tests · diff 3 · SC: SC-6**
+Tests: mock `build_model_list` + file write; refresh thread fires within short TTL; litellm child reload called; parent survives reload failure.
+- File: `tests/test_proxy_cmd.py`
+- Verify: `uv run pytest tests/test_proxy_cmd.py -k model_refresh -q`
+- Expected: tests present (RED until T7,T8)
+
+**T7 [GREEN] · backend-dev-B · refresh · diff 5 · SC: SC-6**
+Extract `_write_proxy_config(catalog, target) -> None` from `proxy()`; add `_start_model_refresh_loop(child, catalog, port, host, interval_secs)` daemon thread reading `LLMCLI_MODEL_REFRESH_SECS` (default 60, reject negative).
+- File: `src/llmcli/cli/proxy.py`
+- Verify: `uv run python -c "import llmcli.cli.proxy"`
+- Expected: import ok
+
+**T8 [GREEN] · backend-dev-B · reload · diff 4 · dep T7 · SC: SC-6**
+Implement `_reload_litellm_child(child, config_path, port, host)`: try SIGHUP; on failure terminate + `_spawn_litellm` respawn; return new Popen handle to refresh loop.
+- File: `src/llmcli/cli/proxy.py`
+- Verify: `uv run pytest tests/test_proxy_cmd.py -k model_refresh -q`
+- Expected: green
+
+**T9 [RED-GATE] · tester-B · refresh-tests · diff 2 · dep T6,T8 · SC: SC-6**
+- Verify: `uv run pytest tests/test_proxy_cmd.py -k model_refresh -q && uv run ruff check src/llmcli/cli/proxy.py`
+- Expected: all green
+
+### Slice 3 — auth invalidation + register-proxy parity (N7–N8)
+
+**T10 [GREEN] · backend-dev-C · cache-inval · diff 3 · SC: SC-7**
+Add module-level `invalidate_model_cache()` + optional `_refresh_callback` register; wire `login_cmd` / `logout_cmd` to call after credential change.
+- Files: `src/llmcli/support/litellm_config.py`, `src/llmcli/cli/xai.py`
+- Verify: `uv run python -c "from llmcli.support.litellm_config import invalidate_model_cache; invalidate_model_cache()"`
+- Expected: no error
+
+**T11 [GREEN] · backend-dev-C · cache-inval · diff 2 · dep T4 · SC: SC-9**
+Test that `build_block()` output includes forwarder-fetched Grok IDs when mocked (register-proxy parity).
+- File: `tests/test_litellm_config.py`
+- Verify: `uv run pytest tests/test_litellm_config.py -k register_proxy_xai -q`
+- Expected: green
+
+**T12 [RED-GATE] · tester-C · integration · diff 3 · dep T10,T11 · SC: SC-7,10**
+Integration: logout clears Grok from subsequent `build_model_list` call; login repopulates (mocked forwarder).
+- Verify: `uv run pytest tests/test_litellm_config.py -k "invalidate or register_proxy_xai" -q`
+- Expected: green
+
+### Slice 4 — docs
+
+**T13 [GREEN] · doc-writer-A · docs · diff 2 · SC: operator clarity**
+Document unified `/v1/models` behaviour, `LLMCLI_MODEL_REFRESH_SECS`, health-filter semantics, login/logout immediate refresh in `docs/guides/deployment.md`.
+- Verify: `grep -E 'LLMCLI_MODEL_REFRESH_SECS|unified.*v1/models' docs/guides/deployment.md`
+- Expected: matches
+
+## Task Seeding Blueprint
+
+### Wave 1 — no deps, 4 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T1 | tester-A | — | discovery-tests |
+| T2 | backend-dev-A | — | discovery |
+| T6 | tester-B | — | refresh-tests |
+| T13 | doc-writer-A | — | docs |
+
+### Wave 2 — after T2, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T3 | backend-dev-A | T2 | probe |
+| T4 | backend-dev-A | T2,T3 | discovery |
+| T7 | backend-dev-B | T2 | refresh |
+
+### Wave 3 — after T4,T7, 3 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T8 | backend-dev-B | T7 | reload |
+| T10 | backend-dev-C | T4 | cache-inval |
+| T11 | backend-dev-C | T4 | cache-inval |
+| T12 | tester-C | T10,T11 | integration |
+
+### Wave 4 — gates, 2 agents ∥
+
+| Task | Agent instance | blockedBy | Subject |
+|------|---------------|-----------|---------|
+| T5 | tester-A | T1,T4 | discovery-tests |
+| T9 | tester-B | T6,T8 | refresh-tests |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: plan-130-t1 — discovery-tests (tester-A)
+- T2: plan-130-t2 — discovery (backend-dev-A)
+- T3: plan-130-t3 — probe (backend-dev-A) [blockedBy T2]
+- T4: plan-130-t4 — discovery (backend-dev-A) [blockedBy T2,T3]
+- T5: plan-130-t5 — discovery-tests RED-GATE (tester-A) [blockedBy T1,T4]
+- T6: plan-130-t6 — refresh-tests (tester-B)
+- T7: plan-130-t7 — refresh (backend-dev-B) [blockedBy T2]
+- T8: plan-130-t8 — reload (backend-dev-B) [blockedBy T7]
+- T9: plan-130-t9 — refresh-tests RED-GATE (tester-B) [blockedBy T6,T8]
+- T10: plan-130-t10 — cache-inval (backend-dev-C) [blockedBy T4]
+- T11: plan-130-t11 — cache-inval (backend-dev-C) [blockedBy T4]
+- T12: plan-130-t12 — integration (tester-C) [blockedBy T10,T11]
+- T13: plan-130-t13 — docs (doc-writer-A)

--- a/artifacts/specs/130-unified-dynamic-v1-models-spec.mdx
+++ b/artifacts/specs/130-unified-dynamic-v1-models-spec.mdx
@@ -1,0 +1,147 @@
+---
+title: "feat(proxy): unified dynamic /v1/models — merge TOML catalog + xAI forwarder discovery"
+issue: 130
+status: approved
+tier: F-lite
+date: 2026-06-17
+promoted_from: artifacts/frames/130-unified-dynamic-v1-models-frame.mdx
+---
+
+## Context
+
+Source: [frame 130](../frames/130-unified-dynamic-v1-models-frame.mdx) (approved 2026-06-17). Analysis skipped (F-lite). Issue [#130](https://github.com/Roxabi/llmCLI/issues/130). Blocker [#129](https://github.com/Roxabi/llmCLI/issues/129) closed — `/xai` pass-through is live; this issue unifies discovery on the canonical `:18091/v1/models`.
+
+Today `build_model_list()` (`src/llmcli/support/litellm_config.py`) emits static TOML entries (ADR-005 `machines` filter) plus hardcoded `_XAI_OAUTH_MODELS` (`grok-4`, `grok-4-fast`) when `xai.json` exists. The xAI forwarder exposes a live catalogue at `http://llmcli-xai-forwarder:18645/v1/models` that LiteLLM never sees. Consumers using standard OpenAI discovery (`GET /v1/models` on `:18091`) get stale Grok lists.
+
+**Spike decision → Option A.** Extend `build_model_list()` to fetch forwarder models, merge with TOML, health-filter remotes, cache in-memory, and background-refresh the generated `proxy.config.yaml` + litellm child reload — no upstream LiteLLM blocker ([#20064](https://github.com/BerriAI/litellm/issues/20064)). Option B (wildcard `grok/*` + `check_provider_endpoint`) is deferred.
+
+## Goal
+
+`GET :18091/v1/models` returns a merged, host-filtered, health-aware catalogue (TOML + live Grok) that refreshes within ~60s and on `xai login`/`logout` — without `systemctl restart llmcli`.
+
+## Users
+
+- **Primary:** Roxabi consumers doing OpenAI-style model discovery on `:18091` — factory omp (`discovery: openai-models-list`), Claude Code, lyra agents.
+- **Secondary:** Operators maintaining per-host TOML catalogs — expect ADR-005 `machines` parity and unhealthy upstreams omitted from listings.
+
+## Expected Behavior
+
+On proxy startup (`llmcli proxy` or Quadlet `llmcli` container), `build_model_list()`:
+
+1. Iterates TOML `models/*.toml`, applies `machines` filter (unchanged ADR-005 semantics).
+2. For each `engine="remote"` entry that passes the filter, runs a lightweight upstream probe (configurable timeout, default 3s). Entries whose probe returns 401/403/5xx or times out are **omitted** from `model_list` (not listed as unhealthy placeholders — absent is the signal).
+3. When `xai.json` exists, `GET http://llmcli-xai-forwarder:18645/v1/models` fetches live Grok IDs. Models matching `grok-imagine-*` are excluded. Each surviving ID becomes a `model_list` entry routed through the xAI forwarder (`openai/responses/{id}` pattern, same as today).
+4. When `xai.json` is absent, Grok entries are omitted (no hardcoded fallback list).
+
+A background refresh loop (default 60s, overridable via `LLMCLI_MODEL_REFRESH_SECS`) re-runs steps 1–3, writes `~/.local/state/llmcli/proxy.config.yaml`, and reloads the litellm child process (SIGHUP if supported, else terminate+respawn within `proxy.py` — **no Podman/container restart**).
+
+`llmcli xai login` and `llmcli xai logout` invalidate the cache immediately and trigger one refresh cycle (so Grok models appear/disappear without waiting for the poll interval).
+
+`llmcli register-proxy` uses the same `build_model_list()` path — merged catalogue parity for legacy `:4000` supervisor setups.
+
+The `/xai` pass-through (#129) remains; this issue does not remove it.
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class ModelDiscoveryCache {
+        +list~dict~ entries
+        +float fetched_at
+        +int ttl_secs
+        +invalidate()
+        +get_or_refresh(build_fn) list
+    }
+    class build_model_list {
+        +Catalog catalog
+        +str public_base_url
+        +str hostname
+        +ModelDiscoveryCache cache
+        +list~dict~ model_list
+    }
+    class probe_upstream {
+        +ModelSpec spec
+        +Provider provider
+        +bool healthy
+    }
+    class fetch_xai_models {
+        +str forwarder_base
+        +list~str~ model_ids
+    }
+    build_model_list --> ModelDiscoveryCache
+    build_model_list --> probe_upstream
+    build_model_list --> fetch_xai_models
+```
+
+```mermaid
+flowchart LR
+    consumer["Consumer<br/>omp / Claude Code / lyra"] -->|GET /v1/models| litellm["litellm :18091"]
+    litellm -->|serves| cfg["proxy.config.yaml<br/>model_list"]
+    proxy["llmcli proxy"] -->|build + merge| cfg
+    proxy -->|60s poll + login/logout| refresh["background refresh"]
+    refresh --> build["build_model_list()"]
+    build --> toml["TOML catalog<br/>machines filter"]
+    build --> probe["upstream health probe"]
+    build --> xai["GET forwarder /v1/models"]
+    xai --> fwd["llmcli-xai-forwarder :18645"]
+    login["llmcli xai login/logout"] -.->|invalidate| refresh
+```
+
+| Consumer | Reads/Writes | When | Status |
+|---|---|---|---|
+| `llmcli proxy` | `ModelDiscoveryCache`, `proxy.config.yaml`, litellm child PID | startup + poll + invalidation | this issue |
+| `llmcli register-proxy` | `build_block()` → same `build_model_list()` | on-demand | this issue |
+| `llmcli xai login/logout` | cache invalidation hook | credential change | this issue |
+| LiteLLM `/v1/models` | merged `model_list` | per request (static until reload) | this issue |
+| `/xai` pass-through | forwarder live catalogue | per request | existing (#129, unchanged) |
+
+## Breadboard
+
+**Places:** `support/litellm_config.py` · `cli/proxy.py` · `cli/xai.py` · `tests/test_litellm_config.py`
+
+| ID | Affordance | Handler | Data |
+|---|---|---|---|
+| N1 | `fetch_xai_models(forwarder_base)` | `litellm_config.py` | HTTP GET `/v1/models` → `data[].id`; filter `grok-imagine-*`; empty list on unreachable forwarder |
+| N2 | `probe_remote_model(spec, provider)` | `litellm_config.py` | HEAD or minimal GET to provider; return healthy iff 2xx; skip OAuth-managed (`_OAUTH_MANAGED`) |
+| N3 | `ModelDiscoveryCache` | `litellm_config.py` | `entries`, `fetched_at`, `ttl_secs`; `invalidate()`; thread-safe `get_or_refresh(fn)` |
+| N4 | extended `build_model_list(..., *, cache=None)` | `litellm_config.py` | TOML loop + N2 probe + N1 merge; **remove** `_XAI_OAUTH_MODELS` hardcoded injection |
+| N5 | background refresh loop | `proxy.py` | daemon thread: sleep `LLMCLI_MODEL_REFRESH_SECS` (default 60) → rebuild YAML → reload litellm child |
+| N6 | litellm child reload | `proxy.py` | SIGHUP to child if litellm accepts; else graceful terminate + `_spawn_litellm` respawn |
+| N7 | cache invalidation on auth change | `cli/xai.py` | `login_cmd` / `logout_cmd` call `invalidate_model_cache()` after credential write/delete |
+| N8 | `register-proxy` parity | `cli/proxy.py:register_proxy` | unchanged call site — benefits automatically via N4 |
+| S1 | unit tests: fetch filter, probe omit, cache TTL, merge shape | `tests/test_litellm_config.py` | mocked HTTP; no live forwarder required |
+
+Wiring: N4←N1,N2,N3; N5→N4→cfg write→N6; N7→N3.invalidate; N8→N4.
+
+## Slices
+
+| # | Slice | Demo |
+|---|---|---|
+| 1 | Discovery primitives (N1, N2, N3, N4): fetch forwarder models, probe remotes, cache, merge; remove `_XAI_OAUTH_MODELS` | `pytest tests/test_litellm_config.py -k xai` green; `build_model_list` with mocked forwarder returns `grok-4.3` entry |
+| 2 | Background refresh + litellm reload (N5, N6) | `llmcli proxy` running; change mock forwarder response; within 60s `curl :PORT/v1/models` reflects new ID without container restart |
+| 3 | Auth invalidation (N7) + register-proxy parity smoke (N8) | `llmcli xai logout` → immediate Grok absence on next `/v1/models`; `register-proxy` block includes live Grok IDs |
+| 4 | Docs + operator notes | `docs/guides/deployment.md` — unified catalogue behavior, `LLMCLI_MODEL_REFRESH_SECS`, health-filter semantics |
+
+## Success Criteria
+
+- [ ] SC-1: With forwarder healthy and `xai.json` present, generated `model_list` includes a live forwarder ID (e.g. `grok-4.3`) **and** TOML entries (e.g. `deepseek-v4-pro`) when both are configured for the host.
+- [ ] SC-2: Models matching `grok-imagine-*` never appear in merged `model_list`.
+- [ ] SC-3: When upstream probe for a remote TOML model returns 401 (simulated in tests; e.g. `kimi-k2.6`), that model is **absent** from `model_list`.
+- [ ] SC-4: ADR-005 `machines` filter unchanged — model with `machines = ["host-a"]` absent when `hostname="host-b"`.
+- [ ] SC-5: When `xai.json` is absent, no Grok entries in `model_list` (hardcoded `_XAI_OAUTH_MODELS` removed).
+- [ ] SC-6: Background refresh updates `proxy.config.yaml` and litellm serves new forwarder model IDs within `LLMCLI_MODEL_REFRESH_SECS` (default 60) without `systemctl restart llmcli`.
+- [ ] SC-7: `llmcli xai login` and `llmcli xai logout` trigger immediate cache invalidation + config regen (Grok entries appear/disappear without waiting for poll).
+- [ ] SC-8: Forwarder unreachable at build time → Grok entries omitted, TOML entries still present; no proxy startup failure.
+- [ ] SC-9: `llmcli register-proxy` emitted block uses the same merged `build_model_list()` output (parity with `llmcli proxy`).
+- [ ] SC-10: Tests in `tests/test_litellm_config.py` cover forwarder fetch, `grok-imagine-*` filter, health probe omission, cache TTL, and `machines` parity (no live network in CI).
+
+## Edge Cases
+
+| Scenario | Handling |
+|---|---|
+| Forwarder down at startup | Omit Grok entries; log warning; proxy starts normally |
+| Forwarder recovers mid-run | Next poll adds Grok entries |
+| All remote models unhealthy | `model_list` may be Grok-only or empty; LiteLLM still starts |
+| `LLMCLI_MODEL_REFRESH_SECS=0` or unset invalid | Treat as default 60; reject negative values at parse |
+| Duplicate ID (TOML name == forwarder ID) | TOML entry wins; forwarder ID skipped (dedup by `model_name`) |
+| litellm child reload fails | Log error; retry next poll; do not crash parent `llmcli proxy` |

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -704,10 +704,19 @@ pattern to the Quadlet-managed `llmcli proxy`:
    `llmcli xai login` complete (M₁ only):
    ```bash
    curl -sS -H "Authorization: Bearer $LLMCLI_API_KEY" \
+     http://127.0.0.1:18091/v1/models | jq '.data[].id'
+   ```
+   The canonical `:18091/v1/models` catalogue merges TOML entries (ADR-005 `machines`
+   filter) with live Grok IDs from `llmcli-xai-forwarder:18645` when `xai.json` exists.
+   Unhealthy remote upstreams (probe 401/5xx) are omitted. Refresh interval defaults to
+   60s (`LLMCLI_MODEL_REFRESH_SECS`); `llmcli xai login` / `logout` triggers immediate
+   invalidation — no `systemctl restart llmcli` required for new Grok models.
+
+   The interim `/xai` pass-through remains available:
+   ```bash
+   curl -sS -H "Authorization: Bearer $LLMCLI_API_KEY" \
      http://127.0.0.1:18091/xai/v1/models | jq '.data[].id'
    ```
-   The `/xai` path forwards to `llmcli-xai-forwarder:18645` with live model discovery —
-   no proxy restart needed when xAI ships new Grok versions.
 
 8. **Migrate Claude Code aliases** — point `~/.bash_aliases` `_cc_fireworks()` /
    `_cc_nvidia()` / `cccc` / `cnd` to `127.0.0.1:18091` (and `/fw-anthropic` for the

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -712,7 +712,8 @@ pattern to the Quadlet-managed `llmcli proxy`:
    {provider}/models` returns 401/5xx or times out) — not per-model health. A model
    can still fail at completion time even when its provider lists 200. Refresh interval
    defaults to 60s (`LLMCLI_MODEL_REFRESH_SECS`; `0` is treated as default 60). Config
-   reload uses terminate+respawn of the litellm child (SIGHUP is not relied upon).
+   reload uses terminate+respawn of the litellm child when the merged `model_list`
+   changes (SIGHUP is not relied upon; unchanged catalogues skip respawn).
    `llmcli xai login` / `logout` updates `xai.json` mtime; the proxy refresh loop polls
    that token every ~1s and regen-reloads within one second (no `systemctl restart llmcli`
    required). Manual edits to `~/.roxabi/llmcli/credentials/xai.json` use the same path.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -708,9 +708,14 @@ pattern to the Quadlet-managed `llmcli proxy`:
    ```
    The canonical `:18091/v1/models` catalogue merges TOML entries (ADR-005 `machines`
    filter) with live Grok IDs from `llmcli-xai-forwarder:18645` when `xai.json` exists.
-   Unhealthy remote upstreams (probe 401/5xx) are omitted. Refresh interval defaults to
-   60s (`LLMCLI_MODEL_REFRESH_SECS`); `llmcli xai login` / `logout` triggers immediate
-   invalidation — no `systemctl restart llmcli` required for new Grok models.
+   Unhealthy remote upstreams are omitted via a **provider-level** probe (`GET
+   {provider}/models` returns 401/5xx or times out) — not per-model health. A model
+   can still fail at completion time even when its provider lists 200. Refresh interval
+   defaults to 60s (`LLMCLI_MODEL_REFRESH_SECS`; `0` is treated as default 60). Config
+   reload uses terminate+respawn of the litellm child (SIGHUP is not relied upon).
+   `llmcli xai login` / `logout` triggers immediate invalidation — no `systemctl restart
+   llmcli` required for new Grok models. Manual edits to `~/.roxabi/llmcli/credentials/xai.json`
+   are picked up via file mtime in the catalogue cache key.
 
    The interim `/xai` pass-through remains available:
    ```bash

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -713,9 +713,9 @@ pattern to the Quadlet-managed `llmcli proxy`:
    can still fail at completion time even when its provider lists 200. Refresh interval
    defaults to 60s (`LLMCLI_MODEL_REFRESH_SECS`; `0` is treated as default 60). Config
    reload uses terminate+respawn of the litellm child (SIGHUP is not relied upon).
-   `llmcli xai login` / `logout` triggers immediate invalidation — no `systemctl restart
-   llmcli` required for new Grok models. Manual edits to `~/.roxabi/llmcli/credentials/xai.json`
-   are picked up via file mtime in the catalogue cache key.
+   `llmcli xai login` / `logout` updates `xai.json` mtime; the proxy refresh loop polls
+   that token every ~1s and regen-reloads within one second (no `systemctl restart llmcli`
+   required). Manual edits to `~/.roxabi/llmcli/credentials/xai.json` use the same path.
 
    The interim `/xai` pass-through remains available:
    ```bash

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -23,6 +23,7 @@ from llmcli.support.litellm_config import (
     load_proxy_base,
     merge_proxy_config,
     register_model_refresh_callback,
+    xai_credentials_cache_token,
 )
 from llmcli.support.providers import PROVIDERS
 
@@ -199,13 +200,22 @@ def proxy(
         raise typer.Exit(0)
 
     # 7. Spawn litellm, background refresh, install signal handlers, wait
-    child_state: dict[str, Any] = {"child": _spawn_litellm(target, resolved_port, host), "stop": False}
+    child_state: dict[str, Any] = {
+        "child": _spawn_litellm(target, resolved_port, host),
+        "stop": False,
+        "refresh_lock": threading.Lock(),
+        "last_xai_token": xai_credentials_cache_token(),
+    }
 
     def _refresh_now() -> None:
         try:
-            _write_proxy_config(catalog, target, base)
-            child_state["child"] = _reload_litellm_child(
-                child_state["child"], target, resolved_port, host
+            _run_catalogue_refresh(
+                child_state,
+                catalog=catalog,
+                target=target,
+                base=base,
+                port=resolved_port,
+                host=host,
             )
         except Exception as exc:
             log.warning("model catalogue refresh failed: %s", exc)
@@ -227,8 +237,21 @@ def proxy(
         register_model_refresh_callback(None)
         refresh_thread.join(timeout=2.0)
 
-    _install_signal_handlers(child_state["child"], pre_handler=_shutdown_handler)
-    returncode = child_state["child"].wait()
+    _install_signal_handlers(child_state, pre_handler=_shutdown_handler)
+    returncode = 0
+    while True:
+        child = child_state["child"]
+        returncode = child.wait()
+        if child_state.get("stop"):
+            break
+        current = child_state.get("child")
+        if (
+            current is not None
+            and current is not child
+            and current.poll() is None
+        ):
+            continue
+        break
     # POSIX convention: negative return = killed by signal N → exit 128+N
     # Specifically, -9 (SIGKILL, e.g. OOM) → 137
     if returncode < 0:
@@ -339,6 +362,26 @@ def _write_proxy_config(catalog: Catalog, target: Path, base: dict[str, Any]) ->
     _write_custom_auth_module(target.parent)
 
 
+def _run_catalogue_refresh(
+    child_state: dict[str, Any],
+    *,
+    catalog: Catalog,
+    target: Path,
+    base: dict[str, Any],
+    port: int,
+    host: str,
+) -> None:
+    """Regenerate proxy config and reload litellm child (single-flight)."""
+    lock = child_state["refresh_lock"]
+    with lock:
+        clear_model_cache()
+        _write_proxy_config(catalog, target, base)
+        child = child_state.get("child")
+        if child is not None and child.poll() is None:
+            child_state["child"] = _reload_litellm_child(child, target, port, host)
+        child_state["last_xai_token"] = xai_credentials_cache_token()
+
+
 def _reload_litellm_child(
     child: subprocess.Popen,
     config_path: Path,
@@ -373,16 +416,30 @@ def _start_model_refresh_loop(
     """Daemon thread: periodic model_list regen + litellm child reload."""
 
     def _loop() -> None:
+        poll_chunk = min(1.0, interval_secs)
         while not child_state.get("stop"):
-            time.sleep(interval_secs)
+            deadline = time.monotonic() + interval_secs
+            while time.monotonic() < deadline:
+                if child_state.get("stop"):
+                    return
+                token = xai_credentials_cache_token()
+                if token != child_state.get("last_xai_token"):
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                time.sleep(min(poll_chunk, remaining))
             if child_state.get("stop"):
                 break
             try:
-                clear_model_cache()
-                _write_proxy_config(catalog, target, base)
-                child = child_state.get("child")
-                if child is not None and child.poll() is None:
-                    child_state["child"] = _reload_litellm_child(child, target, port, host)
+                _run_catalogue_refresh(
+                    child_state,
+                    catalog=catalog,
+                    target=target,
+                    base=base,
+                    port=port,
+                    host=host,
+                )
             except Exception as exc:
                 log.warning("background model refresh failed: %s", exc)
 
@@ -392,12 +449,15 @@ def _start_model_refresh_loop(
 
 
 def _install_signal_handlers(
-    child: subprocess.Popen,
+    child_state: dict[str, Any],
     drain_timeout: float = 10.0,
     *,
     pre_handler: Any | None = None,
 ) -> None:
-    """Forward SIGTERM/SIGINT to the litellm child with a poll-loop drain.
+    """Forward SIGTERM/SIGINT to the current litellm child with a poll-loop drain.
+
+    Resolves ``child_state["child"]`` on each signal so catalogue reloads cannot
+    leave shutdown targeting a stale (already-terminated) process handle.
 
     First signal: child.terminate() → poll child.poll() in 0.1s ticks until
     child exits or drain_timeout elapses; if still alive → child.kill().
@@ -410,6 +470,9 @@ def _install_signal_handlers(
     def handler(signum, frame):  # noqa: ARG001 (signature required by signal.signal)
         if pre_handler is not None:
             pre_handler(signum, frame)
+        child = child_state.get("child")
+        if child is None:
+            return
         if drain_state["active"] and signum == signal.SIGINT:
             child.kill()
             raise SystemExit(130)

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -347,20 +347,7 @@ def _reload_litellm_child(
     *,
     drain_timeout: float = 5.0,
 ) -> subprocess.Popen:
-    """Reload litellm by SIGHUP when possible; otherwise terminate and respawn."""
-    if child.poll() is None:
-        try:
-            child.send_signal(signal.SIGHUP)
-            deadline = time.monotonic() + 1.0
-            while time.monotonic() < deadline:
-                if child.poll() is not None:
-                    break
-                time.sleep(0.1)
-            if child.poll() is None:
-                return child
-        except OSError as exc:
-            log.debug("SIGHUP reload failed, respawning litellm child: %s", exc)
-
+    """Reload litellm by graceful terminate + respawn (LiteLLM ignores SIGHUP config reload)."""
     if child.poll() is None:
         child.terminate()
         deadline = time.monotonic() + drain_timeout

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -18,8 +18,8 @@ from llmcli.cli._app import app, console, err_console
 from llmcli.config import Catalog
 from llmcli.support.litellm_config import (
     build_model_list,
+    clear_model_cache,
     emit_xai_oauth_warning_if_absent,
-    invalidate_model_cache,
     load_proxy_base,
     merge_proxy_config,
     register_model_refresh_callback,
@@ -203,7 +203,6 @@ def proxy(
 
     def _refresh_now() -> None:
         try:
-            invalidate_model_cache()
             _write_proxy_config(catalog, target, base)
             child_state["child"] = _reload_litellm_child(
                 child_state["child"], target, resolved_port, host
@@ -392,7 +391,7 @@ def _start_model_refresh_loop(
             if child_state.get("stop"):
                 break
             try:
-                invalidate_model_cache()
+                clear_model_cache()
                 _write_proxy_config(catalog, target, base)
                 child = child_state.get("child")
                 if child is not None and child.poll() is None:

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
 import shutil
@@ -188,7 +190,7 @@ def proxy(
             raise typer.Exit(127)
 
     # 5. Build model_list + merge into layered config and write to disk
-    _write_proxy_config(catalog, target, base)
+    initial_model_list = _write_proxy_config(catalog, target, base)
 
     # 6. If --config-out, dry-run exit
     if config_out is not None:
@@ -205,6 +207,7 @@ def proxy(
         "stop": False,
         "refresh_lock": threading.Lock(),
         "last_xai_token": xai_credentials_cache_token(),
+        "last_model_list_hash": _hash_model_list(initial_model_list),
     }
 
     def _refresh_now() -> None:
@@ -235,23 +238,12 @@ def proxy(
     def _shutdown_handler(signum, frame):  # noqa: ARG001
         child_state["stop"] = True
         register_model_refresh_callback(None)
+        with child_state["refresh_lock"]:
+            pass
         refresh_thread.join(timeout=2.0)
 
     _install_signal_handlers(child_state, pre_handler=_shutdown_handler)
-    returncode = 0
-    while True:
-        child = child_state["child"]
-        returncode = child.wait()
-        if child_state.get("stop"):
-            break
-        current = child_state.get("child")
-        if (
-            current is not None
-            and current is not child
-            and current.poll() is None
-        ):
-            continue
-        break
+    returncode = _wait_for_litellm_child(child_state)
     # POSIX convention: negative return = killed by signal N → exit 128+N
     # Specifically, -9 (SIGKILL, e.g. OOM) → 137
     if returncode < 0:
@@ -349,7 +341,13 @@ def _parse_model_refresh_interval() -> float:
     return value if value > 0 else 60.0
 
 
-def _write_proxy_config(catalog: Catalog, target: Path, base: dict[str, Any]) -> None:
+def _hash_model_list(model_list: list[dict[str, Any]]) -> str:
+    """Stable SHA-256 digest of model_list for change detection."""
+    payload = json.dumps(model_list, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _write_proxy_config(catalog: Catalog, target: Path, base: dict[str, Any]) -> list[dict[str, Any]]:
     """Build merged proxy YAML from catalog + base transport config and write to target."""
     model_list = build_model_list(catalog, catalog.host.public_base_url)
     cfg = merge_proxy_config(base, model_list, api_key_env=catalog.host.api_key_env)
@@ -360,6 +358,24 @@ def _write_proxy_config(catalog: Catalog, target: Path, base: dict[str, Any]) ->
         f.write(yaml_text)
     target.chmod(0o600)
     _write_custom_auth_module(target.parent)
+    return model_list
+
+
+def _wait_for_litellm_child(child_state: dict[str, Any]) -> int:
+    """Block until the litellm child exits; continue waiting after catalogue respawn."""
+    while True:
+        child = child_state["child"]
+        returncode = child.wait()
+        if child_state.get("stop"):
+            return returncode
+        current = child_state.get("child")
+        if (
+            current is not None
+            and current is not child
+            and current.poll() is None
+        ):
+            continue
+        return returncode
 
 
 def _run_catalogue_refresh(
@@ -374,12 +390,26 @@ def _run_catalogue_refresh(
     """Regenerate proxy config and reload litellm child (single-flight)."""
     lock = child_state["refresh_lock"]
     with lock:
+        if child_state.get("stop"):
+            return
         clear_model_cache()
-        _write_proxy_config(catalog, target, base)
+        model_list = _write_proxy_config(catalog, target, base)
+        new_hash = _hash_model_list(model_list)
+        prev_hash = child_state.get("last_model_list_hash")
+        child_state["last_model_list_hash"] = new_hash
+        child_state["last_xai_token"] = xai_credentials_cache_token()
+        if child_state.get("stop"):
+            return
         child = child_state.get("child")
+        if (
+            prev_hash == new_hash
+            and child is not None
+            and child.poll() is None
+        ):
+            log.debug("model_list unchanged; skipping litellm reload")
+            return
         if child is not None and child.poll() is None:
             child_state["child"] = _reload_litellm_child(child, target, port, host)
-        child_state["last_xai_token"] = xai_credentials_cache_token()
 
 
 def _reload_litellm_child(
@@ -440,6 +470,8 @@ def _start_model_refresh_loop(
                     port=port,
                     host=host,
                 )
+            except typer.Exit as exc:
+                log.warning("background model refresh aborted: litellm unavailable (%s)", exc)
             except Exception as exc:
                 log.warning("background model refresh failed: %s", exc)
 

--- a/src/llmcli/cli/proxy.py
+++ b/src/llmcli/cli/proxy.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import signal
 import socket
 import subprocess
+import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 import yaml
@@ -17,10 +19,14 @@ from llmcli.config import Catalog
 from llmcli.support.litellm_config import (
     build_model_list,
     emit_xai_oauth_warning_if_absent,
+    invalidate_model_cache,
     load_proxy_base,
     merge_proxy_config,
+    register_model_refresh_callback,
 )
 from llmcli.support.providers import PROVIDERS
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # register-proxy
@@ -164,11 +170,6 @@ def proxy(
         err_console.print(f"[red]proxy-base.yaml: {exc}[/red]")
         raise typer.Exit(code=1)
 
-    # 4. Build model_list + merge into layered config
-    model_list = build_model_list(catalog, catalog.host.public_base_url)
-    cfg = merge_proxy_config(base, model_list, api_key_env=catalog.host.api_key_env)
-    yaml_text = yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False)
-
     # 4. Choose target path
     if config_out is not None:
         target = config_out
@@ -185,16 +186,8 @@ def proxy(
             )
             raise typer.Exit(127)
 
-    # 5. Write with 0o700 dir mode, 0o600 file mode
-    # Atomic create with restrictive perms (no write_text→chmod race window).
-    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    fd = os.open(target, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(yaml_text)
-    target.chmod(0o600)  # defense-in-depth: enforce exact mode regardless of process umask
-
-    # 5b. Write custom auth module so LiteLLM can resolve it
-    _write_custom_auth_module(target.parent)
+    # 5. Build model_list + merge into layered config and write to disk
+    _write_proxy_config(catalog, target, base)
 
     # 6. If --config-out, dry-run exit
     if config_out is not None:
@@ -205,10 +198,38 @@ def proxy(
         console.print(f"[green]Wrote proxy config to {target}[/green]")
         raise typer.Exit(0)
 
-    # 7. Spawn litellm, install signal handlers, wait, propagate exit code
-    child = _spawn_litellm(target, resolved_port, host)
-    _install_signal_handlers(child)
-    returncode = child.wait()
+    # 7. Spawn litellm, background refresh, install signal handlers, wait
+    child_state: dict[str, Any] = {"child": _spawn_litellm(target, resolved_port, host), "stop": False}
+
+    def _refresh_now() -> None:
+        try:
+            invalidate_model_cache()
+            _write_proxy_config(catalog, target, base)
+            child_state["child"] = _reload_litellm_child(
+                child_state["child"], target, resolved_port, host
+            )
+        except Exception as exc:
+            log.warning("model catalogue refresh failed: %s", exc)
+
+    register_model_refresh_callback(_refresh_now)
+    refresh_interval = _parse_model_refresh_interval()
+    refresh_thread = _start_model_refresh_loop(
+        child_state,
+        catalog=catalog,
+        target=target,
+        base=base,
+        port=resolved_port,
+        host=host,
+        interval_secs=refresh_interval,
+    )
+
+    def _shutdown_handler(signum, frame):  # noqa: ARG001
+        child_state["stop"] = True
+        register_model_refresh_callback(None)
+        refresh_thread.join(timeout=2.0)
+
+    _install_signal_handlers(child_state["child"], pre_handler=_shutdown_handler)
+    returncode = child_state["child"].wait()
     # POSIX convention: negative return = killed by signal N → exit 128+N
     # Specifically, -9 (SIGKILL, e.g. OOM) → 137
     if returncode < 0:
@@ -290,7 +311,106 @@ def _spawn_litellm(config_path: Path, port: int, host: str) -> subprocess.Popen:
     )
 
 
-def _install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.0) -> None:
+def _parse_model_refresh_interval() -> float:
+    """Parse LLMCLI_MODEL_REFRESH_SECS (default 60); reject negative values."""
+    raw = os.environ.get("LLMCLI_MODEL_REFRESH_SECS", "60")
+    try:
+        value = float(raw)
+    except ValueError:
+        log.warning("LLMCLI_MODEL_REFRESH_SECS=%r invalid; using 60", raw)
+        return 60.0
+    if value < 0:
+        err_console.print(
+            f"[red]LLMCLI_MODEL_REFRESH_SECS={raw} must be non-negative.[/red]"
+        )
+        raise typer.Exit(code=1)
+    return value if value > 0 else 60.0
+
+
+def _write_proxy_config(catalog: Catalog, target: Path, base: dict[str, Any]) -> None:
+    """Build merged proxy YAML from catalog + base transport config and write to target."""
+    model_list = build_model_list(catalog, catalog.host.public_base_url)
+    cfg = merge_proxy_config(base, model_list, api_key_env=catalog.host.api_key_env)
+    yaml_text = yaml.safe_dump(cfg, default_flow_style=False, sort_keys=False)
+    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd = os.open(target, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(yaml_text)
+    target.chmod(0o600)
+    _write_custom_auth_module(target.parent)
+
+
+def _reload_litellm_child(
+    child: subprocess.Popen,
+    config_path: Path,
+    port: int,
+    host: str,
+    *,
+    drain_timeout: float = 5.0,
+) -> subprocess.Popen:
+    """Reload litellm by SIGHUP when possible; otherwise terminate and respawn."""
+    if child.poll() is None:
+        try:
+            child.send_signal(signal.SIGHUP)
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if child.poll() is not None:
+                    break
+                time.sleep(0.1)
+            if child.poll() is None:
+                return child
+        except OSError as exc:
+            log.debug("SIGHUP reload failed, respawning litellm child: %s", exc)
+
+    if child.poll() is None:
+        child.terminate()
+        deadline = time.monotonic() + drain_timeout
+        while time.monotonic() < deadline:
+            if child.poll() is not None:
+                break
+            time.sleep(0.1)
+        if child.poll() is None:
+            child.kill()
+    return _spawn_litellm(config_path, port, host)
+
+
+def _start_model_refresh_loop(
+    child_state: dict[str, Any],
+    *,
+    catalog: Catalog,
+    target: Path,
+    base: dict[str, Any],
+    port: int,
+    host: str,
+    interval_secs: float,
+) -> threading.Thread:
+    """Daemon thread: periodic model_list regen + litellm child reload."""
+
+    def _loop() -> None:
+        while not child_state.get("stop"):
+            time.sleep(interval_secs)
+            if child_state.get("stop"):
+                break
+            try:
+                invalidate_model_cache()
+                _write_proxy_config(catalog, target, base)
+                child = child_state.get("child")
+                if child is not None and child.poll() is None:
+                    child_state["child"] = _reload_litellm_child(child, target, port, host)
+            except Exception as exc:
+                log.warning("background model refresh failed: %s", exc)
+
+    thread = threading.Thread(target=_loop, name="llmcli-model-refresh", daemon=True)
+    thread.start()
+    return thread
+
+
+def _install_signal_handlers(
+    child: subprocess.Popen,
+    drain_timeout: float = 10.0,
+    *,
+    pre_handler: Any | None = None,
+) -> None:
     """Forward SIGTERM/SIGINT to the litellm child with a poll-loop drain.
 
     First signal: child.terminate() → poll child.poll() in 0.1s ticks until
@@ -302,6 +422,8 @@ def _install_signal_handlers(child: subprocess.Popen, drain_timeout: float = 10.
     drain_state = {"active": False}
 
     def handler(signum, frame):  # noqa: ARG001 (signature required by signal.signal)
+        if pre_handler is not None:
+            pre_handler(signum, frame)
         if drain_state["active"] and signum == signal.SIGINT:
             child.kill()
             raise SystemExit(130)

--- a/src/llmcli/cli/xai.py
+++ b/src/llmcli/cli/xai.py
@@ -9,6 +9,7 @@ import typer
 from llmcli.auth import login_flow, store
 from llmcli.auth.store import CredentialsCorruptError
 from llmcli.cli._app import console, err_console
+from llmcli.support.litellm_config import invalidate_model_cache
 
 xai_app = typer.Typer(help="xAI / SuperGrok OAuth credentials")
 
@@ -24,6 +25,7 @@ def login_cmd(
 ) -> None:
     """Run PKCE OAuth flow against auth.x.ai; stores credentials at xai.json."""
     creds = login_flow(manual=manual)
+    invalidate_model_cache()
     console.print(f"[green]✓[/green] Logged in. expires_at={creds.expires_at}")
 
 
@@ -31,6 +33,7 @@ def login_cmd(
 def logout_cmd() -> None:
     """Delete cached xai.json credentials (silent no-op if absent)."""
     store.XAI_CREDENTIALS_PATH.unlink(missing_ok=True)
+    invalidate_model_cache()
     console.print("[green]✓[/green] Credentials removed.")
 
 

--- a/src/llmcli/nats/_lifecycle.py
+++ b/src/llmcli/nats/_lifecycle.py
@@ -21,7 +21,8 @@ from roxabi_contracts.errors import WorkerError
 
 from llmcli.auth.store import XAI_CREDENTIALS_PATH
 from llmcli.config import check_vram_budget, load as load_catalog
-from llmcli.support.litellm_config import _XAI_OAUTH_MODELS
+from llmcli.support.litellm_config import fetch_xai_models
+from llmcli.support.providers import PROVIDERS
 
 log = logging.getLogger(__name__)
 
@@ -250,7 +251,9 @@ class LifecycleMixin:
             for name, spec in catalog.models.items()
         ]
         if XAI_CREDENTIALS_PATH.exists():
-            for model_name in _XAI_OAUTH_MODELS:
+            xai_provider = PROVIDERS.get("xai-oauth")
+            forwarder_base = xai_provider.api_base if xai_provider else ""
+            for model_name in fetch_xai_models(forwarder_base):
                 models.append({
                     "name": model_name,
                     "running": False,  # forwarder liveness checked via /health, not surfaced here

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -159,13 +159,26 @@ def fetch_xai_models(forwarder_base: str, *, timeout: float = _XAI_FETCH_TIMEOUT
     return ids
 
 
-def _xai_credentials_cache_token() -> str:
+def xai_credentials_cache_token() -> str:
     """Cache-bust token for xai.json presence and mtime (manual edits outside CLI)."""
     try:
         stat = _XAI_CREDENTIALS_PATH.stat()
     except OSError:
         return "absent"
     return f"present:{stat.st_mtime_ns}"
+
+
+def _catalog_spec_fingerprint(catalog: Catalog) -> str:
+    """Stable fingerprint of routing-relevant model spec fields for cache invalidation."""
+    parts: list[str] = []
+    for name in sorted(catalog.models):
+        spec = catalog.models[name]
+        machines = ",".join(spec.machines)
+        parts.append(
+            f"{name}:{spec.engine}:{spec.port}:{spec.provider}:{spec.model_id}:"
+            f"{spec.protocol}:{machines}"
+        )
+    return "|".join(parts)
 
 
 def probe_remote_model(
@@ -295,8 +308,8 @@ def build_model_list(
     effective_hostname = hostname if hostname is not None else socket.gethostname()
     cache_key = (
         f"{effective_hostname}:{public_base_url}:"
-        f"{','.join(sorted(catalog.models))}:{catalog.host.api_key_env}:"
-        f"{_xai_credentials_cache_token()}"
+        f"{_catalog_spec_fingerprint(catalog)}:{catalog.host.api_key_env}:"
+        f"{xai_credentials_cache_token()}"
     )
 
     def _builder() -> list[dict[str, Any]]:

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -159,13 +159,26 @@ def fetch_xai_models(forwarder_base: str, *, timeout: float = _XAI_FETCH_TIMEOUT
     return ids
 
 
+def _xai_credentials_cache_token() -> str:
+    """Cache-bust token for xai.json presence and mtime (manual edits outside CLI)."""
+    try:
+        stat = _XAI_CREDENTIALS_PATH.stat()
+    except OSError:
+        return "absent"
+    return f"present:{stat.st_mtime_ns}"
+
+
 def probe_remote_model(
     spec: ModelSpec,
     provider: Provider,
     *,
     timeout: float = _PROBE_TIMEOUT_SECS,
 ) -> bool:
-    """Return True when the remote provider responds 2xx to a lightweight probe."""
+    """Return True when the provider's ``GET /models`` endpoint responds 2xx.
+
+    Provider-level liveness only — a 200 here does not guarantee a specific
+    ``model_id`` (e.g. ``kimi-k2.6``) succeeds at completion time.
+    """
     if provider.key_env == "_OAUTH_MANAGED":
         return True
     api_key = os.environ.get(provider.key_env)
@@ -282,7 +295,8 @@ def build_model_list(
     effective_hostname = hostname if hostname is not None else socket.gethostname()
     cache_key = (
         f"{effective_hostname}:{public_base_url}:"
-        f"{','.join(sorted(catalog.models))}:{catalog.host.api_key_env}"
+        f"{','.join(sorted(catalog.models))}:{catalog.host.api_key_env}:"
+        f"{_xai_credentials_cache_token()}"
     )
 
     def _builder() -> list[dict[str, Any]]:

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -128,9 +128,14 @@ def register_model_refresh_callback(callback: Callable[[], None] | None) -> None
     _refresh_callback = callback
 
 
+def clear_model_cache() -> None:
+    """Clear cached model_list without invoking the refresh callback."""
+    _MODEL_DISCOVERY_CACHE.invalidate()
+
+
 def invalidate_model_cache() -> None:
     """Clear cached model_list; trigger optional immediate refresh callback."""
-    _MODEL_DISCOVERY_CACHE.invalidate()
+    clear_model_cache()
     if _refresh_callback is not None:
         _refresh_callback()
 

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -2,23 +2,29 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
 import socket
 import subprocess
+import threading
+import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+import httpx
 import yaml
 
 from llmcli.auth.store import XAI_CREDENTIALS_PATH as _XAI_CREDENTIALS_PATH
-from llmcli.config import Catalog
-from llmcli.support.providers import PROVIDERS
+from llmcli.config import Catalog, ModelSpec
+from llmcli.support.providers import PROVIDERS, Provider
 
 log = logging.getLogger(__name__)
 
 LITELLM_CONFIG = Path.home() / ".litellm" / "config.yaml"
 
-# xAI OAuth — hardcoded model list (forwarder-routed; NOT in per-host TOML catalog)
-_XAI_OAUTH_MODELS: list[str] = ["grok-4", "grok-4-fast"]
+_DEFAULT_MODEL_REFRESH_SECS = 60.0
+_PROBE_TIMEOUT_SECS = 3.0
+_XAI_FETCH_TIMEOUT_SECS = 3.0
 BLOCK_START = "# --- llmCLI managed block start ---"
 BLOCK_END = "# --- llmCLI managed block end ---"
 
@@ -75,7 +81,113 @@ def merge_proxy_config(
     return result
 
 
-def build_model_list(
+class ModelDiscoveryCache:
+    """Thread-safe in-memory cache for merged model_list entries."""
+
+    def __init__(self, *, ttl_secs: float = _DEFAULT_MODEL_REFRESH_SECS) -> None:
+        self._ttl_secs = ttl_secs
+        self._lock = threading.Lock()
+        self._entries: list[dict[str, Any]] | None = None
+        self._cache_key: str | None = None
+        self._fetched_at: float = 0.0
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._entries = None
+            self._cache_key = None
+            self._fetched_at = 0.0
+
+    def get_or_refresh(
+        self,
+        cache_key: str,
+        builder: Callable[[], list[dict[str, Any]]],
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            now = time.monotonic()
+            if (
+                self._entries is not None
+                and self._cache_key == cache_key
+                and (now - self._fetched_at) < self._ttl_secs
+            ):
+                return copy.deepcopy(self._entries)
+        built = builder()
+        with self._lock:
+            self._entries = copy.deepcopy(built)
+            self._cache_key = cache_key
+            self._fetched_at = time.monotonic()
+            return copy.deepcopy(built)
+
+
+_MODEL_DISCOVERY_CACHE = ModelDiscoveryCache()
+_refresh_callback: Callable[[], None] | None = None
+
+
+def register_model_refresh_callback(callback: Callable[[], None] | None) -> None:
+    """Register a hook invoked after cache invalidation (e.g. proxy immediate refresh)."""
+    global _refresh_callback
+    _refresh_callback = callback
+
+
+def invalidate_model_cache() -> None:
+    """Clear cached model_list; trigger optional immediate refresh callback."""
+    _MODEL_DISCOVERY_CACHE.invalidate()
+    if _refresh_callback is not None:
+        _refresh_callback()
+
+
+def fetch_xai_models(forwarder_base: str, *, timeout: float = _XAI_FETCH_TIMEOUT_SECS) -> list[str]:
+    """Fetch live Grok model IDs from the xAI OAuth forwarder."""
+    url = f"{forwarder_base.rstrip('/')}/models"
+    try:
+        resp = httpx.get(url, timeout=timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+    except Exception as exc:
+        log.warning("xAI forwarder model fetch failed (%s): %s", url, exc)
+        return []
+    ids: list[str] = []
+    for item in payload.get("data", []):
+        if isinstance(item, dict) and isinstance(item.get("id"), str):
+            model_id = item["id"]
+            if not model_id.startswith("grok-imagine-"):
+                ids.append(model_id)
+    return ids
+
+
+def probe_remote_model(
+    spec: ModelSpec,
+    provider: Provider,
+    *,
+    timeout: float = _PROBE_TIMEOUT_SECS,
+) -> bool:
+    """Return True when the remote provider responds 2xx to a lightweight probe."""
+    if provider.key_env == "_OAUTH_MANAGED":
+        return True
+    api_key = os.environ.get(provider.key_env)
+    if not api_key:
+        return False
+    url = f"{provider.api_base.rstrip('/')}/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        resp = httpx.get(url, headers=headers, timeout=timeout)
+        return 200 <= resp.status_code < 300
+    except Exception as exc:
+        log.debug("upstream probe failed for %s: %s", spec.name, exc)
+        return False
+
+
+def _xai_model_entry(model_name: str, api_base: str) -> dict[str, Any]:
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": f"openai/responses/{model_name}",
+            "api_base": api_base,
+            "api_key": "dummy",
+        },
+    }
+
+
+def _build_model_list_uncached(
     catalog: Catalog, public_base_url: str, *, hostname: str | None = None
 ) -> list[dict[str, Any]]:
     """Build the model_list entries from the catalog.
@@ -105,6 +217,8 @@ def build_model_list(
                     f"Valid providers: {sorted(PROVIDERS.keys())}."
                 )
             provider = provider_cfg
+            if not probe_remote_model(spec, provider):
+                continue
             if spec.protocol == "anthropic":
                 entry: dict[str, Any] = {
                     "model_name": name,
@@ -135,27 +249,41 @@ def build_model_list(
             }
         model_list.append(entry)
 
-    # Inject OAuth-managed models (not in catalog — forwarder-routed)
-    # Gate on credentials presence; silently skip when absent.
+    existing_names = {entry["model_name"] for entry in model_list}
     xai_provider = PROVIDERS.get("xai-oauth")
-    if xai_provider is not None and xai_provider.key_env == "_OAUTH_MANAGED":
-        if _XAI_CREDENTIALS_PATH.exists():
-            for model_name in _XAI_OAUTH_MODELS:
-                model_list.append(
-                    {
-                        "model_name": model_name,
-                        "litellm_params": {
-                            # `responses/` prefix triggers LiteLLM's Chat→Responses bridge
-                            # (litellm/main.py:responses_api_bridge_check). Grok-CLI OAuth
-                            # tokens are accepted only at /v1/responses, not /v1/chat/completions.
-                            "model": f"openai/responses/{model_name}",
-                            "api_base": xai_provider.api_base,
-                            "api_key": "dummy",  # LiteLLM requires non-empty; forwarder ignores
-                        },
-                    }
-                )
+    if (
+        xai_provider is not None
+        and xai_provider.key_env == "_OAUTH_MANAGED"
+        and _XAI_CREDENTIALS_PATH.exists()
+    ):
+        for model_name in fetch_xai_models(xai_provider.api_base):
+            if model_name in existing_names:
+                continue
+            model_list.append(_xai_model_entry(model_name, xai_provider.api_base))
+            existing_names.add(model_name)
 
     return model_list
+
+
+def build_model_list(
+    catalog: Catalog,
+    public_base_url: str,
+    *,
+    hostname: str | None = None,
+    cache: ModelDiscoveryCache | None = None,
+) -> list[dict[str, Any]]:
+    """Build merged model_list from catalog, health probes, and live xAI discovery."""
+    effective_cache = cache if cache is not None else _MODEL_DISCOVERY_CACHE
+    effective_hostname = hostname if hostname is not None else socket.gethostname()
+    cache_key = (
+        f"{effective_hostname}:{public_base_url}:"
+        f"{','.join(sorted(catalog.models))}:{catalog.host.api_key_env}"
+    )
+
+    def _builder() -> list[dict[str, Any]]:
+        return _build_model_list_uncached(catalog, public_base_url, hostname=hostname)
+
+    return effective_cache.get_or_refresh(cache_key, _builder)
 
 
 def build_full_config(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import shutil
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +29,31 @@ def _stub_free_vram_probe():
 
 
 @pytest.fixture(autouse=True)
+def _stub_remote_upstream_probe(request: pytest.FixtureRequest):
+    # Remote TOML entries are health-gated; default to healthy so existing
+    # build_block/build_full_config tests stay deterministic without live APIs.
+    if request.node.get_closest_marker("no_probe_stub"):
+        yield
+        return
+    with patch("llmcli.support.litellm_config.probe_remote_model", return_value=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_discovery_cache():
+    from llmcli.support.litellm_config import (
+        _MODEL_DISCOVERY_CACHE,
+        register_model_refresh_callback,
+    )
+
+    _MODEL_DISCOVERY_CACHE.invalidate()
+    register_model_refresh_callback(None)
+    yield
+    _MODEL_DISCOVERY_CACHE.invalidate()
+    register_model_refresh_callback(None)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_xai_credentials_path(tmp_path_factory):
     # OAuth model injection (litellm_config.build_model_list) is gated on
     # XAI_CREDENTIALS_PATH.exists(). Point it at a tmp path so tests are
@@ -35,8 +61,14 @@ def _isolate_xai_credentials_path(tmp_path_factory):
     # host running pytest. Tests that exercise the OAuth path can re-patch.
     from pathlib import Path
     fake = tmp_path_factory.mktemp("no-xai-creds") / "xai.json"
-    with patch("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", Path(fake)), \
-         patch("llmcli.nats._lifecycle.XAI_CREDENTIALS_PATH", Path(fake)):
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", Path(fake))
+        )
+        if importlib.util.find_spec("roxabi_contracts") is not None:
+            stack.enter_context(
+                patch("llmcli.nats._lifecycle.XAI_CREDENTIALS_PATH", Path(fake))
+            )
         yield
 
 
@@ -48,6 +80,10 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
         "gpu: tests that require a live GPU (skipped when no GPU is available)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_probe_stub: disable autouse upstream health probe stub",
     )
 
 

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from llmcli.config import Catalog, HostSettings, ModelSpec
 from llmcli.support.litellm_config import BLOCK_END, BLOCK_START, build_block, write_block
@@ -926,3 +926,196 @@ class TestBuildModelList:
         # Assert
         hash_after = hashlib.sha256(yaml_path.read_bytes()).hexdigest()
         assert hash_before == hash_after
+
+
+# ---------------------------------------------------------------------------
+# Unified dynamic /v1/models — forwarder discovery + health filter (#130)
+# ---------------------------------------------------------------------------
+
+
+class TestXaiModelDiscovery:
+    def test_fetch_xai_models_filters_grok_imagine(self) -> None:
+        from llmcli.support.litellm_config import fetch_xai_models
+
+        payload = {
+            "data": [
+                {"id": "grok-4.3"},
+                {"id": "grok-imagine-v1"},
+                {"id": "grok-4-fast"},
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = payload
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            ids = fetch_xai_models("http://llmcli-xai-forwarder:18645/v1")
+        assert ids == ["grok-4.3", "grok-4-fast"]
+
+    def test_fetch_xai_models_returns_empty_on_error(self) -> None:
+        from llmcli.support.litellm_config import fetch_xai_models
+
+        with patch(
+            "llmcli.support.litellm_config.httpx.get",
+            side_effect=OSError("connection refused"),
+        ):
+            assert fetch_xai_models("http://llmcli-xai-forwarder:18645/v1") == []
+
+    @pytest.mark.no_probe_stub
+    def test_probe_remote_model_omits_on_401(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from llmcli.support.litellm_config import probe_remote_model
+
+        spec = ModelSpec(
+            name="kimi-k2.6",
+            engine="remote",
+            provider="fireworks",
+            model_id="accounts/fireworks/models/kimi-k2p6",
+            protocol="openai",
+        )
+        provider = PROVIDERS["fireworks"]
+        monkeypatch.setenv(provider.key_env, "test-key")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            assert probe_remote_model(spec, provider) is False
+
+    @pytest.mark.no_probe_stub
+    def test_build_model_list_omits_unhealthy_remote(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        catalog = _make_remote_catalog("openai")
+        provider = PROVIDERS["fireworks"]
+        monkeypatch.setenv(provider.key_env, "test-key")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        cache = ModelDiscoveryCache(ttl_secs=60)
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            model_list = build_model_list(
+                catalog, PUBLIC_BASE_URL, hostname="any-host", cache=cache
+            )
+        assert model_list == []
+
+    def test_build_model_list_machines_filter_unchanged(self) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        catalog = _make_catalog(
+            models={
+                "host-only": dict(
+                    engine="llamacpp",
+                    repo="Org/Qwen3-8B-GGUF",
+                    file="qwen3-8b-q4_k_m.gguf",
+                    port=8091,
+                    vram_gib=5.5,
+                    machines=["host-a"],
+                )
+            }
+        )
+        cache = ModelDiscoveryCache(ttl_secs=60)
+        on_a = build_model_list(catalog, PUBLIC_BASE_URL, hostname="host-a", cache=cache)
+        cache.invalidate()
+        on_b = build_model_list(catalog, PUBLIC_BASE_URL, hostname="host-b", cache=cache)
+        assert len(on_a) == 1
+        assert on_b == []
+
+    def test_build_model_list_includes_live_grok_when_creds_exist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        creds = tmp_path / "xai.json"
+        creds.write_text('{"access_token": "t", "refresh_token": "r"}')
+        monkeypatch.setattr("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", creds)
+        payload = {"data": [{"id": "grok-4.3"}]}
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = payload
+        cache = ModelDiscoveryCache(ttl_secs=60)
+        catalog = _make_catalog(models={})
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            model_list = build_model_list(catalog, PUBLIC_BASE_URL, cache=cache)
+        names = [m["model_name"] for m in model_list]
+        assert "grok-4.3" in names
+
+    def test_build_model_list_no_grok_without_creds(self) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        cache = ModelDiscoveryCache(ttl_secs=60)
+        catalog = _make_catalog(models={})
+        model_list = build_model_list(catalog, PUBLIC_BASE_URL, cache=cache)
+        assert all(not n.startswith("grok") for n in (m["model_name"] for m in model_list))
+
+    def test_build_model_list_dedup_toml_over_forwarder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        creds = tmp_path / "xai.json"
+        creds.write_text('{"access_token": "t", "refresh_token": "r"}')
+        monkeypatch.setattr("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", creds)
+        catalog = _make_catalog(
+            models={
+                "grok-4.3": dict(
+                    engine="llamacpp",
+                    repo="Org/Grok-GGUF",
+                    file="grok.gguf",
+                    port=8099,
+                    vram_gib=5.0,
+                )
+            }
+        )
+        payload = {"data": [{"id": "grok-4.3"}]}
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = payload
+        cache = ModelDiscoveryCache(ttl_secs=60)
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            model_list = build_model_list(catalog, PUBLIC_BASE_URL, cache=cache)
+        grok_entries = [m for m in model_list if m["model_name"] == "grok-4.3"]
+        assert len(grok_entries) == 1
+        assert grok_entries[0]["litellm_params"]["api_base"].endswith(":8099/v1")
+
+    def test_invalidate_model_cache_forces_rebuild(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.support.litellm_config import (
+            _MODEL_DISCOVERY_CACHE,
+            build_model_list,
+            invalidate_model_cache,
+        )
+
+        creds = tmp_path / "xai.json"
+        creds.write_text('{"access_token": "t", "refresh_token": "r"}')
+        monkeypatch.setattr("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", creds)
+        _MODEL_DISCOVERY_CACHE._ttl_secs = 3600  # noqa: SLF001 — test-only TTL override
+        catalog = _make_catalog(models={})
+        call_count = 0
+
+        def _fake_fetch(_base: str, *, timeout: float = 3.0) -> list[str]:
+            nonlocal call_count
+            call_count += 1
+            return ["grok-4.3"] if call_count == 1 else ["grok-4.20"]
+
+        with patch("llmcli.support.litellm_config.fetch_xai_models", side_effect=_fake_fetch):
+            first = build_model_list(catalog, PUBLIC_BASE_URL)
+            second = build_model_list(catalog, PUBLIC_BASE_URL)
+            assert first[0]["model_name"] == "grok-4.3"
+            assert second[0]["model_name"] == "grok-4.3"
+            invalidate_model_cache()
+            third = build_model_list(catalog, PUBLIC_BASE_URL)
+        assert third[0]["model_name"] == "grok-4.20"
+
+    def test_register_proxy_xai_block_includes_forwarder_models(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        creds = tmp_path / "xai.json"
+        creds.write_text('{"access_token": "t", "refresh_token": "r"}')
+        monkeypatch.setattr("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", creds)
+        payload = {"data": [{"id": "grok-4.3"}]}
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = payload
+        catalog = _make_catalog(models={})
+        with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
+            block = build_block(catalog, PUBLIC_BASE_URL)
+        assert "grok-4.3" in block

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -1119,3 +1119,58 @@ class TestXaiModelDiscovery:
         with patch("llmcli.support.litellm_config.httpx.get", return_value=mock_resp):
             block = build_block(catalog, PUBLIC_BASE_URL)
         assert "grok-4.3" in block
+
+    def test_xai_credentials_mtime_busts_cache(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        creds = tmp_path / "xai.json"
+        creds.write_text('{"access_token": "t1", "refresh_token": "r"}')
+        monkeypatch.setattr("llmcli.support.litellm_config._XAI_CREDENTIALS_PATH", creds)
+        call_count = 0
+
+        def _fake_fetch(_base: str, *, timeout: float = 3.0) -> list[str]:
+            nonlocal call_count
+            call_count += 1
+            return ["grok-4.3"] if call_count == 1 else ["grok-4.20"]
+
+        cache = ModelDiscoveryCache(ttl_secs=3600)
+        catalog = _make_catalog(models={})
+        with patch("llmcli.support.litellm_config.fetch_xai_models", side_effect=_fake_fetch):
+            first = build_model_list(catalog, PUBLIC_BASE_URL, cache=cache)
+            creds.write_text('{"access_token": "t2", "refresh_token": "r"}')
+            second = build_model_list(catalog, PUBLIC_BASE_URL, cache=cache)
+        assert first[0]["model_name"] == "grok-4.3"
+        assert second[0]["model_name"] == "grok-4.20"
+
+    def test_catalog_spec_change_busts_cache(self) -> None:
+        from llmcli.support.litellm_config import ModelDiscoveryCache, build_model_list
+
+        cache = ModelDiscoveryCache(ttl_secs=3600)
+        catalog_a = _make_catalog(
+            models={
+                "qwen": dict(
+                    engine="llamacpp",
+                    repo="Org/Qwen3-8B-GGUF",
+                    file="qwen3-8b-q4_k_m.gguf",
+                    port=8091,
+                    vram_gib=5.5,
+                )
+            }
+        )
+        first = build_model_list(catalog_a, PUBLIC_BASE_URL, cache=cache)
+        catalog_b = _make_catalog(
+            models={
+                "qwen": dict(
+                    engine="llamacpp",
+                    repo="Org/Qwen3-8B-GGUF",
+                    file="qwen3-8b-q4_k_m.gguf",
+                    port=8092,
+                    vram_gib=5.5,
+                )
+            }
+        )
+        second = build_model_list(catalog_b, PUBLIC_BASE_URL, cache=cache)
+        assert first[0]["litellm_params"]["api_base"].endswith(":8091/v1")
+        assert second[0]["litellm_params"]["api_base"].endswith(":8092/v1")

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1162,3 +1163,86 @@ class TestModelRefresh:
                 interval_secs=60.0,
             ).join(timeout=2.0)
         refresh.assert_called_once()
+
+    def test_wait_for_litellm_child_continues_after_respawn(self) -> None:
+        from llmcli.cli.proxy import _wait_for_litellm_child
+
+        old_child = MagicMock()
+        new_child = MagicMock()
+        new_child.poll.return_value = None
+        new_child.wait.return_value = 0
+        child_state: dict = {"child": old_child, "stop": False}
+
+        def _old_wait() -> int:
+            child_state["child"] = new_child
+            return 0
+
+        old_child.wait.side_effect = _old_wait
+
+        assert _wait_for_litellm_child(child_state) == 0
+        old_child.wait.assert_called_once()
+        new_child.wait.assert_called_once()
+
+    def test_run_catalogue_refresh_skips_reload_when_unchanged(self) -> None:
+        from llmcli.cli.proxy import _hash_model_list, _run_catalogue_refresh
+
+        catalog = _make_catalog()
+        target = Path("/tmp/proxy.config.yaml")
+        base: dict = {"general_settings": {}, "litellm_settings": {}}
+        child = MagicMock()
+        child.poll.return_value = None
+        model_list = [{"model_name": "qwen3-4b", "litellm_params": {}}]
+        child_state: dict = {
+            "child": child,
+            "stop": False,
+            "refresh_lock": threading.Lock(),
+            "last_model_list_hash": _hash_model_list(model_list),
+            "last_xai_token": "absent",
+        }
+
+        with (
+            patch("llmcli.cli.proxy._write_proxy_config", return_value=model_list),
+            patch("llmcli.cli.proxy._reload_litellm_child") as reload,
+            patch("llmcli.cli.proxy.xai_credentials_cache_token", return_value="absent"),
+        ):
+            _run_catalogue_refresh(
+                child_state,
+                catalog=catalog,
+                target=target,
+                base=base,
+                port=18091,
+                host="0.0.0.0",
+            )
+        reload.assert_not_called()
+
+    def test_run_catalogue_refresh_skips_reload_when_stopping(self) -> None:
+        from llmcli.cli.proxy import _hash_model_list, _run_catalogue_refresh
+
+        catalog = _make_catalog()
+        target = Path("/tmp/proxy.config.yaml")
+        base: dict = {"general_settings": {}, "litellm_settings": {}}
+        child = MagicMock()
+        child.poll.return_value = None
+        model_list = [{"model_name": "qwen3-4b", "litellm_params": {}}]
+        child_state: dict = {
+            "child": child,
+            "stop": True,
+            "refresh_lock": threading.Lock(),
+            "last_model_list_hash": _hash_model_list([]),
+            "last_xai_token": "absent",
+        }
+
+        with (
+            patch("llmcli.cli.proxy._write_proxy_config", return_value=model_list) as write_cfg,
+            patch("llmcli.cli.proxy._reload_litellm_child") as reload,
+        ):
+            _run_catalogue_refresh(
+                child_state,
+                catalog=catalog,
+                target=target,
+                base=base,
+                port=18091,
+                host="0.0.0.0",
+            )
+        write_cfg.assert_not_called()
+        reload.assert_not_called()

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -996,3 +996,73 @@ class TestProxyEnvPortMalformed:
             f"Expected 'LLMCLI_PROXY_PORT' in output; got: {combined!r}"
         )
         assert "abc" in combined, f"Expected 'abc' in output; got: {combined!r}"
+
+
+# ---------------------------------------------------------------------------
+# Model catalogue background refresh (#130)
+# ---------------------------------------------------------------------------
+
+
+class TestModelRefresh:
+    def test_parse_model_refresh_interval_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from llmcli.cli.proxy import _parse_model_refresh_interval
+
+        monkeypatch.delenv("LLMCLI_MODEL_REFRESH_SECS", raising=False)
+        assert _parse_model_refresh_interval() == 60.0
+
+    def test_parse_model_refresh_interval_rejects_negative(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.cli.proxy import _parse_model_refresh_interval
+
+        monkeypatch.setenv("LLMCLI_MODEL_REFRESH_SECS", "-1")
+        with pytest.raises(typer.Exit) as exc:
+            _parse_model_refresh_interval()
+        assert exc.value.exit_code == 1
+
+    def test_reload_litellm_child_respawns_when_sighup_ignored(self) -> None:
+        from llmcli.cli.proxy import _reload_litellm_child
+
+        child = MagicMock()
+        child.poll.return_value = None
+        child.send_signal.side_effect = OSError("no sighup")
+        new_child = MagicMock()
+        with patch("llmcli.cli.proxy._spawn_litellm", return_value=new_child) as spawn:
+            result = _reload_litellm_child(child, Path("/tmp/cfg.yaml"), 18091, "0.0.0.0")
+        child.terminate.assert_called_once()
+        spawn.assert_called_once()
+        assert result is new_child
+
+    def test_model_refresh_loop_regenerates_config(self) -> None:
+        from llmcli.cli.proxy import _start_model_refresh_loop
+
+        catalog = _make_catalog()
+        target = Path("/tmp/proxy.config.yaml")
+        base: dict = {"general_settings": {}, "litellm_settings": {}}
+        child = MagicMock()
+        child.poll.return_value = None
+        child_state: dict = {"child": child, "stop": False}
+        sleep_calls = 0
+
+        def _sleep_then_stop(_interval: float) -> None:
+            nonlocal sleep_calls
+            sleep_calls += 1
+            if sleep_calls >= 2:
+                child_state["stop"] = True
+
+        with (
+            patch("llmcli.cli.proxy._write_proxy_config") as write_cfg,
+            patch("llmcli.cli.proxy._reload_litellm_child", return_value=child) as reload,
+            patch("llmcli.cli.proxy.time.sleep", side_effect=_sleep_then_stop),
+        ):
+            _start_model_refresh_loop(
+                child_state,
+                catalog=catalog,
+                target=target,
+                base=base,
+                port=18091,
+                host="0.0.0.0",
+                interval_secs=0.01,
+            ).join(timeout=2.0)
+        write_cfg.assert_called()
+        reload.assert_called()

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -245,7 +245,7 @@ class TestSignalForwarding:
         monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
 
         # Act — register handlers, then invoke captured SIGTERM handler
-        _install_signal_handlers(child, drain_timeout=0.5)
+        _install_signal_handlers({"child": child}, drain_timeout=0.5)
         handler = captured_handlers[signal.SIGTERM]
         handler(signal.SIGTERM, None)
 
@@ -253,6 +253,36 @@ class TestSignalForwarding:
         assert child.terminate.called is True
         assert child.poll.call_count >= 1
         assert child.kill.called is False
+
+    def test_signal_handler_targets_current_child_after_reload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After catalogue reload, SIGTERM must terminate the new litellm child."""
+        import signal
+        import subprocess
+
+        import llmcli.cli.proxy as proxy_mod
+        from llmcli.cli.proxy import _install_signal_handlers
+
+        old_child = MagicMock(spec=subprocess.Popen)
+        old_child.poll.return_value = None
+        new_child = MagicMock(spec=subprocess.Popen)
+        new_child.poll.return_value = None
+        child_state: dict = {"child": new_child}
+
+        captured_handlers: dict = {}
+
+        def fake_signal_signal(signum, handler):
+            captured_handlers[signum] = handler
+
+        monkeypatch.setattr(proxy_mod.signal, "signal", fake_signal_signal)
+        monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
+
+        _install_signal_handlers(child_state, drain_timeout=0.5)
+        captured_handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+        new_child.terminate.assert_called_once()
+        old_child.terminate.assert_not_called()
 
     def test_drain_timeout_exceeded_kills_child(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Handler calls kill when child does not exit within drain_timeout."""
@@ -278,7 +308,7 @@ class TestSignalForwarding:
         monkeypatch.setattr(proxy_mod.time, "sleep", lambda _: None)
 
         # Act — drain_timeout=0.0 → deadline expires immediately, loop skipped
-        _install_signal_handlers(child, drain_timeout=0.0)
+        _install_signal_handlers({"child": child}, drain_timeout=0.0)
         handler = captured_handlers[signal.SIGTERM]
         handler(signal.SIGTERM, None)
 
@@ -311,7 +341,7 @@ class TestSignalForwarding:
 
         # Act — zero timeout so first SIGINT drains immediately and finishes
         # then second SIGINT hits the reentrant path
-        _install_signal_handlers(child, drain_timeout=0.0)
+        _install_signal_handlers({"child": child}, drain_timeout=0.0)
         handler = captured_handlers[signal.SIGINT]
 
         # First SIGINT: triggers drain (timeout=0 so kill is called, but
@@ -1020,6 +1050,14 @@ class TestModelRefresh:
             _parse_model_refresh_interval()
         assert exc.value.exit_code == 1
 
+    def test_parse_model_refresh_interval_zero_treated_as_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from llmcli.cli.proxy import _parse_model_refresh_interval
+
+        monkeypatch.setenv("LLMCLI_MODEL_REFRESH_SECS", "0")
+        assert _parse_model_refresh_interval() == 60.0
+
     def test_reload_litellm_child_always_respawns(self) -> None:
         from llmcli.cli.proxy import _reload_litellm_child
 
@@ -1059,19 +1097,20 @@ class TestModelRefresh:
         base: dict = {"general_settings": {}, "litellm_settings": {}}
         child = MagicMock()
         child.poll.return_value = None
-        child_state: dict = {"child": child, "stop": False}
-        sleep_calls = 0
-
-        def _sleep_then_stop(_interval: float) -> None:
-            nonlocal sleep_calls
-            sleep_calls += 1
-            if sleep_calls >= 2:
-                child_state["stop"] = True
+        child_state: dict = {
+            "child": child,
+            "stop": False,
+            "refresh_lock": __import__("threading").Lock(),
+            "last_xai_token": "absent",
+        }
+        def _refresh(*_args, **_kwargs) -> None:
+            child_state["stop"] = True
 
         with (
-            patch("llmcli.cli.proxy._write_proxy_config") as write_cfg,
-            patch("llmcli.cli.proxy._reload_litellm_child", return_value=child) as reload,
-            patch("llmcli.cli.proxy.time.sleep", side_effect=_sleep_then_stop),
+            patch("llmcli.cli.proxy._run_catalogue_refresh", side_effect=_refresh) as refresh,
+            patch("llmcli.cli.proxy.time.sleep", lambda _: None),
+            patch("llmcli.cli.proxy.xai_credentials_cache_token", return_value="absent"),
+            patch("llmcli.cli.proxy.time.monotonic", side_effect=[0.0, 0.0, 1.0]),
         ):
             _start_model_refresh_loop(
                 child_state,
@@ -1082,5 +1121,44 @@ class TestModelRefresh:
                 host="0.0.0.0",
                 interval_secs=0.01,
             ).join(timeout=2.0)
-        write_cfg.assert_called()
-        reload.assert_called()
+        refresh.assert_called()
+
+    def test_model_refresh_loop_wakes_on_xai_token_change(self) -> None:
+        from llmcli.cli.proxy import _start_model_refresh_loop
+
+        catalog = _make_catalog()
+        target = Path("/tmp/proxy.config.yaml")
+        base: dict = {"general_settings": {}, "litellm_settings": {}}
+        child = MagicMock()
+        child.poll.return_value = None
+        child_state: dict = {
+            "child": child,
+            "stop": False,
+            "refresh_lock": __import__("threading").Lock(),
+            "last_xai_token": "absent",
+        }
+        token_reads = 0
+
+        def _token() -> str:
+            nonlocal token_reads
+            token_reads += 1
+            return "present:1" if token_reads >= 2 else "absent"
+
+        def _refresh(*_args, **_kwargs) -> None:
+            child_state["stop"] = True
+
+        with (
+            patch("llmcli.cli.proxy._run_catalogue_refresh", side_effect=_refresh) as refresh,
+            patch("llmcli.cli.proxy.time.sleep", lambda _: None),
+            patch("llmcli.cli.proxy.xai_credentials_cache_token", side_effect=_token),
+        ):
+            _start_model_refresh_loop(
+                child_state,
+                catalog=catalog,
+                target=target,
+                base=base,
+                port=18091,
+                host="0.0.0.0",
+                interval_secs=60.0,
+            ).join(timeout=2.0)
+        refresh.assert_called_once()

--- a/tests/test_proxy_cmd.py
+++ b/tests/test_proxy_cmd.py
@@ -1020,18 +1020,36 @@ class TestModelRefresh:
             _parse_model_refresh_interval()
         assert exc.value.exit_code == 1
 
-    def test_reload_litellm_child_respawns_when_sighup_ignored(self) -> None:
+    def test_reload_litellm_child_always_respawns(self) -> None:
         from llmcli.cli.proxy import _reload_litellm_child
 
         child = MagicMock()
         child.poll.return_value = None
-        child.send_signal.side_effect = OSError("no sighup")
         new_child = MagicMock()
         with patch("llmcli.cli.proxy._spawn_litellm", return_value=new_child) as spawn:
             result = _reload_litellm_child(child, Path("/tmp/cfg.yaml"), 18091, "0.0.0.0")
         child.terminate.assert_called_once()
+        child.send_signal.assert_not_called()
         spawn.assert_called_once()
         assert result is new_child
+
+    def test_invalidate_model_cache_invokes_registered_callback(self) -> None:
+        from llmcli.support.litellm_config import (
+            invalidate_model_cache,
+            register_model_refresh_callback,
+        )
+
+        calls: list[str] = []
+
+        def _cb() -> None:
+            calls.append("refresh")
+
+        register_model_refresh_callback(_cb)
+        try:
+            invalidate_model_cache()
+        finally:
+            register_model_refresh_callback(None)
+        assert calls == ["refresh"]
 
     def test_model_refresh_loop_regenerates_config(self) -> None:
         from llmcli.cli.proxy import _start_model_refresh_loop


### PR DESCRIPTION
## Summary
- Merge TOML catalog models with live xAI forwarder discovery on canonical `GET :18091/v1/models`
- Add upstream health probes (omit 401/5xx remotes), in-memory cache, 60s background refresh, and immediate invalidation on `xai login`/`logout`
- Update NATS lifecycle `list` to surface live forwarder Grok IDs instead of hardcoded pairs

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #130: unified dynamic /v1/models | OPEN |
| Analysis | — | Absent (F-lite) |
| Spec | [130-unified-dynamic-v1-models-spec.mdx](artifacts/specs/130-unified-dynamic-v1-models-spec.mdx) | Present |
| Implementation | 4 commits on `feat/130-unified-dynamic-v1-models` | Complete |
| Verification | Lint ✅ Tests ✅ (14 new) | Passed |

## Test Plan
- [ ] `curl :18091/v1/models` lists TOML + live Grok when forwarder healthy and `xai.json` present
- [ ] New forwarder model appears within `LLMCLI_MODEL_REFRESH_SECS` without proxy restart
- [ ] `kimi-k2.6` absent when upstream probe returns 401

## SC → Test Matrix

| SC | Test(s) | Status |
|----|---------|--------|
| SC-1: merged TOML + live Grok | `test_litellm_config.py :: test_build_model_list_includes_live_grok_when_creds_exist` | ✅ |
| SC-2: exclude grok-imagine-* | `test_litellm_config.py :: test_fetch_xai_models_filters_grok_imagine` | ✅ |
| SC-3: unhealthy remote omitted | `test_litellm_config.py :: test_build_model_list_omits_unhealthy_remote` | ✅ |
| SC-4: machines filter parity | `test_litellm_config.py :: test_build_model_list_machines_filter_unchanged` | ✅ |
| SC-5: no hardcoded Grok without creds | `test_litellm_config.py :: test_build_model_list_no_grok_without_creds` | ✅ |
| SC-6: background refresh | `test_proxy_cmd.py :: test_model_refresh_loop_regenerates_config` | ✅ |
| SC-7: login/logout invalidation | `test_litellm_config.py :: test_invalidate_model_cache_forces_rebuild` | ✅ |
| SC-8: forwarder down no crash | `test_litellm_config.py :: test_fetch_xai_models_returns_empty_on_error` | ✅ |
| SC-9: register-proxy parity | `test_litellm_config.py :: test_register_proxy_xai_block_includes_forwarder_models` | ✅ |
| SC-10: test coverage | `TestXaiModelDiscovery` + `TestModelRefresh` | ✅ |

Fixes #130

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`