### PR TITLE
fix(deploy): scope proxy host_roles to llm-worker (was any)

### DIFF
--- a/deploy/quadlet.toml
+++ b/deploy/quadlet.toml
@@ -6,7 +6,7 @@ uid = 1502
 container = "llmcli.container"
 required_secrets = ["llmcli-litellm-key"]
 env_file = "~/.roxabi/llmcli/env/proxy.env"
-host_roles = ["any"]
+host_roles = ["llm-worker"]
 
 [component.worker]
 container = "llmcli-nats-worker.container"


### PR DESCRIPTION
Part of epic Roxabi/roxabi-factory#2034 (#2037).

`[component.proxy] host_roles` `["any"] → ["llm-worker"]`. `any` matched **every** host incl. the factory hub M1, so a missing `llmcli-litellm-key` secret on M1 would abort the **factory** converge (cross-repo blast radius). Scoping to `llm-worker` keeps the proxy on M2 (its real host) and removes the coupling.

> Note: #2037 also covers `deploy.sh` per-repo error-tiering — **deferred** (failure-contract design decision, see issue comment). This PR is the host_roles half only.

Refs #2037
Review-gated: do not merge until reviewed.