### PR TITLE
chore(ops): retire supervisord references in proxy reload and docs

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -403,9 +403,9 @@ systemctl --user start llmcli
 ## Running `llmcli proxy` (managed LiteLLM portal)
 
 `llmcli proxy` reads the llmcli catalog (`~/.roxabi/llmcli/llmcli.toml`), builds a
-complete LiteLLM config, and spawns `litellm` as a supervised foreground process on
-`:18091` by default. This replaces the hand-maintained `~/.litellm/config.yaml` + lyra
-supervisor pattern for new deployments.
+complete LiteLLM config, and spawns `litellm` as a foreground process on
+`:18091` by default (managed by the `llmcli` Quadlet unit). This replaces the legacy
+hand-maintained `~/.litellm/config.yaml` pattern.
 
 ### Invocation
 
@@ -651,10 +651,10 @@ If `proxy-base.yaml` is absent, `llmcli proxy` generates a minimal default confi
 The Quadlet unit sets `Environment=LLMCLI_PROXY_HOST=0.0.0.0` so the container listens on
 all interfaces; override in `~/.roxabi/llmcli/env/proxy.env` to restrict.
 
-### Migration recipe (:4000 lyra-supervisor → :18091 Quadlet)
+### Migration recipe (legacy `:4000` → `:18091` Quadlet)
 
-Migrating from the legacy hand-maintained `~/.litellm/config.yaml` + lyra-supervisor
-pattern to the Quadlet-managed `llmcli proxy`:
+Migrating from the legacy hand-maintained `~/.litellm/config.yaml` + `:4000` proxy
+to the Quadlet-managed `llmcli proxy`:
 
 1. **Pre-flight** — confirm `~/.roxabi/llmcli/llmcli.toml` exists and `[host]` has a
    sensible `public_base_url`. Add `port = NNNN` to `[host]` if you need a non-default
@@ -730,9 +730,9 @@ pattern to the Quadlet-managed `llmcli proxy`:
 
 9. **Retire `:4000`** —
    ```bash
-   make litellm stop     # on the lyra hub
+   systemctl --user stop llmcli   # if still running the old unit
    ```
-   Then remove the supervisor program entry. See issue #51.
+   Confirm no legacy `litellm` process binds `:4000`. See issue #51.
 
 10. **Rollback** —
     ```bash

--- a/docs/guides/lyra-integration.md
+++ b/docs/guides/lyra-integration.md
@@ -82,16 +82,10 @@ that `llama-server` validates on each request.
 LLMCLI_API_KEY=$(cat ~/.roxabi/llmcli/api_key)
 ```
 
-**Prod (`roxabituwer`):** add to the supervisor env block in
-`~/projects/lyra/deploy/supervisor/conf.d/lyra_hub.conf`:
+**Prod (`roxabituwer`):** set in the Quadlet env file `~/.roxabi/llmcli/env/proxy.env`
+(or factory hub env if routing through factory):
 
-```ini
-environment =
-    LLMCLI_API_KEY="%(ENV_LLMCLI_API_KEY)s",
-    ...other vars...
-```
-
-Then set the var in `~/projects/lyra/.env` on prod (sourced by `run_*.sh` wrappers):
+Then set the var on prod:
 
 ```bash
 LLMCLI_API_KEY=<the-same-key-in-~/.roxabi/llmcli/api_key>
@@ -105,11 +99,9 @@ accept (`LLMCLI_API_KEY` in the llmCLI catalog's `api_key_env` field).
 lyra makes no attempt to start llmCLI. Ensure the daemon is up before starting lyra:
 
 ```bash
-# Local
-make llm          # starts llmcli_serve via supervisor
-
-# Prod — started automatically by lyra.service linger (autostart=true)
-make remote status
+# Local / prod — Quadlet user unit
+systemctl --user start llmcli
+systemctl --user status llmcli
 ```
 
 ---
@@ -199,7 +191,7 @@ Pattern for prod-always-on lyra deployments:
 
 ```python
 fallbacks=[
-    # Fallback 1: prod small model (always-on, auto-restart via supervisor)
+    # Fallback 1: prod small model (always-on Quadlet unit)
     {
         "model": "openai/qwen3-8b-q4",
         "base_url": "http://roxabituwer.lan:8091/v1",
@@ -238,11 +230,10 @@ local heavy model with a prod fallback.
 
 | Variable | Required | Where set | Description |
 |---|---|---|---|
-| `LLMCLI_API_KEY` | Yes | `lyra/.env`, supervisor env | Bearer token for llama-server auth |
-| `ANTHROPIC_API_KEY` | Yes (if Anthropic fallback) | `lyra/.env`, supervisor env | Anthropic hosted fallback |
+| `LLMCLI_API_KEY` | Yes | `~/.roxabi/llmcli/env/proxy.env` | Bearer token for llama-server auth |
+| `ANTHROPIC_API_KEY` | Yes (if Anthropic fallback) | `~/.roxabi/llmcli/env/proxy.env` | Anthropic hosted fallback |
 
-Both vars are loaded by the supervisor wrapper (`run_hub.sh` sources `~/projects/lyra/.env`).
-Neither is committed to the repo — managed via `.env` files and supervisor env blocks.
+Neither is committed to the repo — managed via env files referenced by Quadlet units.
 
 ---
 

--- a/src/llmcli/support/litellm_config.py
+++ b/src/llmcli/support/litellm_config.py
@@ -473,13 +473,11 @@ def emit_xai_oauth_warning_if_absent(err_console: Any) -> None:
 
 
 def reload_proxy() -> None:
-    """Reload the LiteLLM proxy by running 'make litellm reload' in the lyra supervisor dir.
+    """Reload the LiteLLM proxy via the Quadlet systemd user unit.
 
     This is a thin side-effect wrapper. Tests mock subprocess.run.
     """
-    litellm_dir = Path.home() / ".litellm"
     subprocess.run(  # noqa: S603
-        ["make", "litellm", "reload"],
-        cwd=litellm_dir,
+        ["systemctl", "--user", "restart", "llmcli"],
         check=True,
     )


### PR DESCRIPTION
## Summary
- Remove legacy supervisord hub references (conf.d, hub.mk, make register, supervisorctl)
- Align service management with Quadlet + systemd --user standard

## Test Plan
- [x] Makefiles parse (`make help` / `make -n <target> status`)
- [x] No functional code paths call supervisorctl

---
Generated with Claude Code