### PR TITLE
fix(ci): pass secrets to contracts-bump reusable workflow (secrets: inherit)

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   bump:
     uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    # Reusable workflows do NOT inherit caller secrets by default — without this the
+    # reusable workflow's actions/create-github-app-token fails ("private-key must be
+    # non-empty"), which broke this weekly cron 9/9 runs since inception (audit 2026-07-01).
+    secrets: inherit
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats"


### PR DESCRIPTION
Le cron hebdo contracts-bump a échoué **9/9** depuis sa création : le caller n'avait pas de clé `secrets:` → `create-github-app-token` erreur `private-key must be non-empty`. Les reusable workflows n'héritent pas des secrets par défaut. Fix additif (audit DevOps 2026-07-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)